### PR TITLE
fix!: prevent privilege escalation in PutMyAccount endpoint

### DIFF
--- a/pkg/accounts/types.go
+++ b/pkg/accounts/types.go
@@ -64,6 +64,17 @@ type PasswordUpdateInput struct {
 	NewPassword     string `json:"new_password" binding:"required"`
 }
 
+// AccountUpdateInput represents the data users can update about their own account
+// SECURITY: This type intentionally excludes role, status, username, and password fields
+// to prevent privilege escalation and unauthorized modifications
+type AccountUpdateInput struct {
+	Email               string `json:"email" binding:"required"`
+	Firstname           string `json:"firstname" binding:"required"`
+	Lastname            string `json:"lastname" binding:"required"`
+	PreferredCurrency   string `json:"preferred_currency"`
+	PreferredUnitSystem string `json:"preferred_unit_system"`
+}
+
 // Token represents an authentication token
 type Token struct {
 	Token string `json:"token"`

--- a/tests/api-scenarios/001-user-registration-auth.yaml
+++ b/tests/api-scenarios/001-user-registration-auth.yaml
@@ -87,12 +87,9 @@ scenarios:
       headers:
         Authorization: "Bearer {{access_token}}"
       body:
-        username: "{{username}}"
         email: "{{email}}"
         firstname: "Updated"
         lastname: "TestUser"
-        role: "{{user_role}}"
-        status: "{{user_status}}"
         preferred_unit_system: "metric"
         preferred_currency: "EUR"
     assertions:
@@ -104,6 +101,39 @@ scenarios:
       - type: json_path
         path: "$.preferred_currency"
         equals: "EUR"
+      - type: json_path
+        path: "$.role"
+        equals: "{{user_role}}"
+      - type: json_path
+        path: "$.status"
+        equals: "{{user_status}}"
+
+  - name: "SECURITY: Attempt privilege escalation (should be blocked)"
+    request:
+      method: PUT
+      endpoint: "/v1/myaccount"
+      headers:
+        Authorization: "Bearer {{access_token}}"
+      body:
+        email: "{{email}}"
+        firstname: "Hacker"
+        lastname: "Attempt"
+        role: "admin"
+        status: "revoked"
+        preferred_unit_system: "metric"
+        preferred_currency: "USD"
+    assertions:
+      - type: status_code
+        expected: 200
+      - type: json_path
+        path: "$.firstname"
+        equals: "Hacker"
+      - type: json_path
+        path: "$.role"
+        equals: "standard"
+      - type: json_path
+        path: "$.status"
+        equals: "active"
 
   - name: "Change user password"
     request:


### PR DESCRIPTION
Fixes #160

## Security Fix: Privilege Escalation Vulnerability

### Vulnerability
The `PUT /api/v1/myaccount` endpoint allowed users to modify their own `role` and `status` fields, enabling privilege escalation from standard user to admin.

**Impact**: Any authenticated user could grant themselves admin privileges by sending:
```json
{
  "role": "admin",
  "status": "premium"
}
```

### Root Cause
- Handler accepted full `Account` struct as input
- Database function `updateAccountByID()` updated ALL fields including role and status
- No input validation to exclude sensitive fields

### Fix
1. **Created `AccountUpdateInput` type** with only safe fields:
   - ✅ email, firstname, lastname, preferred_currency, preferred_unit_system
   - ❌ role, status, username (excluded)

2. **Implemented `updateMyAccount()` function** that:
   - Accepts only `AccountUpdateInput` (not full Account)
   - Updates ONLY 5 safe fields via SQL
   - Returns full Account via RETURNING clause (shows unchanged role/status)
   - Validates email format

3. **Updated `PutMyAccount` handler** to:
   - Bind to `AccountUpdateInput` instead of `Account`
   - Call `updateMyAccount()` instead of `updateAccountByID()`

4. **Added security documentation** to `updateAccountByID()`:
   - Marked as ADMIN ONLY
   - Warning to never call from user-facing endpoints

### Testing
✅ **API Test Scenarios** (53 tests pass):
- Added "Update user account details" test - verifies legitimate updates work and role/status remain unchanged
- Added "SECURITY: Attempt privilege escalation" test - verifies role/status cannot be modified

✅ **Linter**: 0 issues

✅ **Manual verification**: Confirmed privilege escalation blocked with curl

### Breaking Change
⚠️ **Request payload format changed** for `PUT /api/v1/myaccount`:
- **Removed fields**: `username`, `role`, `status` (silently ignored if sent)
- **Kept fields**: `email`, `firstname`, `lastname`, `preferred_currency`, `preferred_unit_system`

**Frontend action required**: Remove `username`, `role`, `status` from PUT request body.

### Additional Changes
- Added server management targets to Makefile:
  - `make stop-server` - Stop running server
  - `make start-server` - Start fresh server in background
  - `make restart-server` - Restart server
  - `make api-test-full` - Full test workflow with server management

### Files Changed
- `pkg/accounts/types.go` - Added AccountUpdateInput
- `pkg/accounts/accounts.go` - Added updateMyAccount(), updated docs
- `pkg/accounts/handlers.go` - Updated PutMyAccount handler
- `tests/api-scenarios/001-user-registration-auth.yaml` - Added security tests
- `Makefile` - Added server management targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)