### PR TITLE
feat: add favorite pack feature (single favorite per user)

### DIFF
--- a/main.go
+++ b/main.go
@@ -127,6 +127,8 @@ func setupProtectedRoutes(router *gin.Engine) {
 	protected.DELETE("/mypack/:id", packs.DeleteMyPackByID)
 	protected.POST("/mypack/:id/share", packs.ShareMyPack)
 	protected.DELETE("/mypack/:id/share", packs.UnshareMyPack)
+	protected.POST("/mypack/:id/favorite", packs.FavoriteMyPack)
+	protected.DELETE("/mypack/:id/favorite", packs.UnfavoriteMyPack)
 	protected.GET("/mypack/:id/packcontents", packs.GetMyPackContentsByPackID)
 	protected.POST("/mypack/:id/packcontent", packs.PostMyPackContent)
 	protected.PUT("/mypack/:id/packcontent/:item_id", packs.PutMyPackContentByID)

--- a/pkg/database/migration/migration_scripts/000013_pack_is_favorite.down.sql
+++ b/pkg/database/migration/migration_scripts/000013_pack_is_favorite.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_pack_one_favorite_per_user;
+ALTER TABLE "pack" DROP COLUMN IF EXISTS "is_favorite";

--- a/pkg/database/migration/migration_scripts/000013_pack_is_favorite.up.sql
+++ b/pkg/database/migration/migration_scripts/000013_pack_is_favorite.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "pack" ADD COLUMN "is_favorite" BOOLEAN NOT NULL DEFAULT false;
+-- Enforce at most one favorite pack per user at the database level
+CREATE UNIQUE INDEX idx_pack_one_favorite_per_user ON pack (user_id) WHERE is_favorite = true;

--- a/pkg/packs/types.go
+++ b/pkg/packs/types.go
@@ -12,6 +12,9 @@ var (
 
 	// ErrPackContentNotFound is returned when no items are found in a given pack
 	ErrPackContentNotFound = errors.New("pack content not found")
+
+	// ErrPackNotOwned is returned when a user tries to operate on a pack they don't own
+	ErrPackNotOwned = errors.New("pack does not belong to user")
 )
 
 // Pack represents a pack with its metadata
@@ -23,6 +26,7 @@ type Pack struct {
 	PackWeight      int       `json:"pack_weight"`
 	PackItemsCount  int       `json:"pack_items_count"`
 	SharingCode     *string   `json:"sharing_code,omitempty"`
+	IsFavorite      bool      `json:"is_favorite"`
 	HasImage        bool      `json:"has_image"`
 	CreatedAt       time.Time `json:"created_at"`
 	UpdatedAt       time.Time `json:"updated_at"`

--- a/specs/006_pack-favorite.md
+++ b/specs/006_pack-favorite.md
@@ -1,0 +1,159 @@
+# Pack Favorite - Specification
+
+**Status**: Draft
+**Author**: Claude Agent
+**Date**: 2026-02-14
+**Last Updated**: 2026-02-14
+
+---
+
+## Overview
+
+### Purpose
+Allow users to mark one pack as their favorite. Only one pack per user can be the favorite at a time - setting a new favorite automatically unfavorites the previous one.
+
+### Goals
+- Allow users to mark a pack as their favorite
+- Enforce single-favorite-per-user constraint
+- Keep favorite status private (not exposed in shared pack views)
+
+### Non-Goals
+- Multiple favorites per user
+- Favorite ordering/ranking
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+#### FR1: Single Favorite Per User
+**Description**: Only one pack per user can be marked as favorite at any time. Setting a new favorite automatically clears the previous one.
+
+**Acceptance Criteria**:
+- [ ] Only one pack per user has `is_favorite = true` (enforced by partial unique index at DB level)
+- [ ] Setting a new favorite unfavorites the previous one atomically (transaction)
+- [ ] New packs default to `is_favorite = false`
+
+**Priority**: High
+
+#### FR2: Favorite Endpoint
+**Description**: Users can favorite a pack via a dedicated POST endpoint.
+
+**Acceptance Criteria**:
+- [ ] POST `/v1/mypack/:id/favorite` marks the pack as favorite
+- [ ] Only pack owner can favorite their pack
+- [ ] Operation is idempotent (favoriting an already-favorited pack is a no-op)
+- [ ] Previous favorite is automatically cleared
+
+**Priority**: High
+
+#### FR3: Unfavorite Endpoint
+**Description**: Users can unfavorite a pack via a dedicated DELETE endpoint.
+
+**Acceptance Criteria**:
+- [ ] DELETE `/v1/mypack/:id/favorite` removes favorite status
+- [ ] Only pack owner can unfavorite their pack
+- [ ] Operation is idempotent (unfavoriting a non-favorite pack is a no-op)
+
+**Priority**: High
+
+#### FR4: No Leaking in Shared Views
+**Description**: The `is_favorite` field must not be exposed in shared/public pack views.
+
+**Acceptance Criteria**:
+- [ ] `SharedPackInfo` struct does not include `is_favorite`
+- [ ] Public shared pack endpoint does not return `is_favorite`
+
+**Priority**: High
+
+---
+
+## Design
+
+### Data Model
+
+#### Database Schema
+
+**Migration: 000013_pack_is_favorite.up.sql**
+```sql
+ALTER TABLE "pack" ADD COLUMN "is_favorite" BOOLEAN NOT NULL DEFAULT false;
+-- Enforce at most one favorite pack per user at the database level
+CREATE UNIQUE INDEX idx_pack_one_favorite_per_user ON pack (user_id) WHERE is_favorite = true;
+```
+
+**Migration: 000013_pack_is_favorite.down.sql**
+```sql
+DROP INDEX IF EXISTS idx_pack_one_favorite_per_user;
+ALTER TABLE "pack" DROP COLUMN IF EXISTS "is_favorite";
+```
+
+#### Modified Types
+```go
+type Pack struct {
+    // ... existing fields ...
+    SharingCode *string   `json:"sharing_code,omitempty"`
+    IsFavorite  bool      `json:"is_favorite"`
+    HasImage    bool      `json:"has_image"`
+    // ... existing fields ...
+}
+```
+
+### API Design
+
+#### POST /api/v1/mypack/:id/favorite
+**Description**: Mark a pack as favorite (idempotent, auto-unfavorites previous)
+
+**Response** (200 OK):
+```json
+{"message": "Pack favorited successfully"}
+```
+
+**Error Responses**: 400, 401, 403, 404, 500
+
+#### DELETE /api/v1/mypack/:id/favorite
+**Description**: Remove favorite status from a pack (idempotent)
+
+**Response** (200 OK):
+```json
+{"message": "Pack unfavorited successfully"}
+```
+
+**Error Responses**: 400, 401, 403, 404, 500
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+- `TestFavoriteMyPack`: success, idempotent, switch favorite, forbidden, not found
+- `TestUnfavoriteMyPack`: success, idempotent, forbidden, not found
+- Verify new packs default to `is_favorite = false`
+
+### API Tests
+- Scenario 002: favorite, verify, idempotent, unfavorite, verify, idempotent
+
+---
+
+## Implementation Plan
+
+### Phase 1: Database Migration
+- [ ] Create migration files (000013)
+
+### Phase 2: Data Model
+- [ ] Add `IsFavorite` to `Pack` struct
+
+### Phase 3: Repository
+- [ ] Update SELECT queries (3 functions)
+- [ ] Add `favoritePackByID` and `unfavoritePackByID`
+
+### Phase 4: Handlers
+- [ ] Add `FavoriteMyPack` and `UnfavoriteMyPack`
+- [ ] Update admin PUT handler to preserve `IsFavorite`
+
+### Phase 5: Routes
+- [ ] Register routes in `main.go`
+
+### Phase 6: Testing
+- [ ] Unit tests
+- [ ] API test scenario updates

--- a/tests/api-scenarios/002-pack-crud.yaml
+++ b/tests/api-scenarios/002-pack-crud.yaml
@@ -229,6 +229,78 @@ scenarios:
       - type: status_code
         expected: 404
 
+  - name: "Favorite the pack"
+    request:
+      method: POST
+      endpoint: "/v1/mypack/{{pack_id}}/favorite"
+      headers:
+        Authorization: "Bearer {{access_token}}"
+    assertions:
+      - type: status_code
+        expected: 200
+      - type: json_path
+        path: "$.message"
+        equals: "Pack favorited successfully"
+
+  - name: "Verify pack is favorited"
+    request:
+      method: GET
+      endpoint: "/v1/mypack/{{pack_id}}"
+      headers:
+        Authorization: "Bearer {{access_token}}"
+    assertions:
+      - type: status_code
+        expected: 200
+      - type: json_path
+        path: "$.is_favorite"
+        equals: "true"
+
+  - name: "Favorite the pack again (idempotent)"
+    request:
+      method: POST
+      endpoint: "/v1/mypack/{{pack_id}}/favorite"
+      headers:
+        Authorization: "Bearer {{access_token}}"
+    assertions:
+      - type: status_code
+        expected: 200
+
+  - name: "Unfavorite the pack"
+    request:
+      method: DELETE
+      endpoint: "/v1/mypack/{{pack_id}}/favorite"
+      headers:
+        Authorization: "Bearer {{access_token}}"
+    assertions:
+      - type: status_code
+        expected: 200
+      - type: json_path
+        path: "$.message"
+        equals: "Pack unfavorited successfully"
+
+  - name: "Verify pack is no longer favorited"
+    request:
+      method: GET
+      endpoint: "/v1/mypack/{{pack_id}}"
+      headers:
+        Authorization: "Bearer {{access_token}}"
+    assertions:
+      - type: status_code
+        expected: 200
+      - type: json_path
+        path: "$.is_favorite"
+        equals: "false"
+
+  - name: "Unfavorite the pack again (idempotent)"
+    request:
+      method: DELETE
+      endpoint: "/v1/mypack/{{pack_id}}/favorite"
+      headers:
+        Authorization: "Bearer {{access_token}}"
+    assertions:
+      - type: status_code
+        expected: 200
+
   - name: "Cleanup: Delete pack content"
     request:
       method: DELETE


### PR DESCRIPTION
## Summary
- Add POST/DELETE endpoints for favoriting/unfavoriting a pack (`/v1/mypack/:id/favorite`)
- Enforce single favorite per user via a PostgreSQL partial unique index
- Refactor share/unshare/favorite/unfavorite handlers into a shared `packAction` helper and introduce `ErrPackNotOwned` sentinel error

## Test plan
- [x] Unit tests: `TestFavoriteMyPack` (5 sub-tests) and `TestUnfavoriteMyPack` (4 sub-tests)
- [x] E2E API tests: 6 new steps in scenario 002 (favorite, verify, idempotent, unfavorite, verify, idempotent)
- [x] `make test` — all pass
- [x] `make lint` — 0 issues
- [x] `make api-test-full` — 115/115 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)