### PR TITLE
feat: add automated seed data for local development

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,6 +6,7 @@ DB_PASSWORD=pmp1234
 DB_NAME=pmp_db
 DB_PORT=5432
 STAGE=DEV
+SEED_ON_STARTUP=false                              # Seed DB with sample data on startup (only when STAGE=LOCAL)
 
 # JWT Authentication Configuration
 API_SECRET=myawsomeapisecret

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Angak0k/pimpmypack/pkg/accounts"
 	"github.com/Angak0k/pimpmypack/pkg/config"
 	"github.com/Angak0k/pimpmypack/pkg/database"
+	"github.com/Angak0k/pimpmypack/pkg/database/seed"
 	"github.com/Angak0k/pimpmypack/pkg/images"
 	"github.com/Angak0k/pimpmypack/pkg/inventories"
 	"github.com/Angak0k/pimpmypack/pkg/packs"
@@ -41,6 +42,13 @@ func initApp() error {
 	err = database.Migrate()
 	if err != nil {
 		return fmt.Errorf("error migrating database : %w", err)
+	}
+
+	// seed DB for local development
+	if config.SeedOnStartup && config.Stage == envLocal {
+		if err := seed.Seed(context.Background()); err != nil {
+			log.Printf("WARNING: seed failed: %v", err)
+		}
 	}
 
 	return nil

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -43,6 +43,7 @@ var (
 	RefreshRateLimitRequests         int
 	RefreshRateLimitWindowMinutes    int
 	MailServerConfig                 MailServer
+	SeedOnStartup                    bool
 )
 
 type Config struct {
@@ -59,6 +60,7 @@ type Config struct {
 	RefreshRateLimitRequests         int
 	RefreshRateLimitWindowMinutes    int
 	MailServer                       MailServer
+	SeedOnStartup                    bool
 }
 
 func EnvInit(envFilePath string) error {
@@ -84,6 +86,7 @@ func EnvInit(envFilePath string) error {
 	RefreshRateLimitRequests = newConfig.RefreshRateLimitRequests
 	RefreshRateLimitWindowMinutes = newConfig.RefreshRateLimitWindowMinutes
 	MailServerConfig = newConfig.MailServer
+	SeedOnStartup = newConfig.SeedOnStartup
 
 	return nil
 }
@@ -164,6 +167,7 @@ func setEnvVars(cfg *Config) {
 	cfg.MailServer.MailPassword = os.Getenv("MAIL_PASSWORD")
 	cfg.MailServer.MailServer = os.Getenv("MAIL_SERVER")
 	cfg.MailServer.MailPort, _ = strconv.Atoi(ifEnvEmpty(os.Getenv("MAIL_PORT"), strconv.Itoa(cfg.MailServer.MailPort)))
+	cfg.SeedOnStartup = os.Getenv("SEED_ON_STARTUP") == "true"
 }
 
 func ifEnvEmpty(envVar, defaultValue string) string {

--- a/pkg/database/seed/seed.go
+++ b/pkg/database/seed/seed.go
@@ -179,29 +179,19 @@ func createPacks(
 			`INSERT INTO pack
 			(user_id, pack_name, pack_description,
 			 season, trail, adventure,
+			 is_favorite,
 			 created_at, updated_at)
-			VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
 			RETURNING id`,
 			userID, p.packName, p.packDescription,
-			p.season, p.trail, p.adventure, now, now,
+			p.season, p.trail, p.adventure, p.isFavorite,
+			now, now,
 		).Scan(&id)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"failed to create pack %q: %w", p.packName, err)
 		}
 		packIDs[i] = id
-
-		if p.isFavorite {
-			_, err = tx.ExecContext(ctx,
-				`UPDATE pack SET is_favorite = true WHERE id = $1`,
-				id,
-			)
-			if err != nil {
-				return nil, fmt.Errorf(
-					"failed to set favorite on pack %q: %w",
-					p.packName, err)
-			}
-		}
 	}
 
 	return packIDs, nil

--- a/pkg/database/seed/seed.go
+++ b/pkg/database/seed/seed.go
@@ -1,0 +1,263 @@
+package seed
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Angak0k/pimpmypack/pkg/database"
+	"github.com/Angak0k/pimpmypack/pkg/security"
+)
+
+// itemKey identifies an inventory item by its composite key.
+type itemKey struct {
+	itemName    string
+	category    string
+	description string
+}
+
+// Seed populates the database with realistic development data.
+// It is idempotent: if the seed user already exists, it skips.
+func Seed(ctx context.Context) error {
+	exists, err := userExists(ctx, defaultUser.username)
+	if err != nil {
+		return fmt.Errorf("failed to check for existing user: %w", err)
+	}
+	if exists {
+		log.Printf("[SEED] User '%s' already exists, skipping seed.",
+			defaultUser.username)
+		return nil
+	}
+
+	log.Println("[SEED] Starting database seed...")
+
+	tx, err := database.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	now := time.Now().Truncate(time.Second)
+
+	userID, err := createAccount(ctx, tx, now)
+	if err != nil {
+		return err
+	}
+
+	if err = createPassword(ctx, tx, userID, now); err != nil {
+		return err
+	}
+
+	itemIDs, err := createInventoryItems(ctx, tx, userID, now)
+	if err != nil {
+		return err
+	}
+
+	packIDs, err := createPacks(ctx, tx, userID, now)
+	if err != nil {
+		return err
+	}
+
+	contentCount, err := createPackContents(ctx, tx, packIDs, itemIDs, now)
+	if err != nil {
+		return err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit seed transaction: %w", err)
+	}
+
+	log.Printf("[SEED] Database seed completed successfully! "+
+		"Created %d inventory items, %d packs, %d pack contents.",
+		len(itemIDs), len(seedPackDefs), contentCount)
+
+	return nil
+}
+
+func userExists(ctx context.Context, username string) (bool, error) {
+	var exists bool
+	err := database.DB().QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM account WHERE username = $1)`,
+		username,
+	).Scan(&exists)
+	return exists, err
+}
+
+func createAccount(
+	ctx context.Context, tx *sql.Tx, now time.Time,
+) (uint, error) {
+	var userID uint
+	err := tx.QueryRowContext(ctx,
+		`INSERT INTO account
+		(username, email, firstname, lastname, role, status,
+		 preferred_currency, preferred_unit_system,
+		 created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+		RETURNING id`,
+		defaultUser.username, defaultUser.email,
+		defaultUser.firstname, defaultUser.lastname,
+		defaultUser.role, defaultUser.status,
+		"EUR", "METRIC", now, now,
+	).Scan(&userID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create account: %w", err)
+	}
+	return userID, nil
+}
+
+func createPassword(
+	ctx context.Context, tx *sql.Tx, userID uint, now time.Time,
+) error {
+	hashedPassword, err := security.HashPassword(defaultUser.password)
+	if err != nil {
+		return fmt.Errorf("failed to hash password: %w", err)
+	}
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO password (user_id, password, updated_at)
+		VALUES ($1, $2, $3)`,
+		userID, hashedPassword, now,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create password: %w", err)
+	}
+	return nil
+}
+
+func createInventoryItems(
+	ctx context.Context, tx *sql.Tx, userID uint, now time.Time,
+) (map[itemKey]uint, error) {
+	itemIDs := make(map[itemKey]uint, len(seedInventoryItems))
+
+	for _, item := range seedInventoryItems {
+		key := itemKey{
+			itemName:    item.itemName,
+			category:    item.category,
+			description: item.description,
+		}
+		if _, ok := itemIDs[key]; ok {
+			continue
+		}
+
+		var id uint
+		err := tx.QueryRowContext(ctx,
+			`INSERT INTO inventory
+			(user_id, item_name, category, description,
+			 weight, url, price, currency,
+			 created_at, updated_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+			RETURNING id`,
+			userID, item.itemName, item.category,
+			item.description, item.weight, item.url,
+			item.price, item.currency, now, now,
+		).Scan(&id)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed to create inventory item %q: %w",
+				item.itemName, err)
+		}
+		itemIDs[key] = id
+	}
+
+	return itemIDs, nil
+}
+
+func createPacks(
+	ctx context.Context, tx *sql.Tx, userID uint, now time.Time,
+) ([]uint, error) {
+	packIDs := make([]uint, len(seedPackDefs))
+
+	for i, p := range seedPackDefs {
+		var id uint
+		err := tx.QueryRowContext(ctx,
+			`INSERT INTO pack
+			(user_id, pack_name, pack_description,
+			 season, trail, adventure,
+			 created_at, updated_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+			RETURNING id`,
+			userID, p.packName, p.packDescription,
+			p.season, p.trail, p.adventure, now, now,
+		).Scan(&id)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed to create pack %q: %w", p.packName, err)
+		}
+		packIDs[i] = id
+
+		if p.isFavorite {
+			_, err = tx.ExecContext(ctx,
+				`UPDATE pack SET is_favorite = true WHERE id = $1`,
+				id,
+			)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"failed to set favorite on pack %q: %w",
+					p.packName, err)
+			}
+		}
+	}
+
+	return packIDs, nil
+}
+
+func createPackContents(
+	ctx context.Context,
+	tx *sql.Tx,
+	packIDs []uint,
+	itemIDs map[itemKey]uint,
+	now time.Time,
+) (int, error) {
+	count := 0
+	for _, pc := range seedPackContentDefs {
+		key := itemKey{
+			itemName:    pc.itemName,
+			category:    pc.category,
+			description: pc.description,
+		}
+
+		itemID, ok := itemIDs[key]
+		if !ok {
+			return 0, fmt.Errorf(
+				"pack content references unknown item: %q/%q/%q",
+				pc.itemName, pc.category, pc.description)
+		}
+
+		var dupExists bool
+		err := tx.QueryRowContext(ctx,
+			`SELECT EXISTS(
+				SELECT 1 FROM pack_content
+				WHERE pack_id = $1 AND item_id = $2)`,
+			packIDs[pc.packIndex], itemID,
+		).Scan(&dupExists)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return 0, fmt.Errorf(
+				"failed to check pack content duplicate: %w", err)
+		}
+		if dupExists {
+			continue
+		}
+
+		_, err = tx.ExecContext(ctx,
+			`INSERT INTO pack_content
+			(pack_id, item_id, quantity, worn, consumable,
+			 created_at, updated_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+			packIDs[pc.packIndex], itemID,
+			pc.quantity, pc.worn, pc.consumable, now, now,
+		)
+		if err != nil {
+			return 0, fmt.Errorf(
+				"failed to create pack content for %q: %w",
+				pc.itemName, err)
+		}
+		count++
+	}
+	return count, nil
+}

--- a/pkg/database/seed/seed_data.go
+++ b/pkg/database/seed/seed_data.go
@@ -1,0 +1,497 @@
+package seed
+
+// seedUser holds the seed account data.
+type seedUser struct {
+	username  string
+	password  string
+	email     string
+	firstname string
+	lastname  string
+	role      string
+	status    string
+}
+
+// seedItem represents an inventory item for seeding.
+type seedItem struct {
+	itemName    string
+	category    string
+	description string
+	weight      int
+	url         string
+	price       int
+	currency    string
+}
+
+// seedPackDef represents a pack definition for seeding.
+type seedPackDef struct {
+	packName        string
+	packDescription string
+	season          *string
+	trail           *string
+	adventure       *string
+	isFavorite      bool
+}
+
+// seedPackContentDef links items to packs by composite key.
+type seedPackContentDef struct {
+	packIndex   int // index into seedPackDefs
+	itemName    string
+	category    string
+	description string
+	quantity    int
+	worn        bool
+	consumable  bool
+}
+
+func strPtr(s string) *string { return &s }
+
+// Shorthand constructors to keep data declarations under 120 chars.
+func item(name, cat, desc string, w int) seedItem {
+	return seedItem{
+		itemName: name, category: cat,
+		description: desc, weight: w, currency: "EUR",
+	}
+}
+
+func pc(
+	idx int, name, cat, desc string, qty int,
+) seedPackContentDef {
+	return seedPackContentDef{
+		packIndex: idx, itemName: name,
+		category: cat, description: desc, quantity: qty,
+	}
+}
+
+func pcWorn(idx int, name, desc string) seedPackContentDef {
+	return seedPackContentDef{
+		packIndex: idx, itemName: name,
+		category: "Worn", description: desc,
+		quantity: 1, worn: true,
+	}
+}
+
+func pcCons(
+	idx int, name, cat, desc string, qty int,
+) seedPackContentDef {
+	return seedPackContentDef{
+		packIndex: idx, itemName: name,
+		category: cat, description: desc,
+		quantity: qty, consumable: true,
+	}
+}
+
+var defaultUser = seedUser{
+	username:  "Romain",
+	password:  "romain1234",
+	email:     "john.doe@angakok.net",
+	firstname: "John",
+	lastname:  "Doe",
+	role:      "standard",
+	status:    "active",
+}
+
+// packGR10 and packGR54 are indexes into seedPackDefs.
+const (
+	packGR10 = 0
+	packGR54 = 1
+)
+
+var seedPackDefs = []seedPackDef{
+	{
+		packName:        "GR10 - Saison 5",
+		packDescription: "GR10 Thru-hike gear list",
+		season:          strPtr("3-Season"),
+		trail:           strPtr("GR10"),
+		adventure:       strPtr("Thru-hike"),
+		isFavorite:      true,
+	},
+	{
+		packName:        "GR54",
+		packDescription: "GR54 Backpacking gear list",
+		season:          strPtr("3-Season"),
+		trail:           strPtr("GR54"),
+		adventure:       strPtr("Backpacking"),
+		isFavorite:      false,
+	},
+}
+
+// seedInventoryItems is the deduplicated list from both CSVs.
+// Categories normalized: Wear->Clothes, Healthpack->Healthcare,
+// Food->Food & Drinks, MISC->Various.
+var seedInventoryItems = []seedItem{
+	// Backpack
+	item("ALD Hybrid 30", "Backpack", "Backpack", 525),
+	item("Sakasec", "Backpack", "Liner", 33),
+
+	// Shelter
+	item("X-MID-PRO 1", "Shelter", "Tent", 480),
+	item("Stake", "Shelter", "Stake", 9),
+	item("Polycree Footprint 1p", "Shelter", "Tent", 45),
+	item("Stakes bag", "Shelter", "Stake", 3),
+
+	// Sleeping
+	item("Thermarest Neoair X-Light R", "Sleeping", "Sleeping pad", 384),
+	item("Seatosummit Aero Ultralight", "Sleeping", "Pillow", 82),
+	item("Seatosummit Reactor", "Sleeping", "Sleep Liner", 275),
+	item("Seatosummit Spark 0", "Sleeping", "Sleeping Bag", 240),
+	item("Seatosummit Ember Eb II", "Sleeping", "Quilt", 610),
+
+	// Water
+	item("Katadyn BeFree", "Water", "Hydratation", 38),
+	item("Hydrapak Seeker 3L", "Water", "Hydratation", 92),
+	item("Hydrapak Ultraflask", "Water", "Hydratation", 55),
+	item("Hydrapak Skyflask IT", "Water", "Hydratation", 69),
+	item("Water Bottle", "Water", "Hydratation", 28),
+
+	// Cooking
+	item("Sakabouf", "Cooking", "Bag", 50),
+	item("Wildo Fold a cup", "Cooking", "Popote", 24),
+	item("Forclaz Trek 500 Folding", "Cooking", "Popote", 10),
+	item("TOAKS Titanium", "Cooking", "Popote", 120),
+	item("MSR Pocket Rocket 2", "Cooking", "Réchaud", 73),
+	item("Briquet BIC", "Cooking", "Réchaud", 10),
+	item("Wind Screen", "Cooking", "Réchaud", 36),
+	item("Optimus Support Cartouche", "Cooking", "Réchaud", 25),
+	item("Cartouche", "Cooking", "Réchaud", 186),
+	item("Allume feu", "Cooking", "Fire", 30),
+	item("Couteau Leatherman", "Cooking", "Various", 56),
+
+	// Clothes (normalized from Wear)
+	item("Buff Merinos", "Clothes", "Couche 2-3", 60),
+	item("Veste Millet (hardshell)", "Clothes", "Couche 2-3", 380),
+	item("Short Millet", "Clothes", "Bas", 120),
+	item("Boxer Forclaz", "Clothes", "Couche 1 - rechange", 37),
+	item("Chaussettes Quechua Hike 900", "Clothes", "Couche 1 - rechange", 30),
+	item("Filets", "Clothes", "Bag", 44),
+	item("Tongs Olaian", "Clothes", "Shoes", 220),
+	item("Polo manches longues merinos / Forclaz Travel 500",
+		"Clothes", "Nuit", 190),
+	item("Collant Forclaz MT500 / Merinos / Taille L",
+		"Clothes", "Nuit", 174),
+	item("Doudoune Montbell Superior", "Clothes", "Couche 2-3", 243),
+	item("filets", "Clothes", "sac à dos", 20),
+	item("dry sack 20L", "Clothes", "Sac à dos", 86),
+
+	// Healthcare (normalized from Healthpack)
+	item("Scrubba Wash Bag", "Healthcare", "Hygiene", 145),
+	item("Serviette Microfibre D4", "Healthcare", "Hygiene", 100),
+	item("Eponge naturelle", "Healthcare", "Hygiene", 5),
+	item("Repulsif Insectes", "Healthcare", "Hygiene", 40),
+	item("Brosse à dents + dentifrice", "Healthcare", "Hygiene", 35),
+	item("Gel Douche", "Healthcare", "Hygiene", 80),
+	item("Savon de Marseille", "Healthcare", "Hygiene", 80),
+	item("Mouchoirs en papier", "Healthcare", "Hygiene", 23),
+	item("Solar Lipstick", "Healthcare", "Healthcare", 15),
+	item("Compeed", "Healthcare", "Healthcare", 36),
+	item("Compresse", "Healthcare", "Healthcare", 1),
+	item("Tire-tiques", "Healthcare", "Healthcare", 2),
+	item("Steristrip", "Healthcare", "Healthcare", 1),
+	item("Chlorexidine", "Healthcare", "Healthcare", 50),
+	item("Bande", "Healthcare", "Healthcare", 8),
+	item("Niflugel", "Healthcare", "Healthcare", 15),
+	item("Nurofen", "Healthcare", "Healthcare", 1),
+	item("Serum physiologique", "Healthcare", "Healthcare", 6),
+	item("Sparadrap", "Healthcare", "Healthcare", 24),
+	item("Creme solaire", "Healthcare", "Santé", 100),
+
+	// Worn
+	item("Chaussure La sportiva TX4", "Worn", "Bas", 820),
+	item("Picture Shooner Strecht Pants", "Worn", "Bas", 280),
+	item("Baton BD FLZ", "Worn", "Divers", 385),
+	item("Casquette", "Worn", "Protection Solaire", 80),
+	item("Lunettes de soleil", "Worn", "Protection Solaire", 200),
+	item("Boxer Forclaz", "Worn", "Couche 1", 37),
+	item("Hoodie Blackcrows", "Worn", "Couche 1", 200),
+	item("Chaussettes Quechua Hike 900", "Worn", "Couche 1", 30),
+	item("Montre Suunto 9", "Worn", "Montre", 80),
+	item("La Sportiva Akasha II", "Worn", "Chaussure", 620),
+
+	// Electronics
+	item("iPhone13", "Electronics", "Telephone", 173),
+	item("Seatosummit DrySack UlytaSil Nano 2L",
+		"Electronics", "Bag", 23),
+	item("Anker Nano3 Charger", "Electronics", "Energy", 38),
+	item("Kit Cables USB-C", "Electronics", "Energy", 52),
+	item("Nitecore Carbon 10000", "Electronics", "Energy", 157),
+	item("TOMTOP SOLAR PANEL 7.8 W CUSTOM",
+		"Electronics", "Energy", 125),
+	item("Flextail gear Tiny pump", "Electronics", "Various", 88),
+	item("Headset", "Electronics", "Telephone", 30),
+	item("Petzl Bindi", "Electronics", "Lamp", 35),
+
+	// Various (normalized from MISC)
+	item("Patchs", "Various", "DIY", 30),
+	item("String", "Various", "DIY", 1),
+	item("Couteau Leatherman", "Various", "Various", 56),
+	item("Ziplocs", "Various", "Bag", 30),
+	item("Pelle TheTentLab", "Various", "Outils", 27),
+	item("Bouchons oreille", "Various", "Healthcare", 7),
+	item("Cordelette", "Various", "Brico", 30),
+	item("Argent/Cheques", "Various", "", 20),
+	item("Lunettes de soleil", "Various", "Protection Solaire", 200),
+
+	// Food & Drinks (normalized from Food)
+	item("Water", "Food & Drinks", "Water", 500),
+	item("cliffbar", "Food & Drinks", "food", 68),
+	item("Lyophilisés soir", "Food & Drinks", "food", 130),
+	item("Lyophilisés matin", "Food & Drinks", "food", 80),
+	item("Tea & Coffee", "Food & Drinks", "food", 100),
+}
+
+// seedPackContentDefs links items to packs.
+// Items identified by (itemName, category, description).
+//
+//nolint:dupl
+var seedPackContentDefs = []seedPackContentDef{
+	// ==========================================================
+	// GR10 Pack Contents
+	// ==========================================================
+
+	// Backpack
+	pc(packGR10, "Sakasec", "Backpack", "Liner", 1),
+	pc(packGR10, "ALD Hybrid 30", "Backpack", "Backpack", 1),
+
+	// Shelter
+	pc(packGR10, "X-MID-PRO 1", "Shelter", "Tent", 1),
+	pc(packGR10, "Stake", "Shelter", "Stake", 8),
+	pc(packGR10, "Polycree Footprint 1p", "Shelter", "Tent", 1),
+	pc(packGR10, "Stakes bag", "Shelter", "Stake", 1),
+
+	// Sleeping
+	pc(packGR10, "Thermarest Neoair X-Light R",
+		"Sleeping", "Sleeping pad", 1),
+	pc(packGR10, "Seatosummit Aero Ultralight",
+		"Sleeping", "Pillow", 1),
+	pc(packGR10, "Seatosummit Reactor",
+		"Sleeping", "Sleep Liner", 1),
+	pc(packGR10, "Seatosummit Spark 0",
+		"Sleeping", "Sleeping Bag", 1),
+
+	// Water
+	pc(packGR10, "Katadyn BeFree", "Water", "Hydratation", 1),
+	pc(packGR10, "Hydrapak Seeker 3L", "Water", "Hydratation", 1),
+	pc(packGR10, "Hydrapak Ultraflask", "Water", "Hydratation", 1),
+	pc(packGR10, "Hydrapak Skyflask IT", "Water", "Hydratation", 1),
+	pc(packGR10, "Water Bottle", "Water", "Hydratation", 1),
+
+	// Cooking
+	pc(packGR10, "Sakabouf", "Cooking", "Bag", 1),
+	pc(packGR10, "Wildo Fold a cup", "Cooking", "Popote", 1),
+	pc(packGR10, "Forclaz Trek 500 Folding", "Cooking", "Popote", 1),
+	pc(packGR10, "TOAKS Titanium", "Cooking", "Popote", 1),
+	pc(packGR10, "MSR Pocket Rocket 2", "Cooking", "Réchaud", 1),
+	pc(packGR10, "Briquet BIC", "Cooking", "Réchaud", 1),
+	pc(packGR10, "Wind Screen", "Cooking", "Réchaud", 1),
+	pc(packGR10, "Optimus Support Cartouche",
+		"Cooking", "Réchaud", 1),
+	pc(packGR10, "Cartouche", "Cooking", "Réchaud", 1),
+	pcCons(packGR10, "Allume feu", "Cooking", "Fire", 5),
+
+	// Clothes
+	pc(packGR10, "Buff Merinos", "Clothes", "Couche 2-3", 1),
+	pc(packGR10, "Veste Millet (hardshell)",
+		"Clothes", "Couche 2-3", 1),
+	pc(packGR10, "Short Millet", "Clothes", "Bas", 1),
+	pc(packGR10, "Boxer Forclaz",
+		"Clothes", "Couche 1 - rechange", 1),
+	pc(packGR10, "Chaussettes Quechua Hike 900",
+		"Clothes", "Couche 1 - rechange", 1),
+	pc(packGR10, "Filets", "Clothes", "Bag", 1),
+	pc(packGR10, "Tongs Olaian", "Clothes", "Shoes", 1),
+	pc(packGR10, "Polo manches longues merinos / Forclaz Travel 500",
+		"Clothes", "Nuit", 1),
+	pc(packGR10, "Collant Forclaz MT500 / Merinos / Taille L",
+		"Clothes", "Nuit", 1),
+	pc(packGR10, "Doudoune Montbell Superior",
+		"Clothes", "Couche 2-3", 1),
+
+	// Healthcare
+	pc(packGR10, "Scrubba Wash Bag", "Healthcare", "Hygiene", 1),
+	pc(packGR10, "Serviette Microfibre D4",
+		"Healthcare", "Hygiene", 1),
+	pc(packGR10, "Eponge naturelle", "Healthcare", "Hygiene", 1),
+	pc(packGR10, "Repulsif Insectes", "Healthcare", "Hygiene", 1),
+	pc(packGR10, "Brosse à dents + dentifrice",
+		"Healthcare", "Hygiene", 1),
+	pc(packGR10, "Gel Douche", "Healthcare", "Hygiene", 1),
+	pc(packGR10, "Savon de Marseille", "Healthcare", "Hygiene", 1),
+	pc(packGR10, "Mouchoirs en papier", "Healthcare", "Hygiene", 2),
+	pc(packGR10, "Solar Lipstick", "Healthcare", "Healthcare", 1),
+	pc(packGR10, "Compeed", "Healthcare", "Healthcare", 1),
+	pc(packGR10, "Compresse", "Healthcare", "Healthcare", 2),
+	pc(packGR10, "Tire-tiques", "Healthcare", "Healthcare", 1),
+	pc(packGR10, "Steristrip", "Healthcare", "Healthcare", 1),
+	pc(packGR10, "Chlorexidine", "Healthcare", "Healthcare", 1),
+	pc(packGR10, "Bande", "Healthcare", "Healthcare", 1),
+	pc(packGR10, "Niflugel", "Healthcare", "Healthcare", 1),
+	pc(packGR10, "Nurofen", "Healthcare", "Healthcare", 8),
+	pc(packGR10, "Serum physiologique",
+		"Healthcare", "Healthcare", 2),
+	pc(packGR10, "Sparadrap", "Healthcare", "Healthcare", 1),
+
+	// Worn
+	pcWorn(packGR10, "Chaussure La sportiva TX4", "Bas"),
+	pcWorn(packGR10, "Picture Shooner Strecht Pants", "Bas"),
+	pcWorn(packGR10, "Baton BD FLZ", "Divers"),
+	pcWorn(packGR10, "Casquette", "Protection Solaire"),
+	pcWorn(packGR10, "Lunettes de soleil", "Protection Solaire"),
+	pcWorn(packGR10, "Boxer Forclaz", "Couche 1"),
+	pcWorn(packGR10, "Hoodie Blackcrows", "Couche 1"),
+	pcWorn(packGR10, "Chaussettes Quechua Hike 900", "Couche 1"),
+	pcWorn(packGR10, "Montre Suunto 9", "Montre"),
+
+	// Electronics
+	pc(packGR10, "iPhone13", "Electronics", "Telephone", 1),
+	pc(packGR10, "Seatosummit DrySack UlytaSil Nano 2L",
+		"Electronics", "Bag", 2),
+	pc(packGR10, "Anker Nano3 Charger",
+		"Electronics", "Energy", 1),
+	pc(packGR10, "Kit Cables USB-C", "Electronics", "Energy", 1),
+	pc(packGR10, "Nitecore Carbon 10000",
+		"Electronics", "Energy", 1),
+	pc(packGR10, "TOMTOP SOLAR PANEL 7.8 W CUSTOM",
+		"Electronics", "Energy", 1),
+	pc(packGR10, "Flextail gear Tiny pump",
+		"Electronics", "Various", 1),
+	pc(packGR10, "Headset", "Electronics", "Telephone", 1),
+	pc(packGR10, "Petzl Bindi", "Electronics", "Lamp", 1),
+
+	// Various
+	pc(packGR10, "Patchs", "Various", "DIY", 1),
+	pc(packGR10, "String", "Various", "DIY", 14),
+	pc(packGR10, "Couteau Leatherman", "Various", "Various", 1),
+	pc(packGR10, "Ziplocs", "Various", "Bag", 1),
+	pc(packGR10, "Pelle TheTentLab", "Various", "Outils", 1),
+	pc(packGR10, "Bouchons oreille", "Various", "Healthcare", 1),
+
+	// Food & Drinks
+	pcCons(packGR10, "Water", "Food & Drinks", "Water", 2),
+	pcCons(packGR10, "cliffbar", "Food & Drinks", "food", 6),
+	pcCons(packGR10, "Lyophilisés soir",
+		"Food & Drinks", "food", 3),
+	pcCons(packGR10, "Lyophilisés matin",
+		"Food & Drinks", "food", 3),
+	pcCons(packGR10, "Tea & Coffee", "Food & Drinks", "food", 1),
+
+	// ==========================================================
+	// GR54 Pack Contents
+	// ==========================================================
+
+	// Backpack
+	pc(packGR54, "ALD Hybrid 30", "Backpack", "Backpack", 1),
+	pc(packGR54, "Sakasec", "Backpack", "Liner", 1),
+
+	// Shelter
+	pc(packGR54, "X-MID-PRO 1", "Shelter", "Tent", 1),
+	pc(packGR54, "Stake", "Shelter", "Stake", 8),
+	pc(packGR54, "Stakes bag", "Shelter", "Stake", 1),
+	pc(packGR54, "Polycree Footprint 1p", "Shelter", "Tent", 1),
+
+	// Sleeping
+	pc(packGR54, "Seatosummit Aero Ultralight",
+		"Sleeping", "Pillow", 1),
+	pc(packGR54, "Thermarest Neoair X-Light R",
+		"Sleeping", "Sleeping pad", 1),
+	pc(packGR54, "Seatosummit Ember Eb II",
+		"Sleeping", "Quilt", 1),
+
+	// Water
+	pc(packGR54, "Hydrapak Ultraflask", "Water", "Hydratation", 1),
+	pc(packGR54, "Katadyn BeFree", "Water", "Hydratation", 1),
+	pc(packGR54, "Hydrapak Seeker 3L", "Water", "Hydratation", 1),
+	pc(packGR54, "Hydrapak Skyflask IT", "Water", "Hydratation", 1),
+
+	// Clothes (normalized from Wear)
+	pc(packGR54, "Doudoune Montbell Superior",
+		"Clothes", "Couche 2-3", 1),
+	pc(packGR54, "Veste Millet (hardshell)",
+		"Clothes", "Couche 2-3", 1),
+	pc(packGR54, "Short Millet", "Clothes", "Bas", 1),
+	pc(packGR54, "Chaussettes Quechua Hike 900",
+		"Clothes", "Couche 1 - rechange", 1),
+	pc(packGR54, "Boxer Forclaz",
+		"Clothes", "Couche 1 - rechange", 1),
+	pc(packGR54, "Collant Forclaz MT500 / Merinos / Taille L",
+		"Clothes", "Nuit", 1),
+	pc(packGR54, "Polo manches longues merinos / Forclaz Travel 500",
+		"Clothes", "Nuit", 1),
+	pc(packGR54, "Tongs Olaian", "Clothes", "Shoes", 1),
+	pc(packGR54, "Buff Merinos", "Clothes", "Couche 2-3", 1),
+	pc(packGR54, "filets", "Clothes", "sac à dos", 1),
+	pc(packGR54, "dry sack 20L", "Clothes", "Sac à dos", 1),
+
+	// Healthcare
+	pc(packGR54, "Creme solaire", "Healthcare", "Santé", 1),
+	pc(packGR54, "Solar Lipstick", "Healthcare", "Healthcare", 1),
+	pc(packGR54, "Gel Douche", "Healthcare", "Hygiene", 1),
+	pc(packGR54, "Brosse à dents + dentifrice",
+		"Healthcare", "Hygiene", 1),
+	pc(packGR54, "Repulsif Insectes", "Healthcare", "Hygiene", 1),
+	pc(packGR54, "Savon de Marseille", "Healthcare", "Hygiene", 1),
+	pc(packGR54, "Eponge naturelle", "Healthcare", "Hygiene", 1),
+	pc(packGR54, "Scrubba Wash Bag", "Healthcare", "Hygiene", 1),
+	pc(packGR54, "Mouchoirs en papier", "Healthcare", "Hygiene", 2),
+	pc(packGR54, "Serviette Microfibre D4",
+		"Healthcare", "Hygiene", 1),
+	pc(packGR54, "Compeed", "Healthcare", "Healthcare", 1),
+	pc(packGR54, "Serum physiologique",
+		"Healthcare", "Healthcare", 2),
+	pc(packGR54, "Chlorexidine", "Healthcare", "Healthcare", 1),
+	pc(packGR54, "Tire-tiques", "Healthcare", "Healthcare", 1),
+	pc(packGR54, "Niflugel", "Healthcare", "Healthcare", 1),
+	pc(packGR54, "Bande", "Healthcare", "Healthcare", 1),
+	pc(packGR54, "Sparadrap", "Healthcare", "Healthcare", 1),
+	pc(packGR54, "Nurofen", "Healthcare", "Healthcare", 8),
+
+	// Cooking
+	pc(packGR54, "Cartouche", "Cooking", "Réchaud", 1),
+	pc(packGR54, "MSR Pocket Rocket 2", "Cooking", "Réchaud", 1),
+	pc(packGR54, "Sakabouf", "Cooking", "Bag", 1),
+	pc(packGR54, "Wind Screen", "Cooking", "Réchaud", 1),
+	pc(packGR54, "Briquet BIC", "Cooking", "Réchaud", 1),
+	pc(packGR54, "Couteau Leatherman", "Cooking", "Various", 1),
+	pc(packGR54, "Wildo Fold a cup", "Cooking", "Popote", 1),
+	pc(packGR54, "Forclaz Trek 500 Folding", "Cooking", "Popote", 1),
+
+	// Electronics
+	pc(packGR54, "Petzl Bindi", "Electronics", "Lamp", 1),
+	pc(packGR54, "Headset", "Electronics", "Telephone", 1),
+	pc(packGR54, "TOMTOP SOLAR PANEL 7.8 W CUSTOM",
+		"Electronics", "Energy", 1),
+	pc(packGR54, "Flextail gear Tiny pump",
+		"Electronics", "Various", 1),
+	pc(packGR54, "Nitecore Carbon 10000",
+		"Electronics", "Energy", 1),
+	pc(packGR54, "Kit Cables USB-C", "Electronics", "Energy", 1),
+	pc(packGR54, "Anker Nano3 Charger",
+		"Electronics", "Energy", 1),
+	pc(packGR54, "iPhone13", "Electronics", "Telephone", 1),
+	pc(packGR54, "Seatosummit DrySack UlytaSil Nano 2L",
+		"Electronics", "Bag", 2),
+
+	// Various (normalized from MISC)
+	pc(packGR54, "Lunettes de soleil",
+		"Various", "Protection Solaire", 1),
+	pc(packGR54, "Bouchons oreille", "Various", "Healthcare", 1),
+	pc(packGR54, "Cordelette", "Various", "Brico", 1),
+	pc(packGR54, "Patchs", "Various", "DIY", 1),
+	pc(packGR54, "Argent/Cheques", "Various", "", 1),
+
+	// Worn
+	pcWorn(packGR54, "Chaussettes Quechua Hike 900", "Couche 1"),
+	pcWorn(packGR54, "Hoodie Blackcrows", "Couche 1"),
+	pcWorn(packGR54, "Boxer Forclaz", "Couche 1"),
+	pcWorn(packGR54, "Picture Shooner Strecht Pants", "Bas"),
+	pcWorn(packGR54, "Casquette", "Protection Solaire"),
+	pcWorn(packGR54, "La Sportiva Akasha II", "Chaussure"),
+	pcWorn(packGR54, "Baton BD FLZ", "Divers"),
+	pcWorn(packGR54, "Montre Suunto 9", "Montre"),
+
+	// Food & Drinks (normalized from Food)
+	pcCons(packGR54, "Water", "Food & Drinks", "Water", 2),
+	pcCons(packGR54, "Tea & Coffee", "Food & Drinks", "food", 1),
+	pcCons(packGR54, "Lyophilisés soir",
+		"Food & Drinks", "food", 1),
+	pcCons(packGR54, "Lyophilisés matin",
+		"Food & Drinks", "food", 1),
+}


### PR DESCRIPTION
## Summary

Closes #189

When running the server locally, the database starts empty after migrations. Populating it with realistic data for manual testing or frontend development previously required manually calling API endpoints or running API test scenarios (which clean up after themselves). This PR adds an automated seed mechanism to solve that problem.

### What this adds

- **New `pkg/database/seed/` package** with two files:
  - `seed.go` — idempotent `Seed()` function that creates a demo account, inventory items, packs, and pack contents inside a single transaction
  - `seed_data.go` — realistic dataset with ~70 inventory items across 10 categories, 2 packs (GR10, GR54) with full contents including worn/consumable items

- **`SEED_ON_STARTUP` env variable** — when set to `true` and `STAGE=LOCAL`, the server automatically seeds the database on startup (after migrations)

- **Safety guardrails**:
  - Only runs when `STAGE=LOCAL` — refuses to seed in any other environment
  - Idempotent — checks if the seed user already exists and skips if so
  - Runs in a single transaction — all-or-nothing, no partial state on failure
  - Logs a warning instead of crashing if seeding fails

### Demo credentials

```
Username: Romain
Password: romain1234
Email:    john.doe@angakok.net
```

### Files changed

- `.env.sample` — documents the new `SEED_ON_STARTUP` variable
- `main.go` — calls `seed.Seed()` during `initApp()` when conditions are met
- `pkg/config/env.go` — loads the `SEED_ON_STARTUP` env var
- `pkg/database/seed/seed.go` — seed logic (account, password, inventory, packs, pack contents)
- `pkg/database/seed/seed_data.go` — seed dataset definitions


🤖 Generated with [Claude Code](https://claude.com/claude-code)