### PR TITLE
feat: return pack ID on successful Lighterpack import

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -243,9 +243,9 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "CSV data imported successfully",
+                        "description": "CSV data imported successfully with pack ID",
                         "schema": {
-                            "$ref": "#/definitions/apitypes.OkResponse"
+                            "$ref": "#/definitions/packs.ImportLighterPackResponse"
                         }
                     },
                     "400": {
@@ -1800,6 +1800,17 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "weight": {
+                    "type": "integer"
+                }
+            }
+        },
+        "packs.ImportLighterPackResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "pack_id": {
                     "type": "integer"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -240,9 +240,9 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "CSV data imported successfully",
+                        "description": "CSV data imported successfully with pack ID",
                         "schema": {
-                            "$ref": "#/definitions/apitypes.OkResponse"
+                            "$ref": "#/definitions/packs.ImportLighterPackResponse"
                         }
                     },
                     "400": {
@@ -1797,6 +1797,17 @@
                     "type": "integer"
                 },
                 "weight": {
+                    "type": "integer"
+                }
+            }
+        },
+        "packs.ImportLighterPackResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "pack_id": {
                     "type": "integer"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -111,6 +111,13 @@ definitions:
       weight:
         type: integer
     type: object
+  packs.ImportLighterPackResponse:
+    properties:
+      message:
+        type: string
+      pack_id:
+        type: integer
+    type: object
   packs.Pack:
     properties:
       created_at:
@@ -357,9 +364,9 @@ paths:
       - application/json
       responses:
         "200":
-          description: CSV data imported successfully
+          description: CSV data imported successfully with pack ID
           schema:
-            $ref: '#/definitions/apitypes.OkResponse'
+            $ref: '#/definitions/packs.ImportLighterPackResponse'
         "400":
           description: Invalid CSV format
           schema:

--- a/pkg/images/testdata.go
+++ b/pkg/images/testdata.go
@@ -7,39 +7,54 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Angak0k/pimpmypack/pkg/accounts"
 	"github.com/Angak0k/pimpmypack/pkg/database"
 	"github.com/Angak0k/pimpmypack/pkg/packs"
+	"github.com/Angak0k/pimpmypack/pkg/security"
+	"github.com/gruntwork-io/terratest/modules/random"
 )
+
+// Test user for image storage tests
+var testUser = accounts.User{
+	Username:     "image-test-user-" + random.UniqueId(),
+	Email:        "image-test-" + random.UniqueId() + "@example.com",
+	Firstname:    "Image",
+	Lastname:     "Tester",
+	Role:         "standard",
+	Status:       "active",
+	Password:     "password",
+	LastPassword: "password",
+}
 
 // Test packs for image storage tests
 var testPacks = []packs.Pack{
 	{
 		ID:              999,
-		UserID:          1,
+		UserID:          0, // Will be set dynamically
 		PackName:        "Image Test Pack 1",
 		PackDescription: "Pack for testing image save operations",
 	},
 	{
 		ID:              1000,
-		UserID:          1,
+		UserID:          0, // Will be set dynamically
 		PackName:        "Image Test Pack 2",
 		PackDescription: "Pack for testing image update operations",
 	},
 	{
 		ID:              1001,
-		UserID:          1,
+		UserID:          0, // Will be set dynamically
 		PackName:        "Image Test Pack 3",
 		PackDescription: "Pack for testing image get operations",
 	},
 	{
 		ID:              1002,
-		UserID:          1,
+		UserID:          0, // Will be set dynamically
 		PackName:        "Image Test Pack 4",
 		PackDescription: "Pack for testing image delete operations",
 	},
 	{
 		ID:              1003,
-		UserID:          1,
+		UserID:          0, // Will be set dynamically
 		PackName:        "Image Test Pack 5",
 		PackDescription: "Pack for testing image exists operations",
 	},
@@ -60,14 +75,76 @@ func loadImageTestData() error {
 		}
 	}()
 
+	println("-> Loading image test data...")
+
+	// Create or find test user
+	var existingID int
+	err = tx.QueryRowContext(ctx,
+		"SELECT id FROM account WHERE username = $1", testUser.Username).Scan(&existingID)
+	if err == nil {
+		// User exists, use existing ID
+		if existingID < 0 {
+			return fmt.Errorf("invalid user ID: negative value %d for user %s", existingID, testUser.Username)
+		}
+		testUser.ID = uint(existingID)
+	} else if errors.Is(err, sql.ErrNoRows) {
+		// User doesn't exist, create them
+		println("-> Creating test user for image tests...")
+		err = tx.QueryRowContext(ctx,
+			`INSERT INTO account (username, email, firstname, lastname, role, status, created_at, updated_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+			RETURNING id;`,
+			testUser.Username,
+			testUser.Email,
+			testUser.Firstname,
+			testUser.Lastname,
+			testUser.Role,
+			testUser.Status,
+			time.Now().Truncate(time.Second),
+			time.Now().Truncate(time.Second)).Scan(&testUser.ID)
+		if err != nil {
+			return fmt.Errorf("failed to insert test user: %w", err)
+		}
+
+		// Create password for test user
+		hashedPassword, err := security.HashPassword(testUser.Password)
+		if err != nil {
+			return fmt.Errorf("failed to hash password: %w", err)
+		}
+
+		hashedLastPassword, err := security.HashPassword(testUser.LastPassword)
+		if err != nil {
+			return fmt.Errorf("failed to hash last password: %w", err)
+		}
+
+		var passwordID uint
+		err = tx.QueryRowContext(ctx,
+			`INSERT INTO password (user_id, password, last_password, updated_at) VALUES ($1,$2,$3,$4)
+			RETURNING id;`,
+			testUser.ID,
+			hashedPassword,
+			hashedLastPassword,
+			time.Now().Truncate(time.Second)).Scan(&passwordID)
+		if err != nil {
+			return fmt.Errorf("failed to insert password for test user: %w", err)
+		}
+	} else {
+		return fmt.Errorf("failed to check existing user: %w", err)
+	}
+
 	println("-> Loading image test packs...")
+
+	// Set user ID for all test packs
+	for i := range testPacks {
+		testPacks[i].UserID = testUser.ID
+	}
 
 	// Insert test packs
 	for i := range testPacks {
 		// Check if pack already exists
-		var existingID int
+		var existingPackID int
 		err := tx.QueryRowContext(ctx,
-			"SELECT id FROM pack WHERE id = $1", testPacks[i].ID).Scan(&existingID)
+			"SELECT id FROM pack WHERE id = $1", testPacks[i].ID).Scan(&existingPackID)
 		if err == nil {
 			// Pack exists, skip
 			continue
@@ -95,11 +172,11 @@ func loadImageTestData() error {
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
-	println("-> Image test packs loaded...")
+	println("-> Image test data loaded...")
 	return nil
 }
 
-// cleanupImageTestData removes test packs and their images
+// cleanupImageTestData removes test packs, user, and their images
 func cleanupImageTestData() error {
 	ctx := context.Background()
 
@@ -110,6 +187,14 @@ func cleanupImageTestData() error {
 		_, err := database.DB().ExecContext(ctx, "DELETE FROM pack WHERE id = $1", pack.ID)
 		if err != nil {
 			return fmt.Errorf("failed to delete pack %d: %w", pack.ID, err)
+		}
+	}
+
+	// Delete test user (this will cascade delete passwords)
+	if testUser.ID != 0 {
+		_, err := database.DB().ExecContext(ctx, "DELETE FROM account WHERE id = $1", testUser.ID)
+		if err != nil {
+			return fmt.Errorf("failed to delete test user %d: %w", testUser.ID, err)
 		}
 	}
 

--- a/pkg/images/testdata.go
+++ b/pkg/images/testdata.go
@@ -148,7 +148,8 @@ func loadImageTestData() error {
 	println("-> Loading image test data...")
 
 	// Create or find test user
-	if err := createOrFindTestUser(ctx, tx); err != nil {
+	err = createOrFindTestUser(ctx, tx)
+	if err != nil {
 		return err
 	}
 
@@ -161,13 +162,15 @@ func loadImageTestData() error {
 
 	// Insert test packs
 	for i := range testPacks {
-		if err := insertTestPack(ctx, tx, &testPacks[i]); err != nil {
+		err = insertTestPack(ctx, tx, &testPacks[i])
+		if err != nil {
 			return err
 		}
 	}
 
 	// Commit the transaction
-	if err := tx.Commit(); err != nil {
+	err = tx.Commit()
+	if err != nil {
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 

--- a/pkg/packs/packs.go
+++ b/pkg/packs/packs.go
@@ -1431,7 +1431,7 @@ func unsharePackByID(ctx context.Context, packID uint, userID uint) error {
 // @Accept  multipart/form-data
 // @Produce  json
 // @Param file formData file true "CSV file"
-// @Success 200 {object} apitypes.OkResponse "CSV data imported successfully"
+// @Success 200 {object} ImportLighterPackResponse "CSV data imported successfully with pack ID"
 // @Failure 400 {object} apitypes.ErrorResponse "Invalid CSV format"
 // @Failure 401 {object} apitypes.ErrorResponse "Unauthorized"
 // @Failure 500 {object} apitypes.ErrorResponse "Internal Server Error"
@@ -1495,12 +1495,15 @@ func ImportFromLighterPack(c *gin.Context) {
 	}
 
 	// Perform database insertion
-	err = insertLighterPack(&lighterPack, userID)
+	packID, err := insertLighterPack(&lighterPack, userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "CSV data imported successfully"})
+	c.JSON(http.StatusOK, gin.H{
+		"message": "CSV data imported successfully",
+		"pack_id": packID,
+	})
 }
 
 // Take a record from csv.Newreder and return a LighterPackItem
@@ -1545,9 +1548,9 @@ func readLineFromCSV(record []string) (LighterPackItem, error) {
 	return lighterPackItem, nil
 }
 
-func insertLighterPack(lp *LighterPack, userID uint) error {
+func insertLighterPack(lp *LighterPack, userID uint) (uint, error) {
 	if lp == nil {
-		return errors.New("payload is empty")
+		return 0, errors.New("payload is empty")
 	}
 
 	// Create new pack
@@ -1557,7 +1560,7 @@ func insertLighterPack(lp *LighterPack, userID uint) error {
 	newPack.PackDescription = "LighterPack Import"
 	err := insertPack(&newPack)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	ctx := context.Background()
@@ -1575,7 +1578,7 @@ func insertLighterPack(lp *LighterPack, userID uint) error {
 			item.Desc,
 		)
 		if err != nil && !errors.Is(err, inventories.ErrNoItemFound) {
-			return fmt.Errorf("failed to check for existing item: %w", err)
+			return 0, fmt.Errorf("failed to check for existing item: %w", err)
 		}
 
 		if existingItem != nil {
@@ -1594,7 +1597,7 @@ func insertLighterPack(lp *LighterPack, userID uint) error {
 			i.Currency = "USD"
 			err := inventories.InsertInventory(ctx, &i)
 			if err != nil {
-				return err
+				return 0, err
 			}
 			itemID = i.ID
 		}
@@ -1608,10 +1611,10 @@ func insertLighterPack(lp *LighterPack, userID uint) error {
 		pc.Consumable = item.Consumable
 		err = insertPackContent(&pc)
 		if err != nil {
-			return err
+			return 0, err
 		}
 	}
-	return nil
+	return newPack.ID, nil
 }
 
 // SharedList gets pack metadata and contents for a shared pack

--- a/pkg/packs/packs.go
+++ b/pkg/packs/packs.go
@@ -1549,7 +1549,7 @@ func readLineFromCSV(record []string) (LighterPackItem, error) {
 }
 
 func insertLighterPack(lp *LighterPack, userID uint) (uint, error) {
-	if lp == nil {
+	if lp == nil || len(*lp) == 0 {
 		return 0, errors.New("payload is empty")
 	}
 

--- a/pkg/packs/types.go
+++ b/pkg/packs/types.go
@@ -79,6 +79,12 @@ type LighterPackItem struct {
 // LighterPack represents a collection of LighterPack items
 type LighterPack []LighterPackItem
 
+// ImportLighterPackResponse represents the response when importing from LighterPack
+type ImportLighterPackResponse struct {
+	Message string `json:"message"`
+	PackID  uint   `json:"pack_id"`
+}
+
 // SharedPackResponse represents the response structure for shared pack endpoint
 type SharedPackResponse struct {
 	Pack     SharedPackInfo       `json:"pack"`


### PR DESCRIPTION
## Summary
- Return the created pack ID in the response when importing from Lighterpack
- Fix foreign key constraint violation in image package tests

## Changes

### Pack Import Enhancement
- Modified `insertLighterPack` function to return the created pack ID
- Updated `ImportFromLighterPack` handler to include `pack_id` in the JSON response
- Added `ImportLighterPackResponse` type for proper API documentation
- Updated Swagger annotations to reflect the new response structure

**Before:**
```json
{
  "message": "CSV data imported successfully"
}
```

**After:**
```json
{
  "message": "CSV data imported successfully",
  "pack_id": 123
}
```

### Test Data Fix
- Fixed foreign key constraint violation in `pkg/images/testdata.go`
- Created test user before inserting test packs (similar to packs package pattern)
- Dynamically assign user ID to test packs
- Cleanup test user in teardown to prevent data leakage

## Benefits
This enhancement facilitates frontend integration by allowing direct navigation to the newly created pack after a successful import.

## Test Results
- ✅ All tests pass in `pkg/images`
- ✅ All tests pass in `pkg/packs`
- ✅ Code compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)