### PR TITLE
feat: add resend confirmation email endpoint

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,6 +21,8 @@ REFRESH_TOKEN_CLEANUP_INTERVAL_HOURS=24         # Cleanup interval for expired t
 # Rate Limiting Configuration
 REFRESH_RATE_LIMIT_REQUESTS=10                  # Requests per minute per IP (default: 10)
 REFRESH_RATE_LIMIT_WINDOW_MINUTES=1             # Time window in minutes (default: 1)
+RESEND_CONFIRM_RATE_LIMIT_REQUESTS=1            # Requests per minute per IP for resend (default: 1)
+RESEND_CONFIRM_RATE_LIMIT_WINDOW_MINUTES=1      # Time window in minutes (default: 1)
 
 # Email Configuration
 MAIL_SERVER=smtp.gmail.com

--- a/api-doc/docs.go
+++ b/api-doc/docs.go
@@ -1185,6 +1185,46 @@ const docTemplate = `{
                 }
             }
         },
+        "/resend-confirmemail": {
+            "post": {
+                "description": "Resend confirmation email to a pending user account. Always returns 200 to prevent user enumeration.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Public"
+                ],
+                "summary": "Resend confirmation email",
+                "parameters": [
+                    {
+                        "description": "Email Address",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/accounts.ResendConfirmEmailInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.OkResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/sharedlist/{sharing_code}": {
             "get": {
                 "description": "Retrieves pack metadata and contents using a sharing code",
@@ -3350,6 +3390,17 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "accounts.ResendConfirmEmailInput": {
+            "type": "object",
+            "required": [
+                "email"
+            ],
+            "properties": {
+                "email": {
                     "type": "string"
                 }
             }

--- a/api-doc/swagger.json
+++ b/api-doc/swagger.json
@@ -1182,6 +1182,46 @@
                 }
             }
         },
+        "/resend-confirmemail": {
+            "post": {
+                "description": "Resend confirmation email to a pending user account. Always returns 200 to prevent user enumeration.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Public"
+                ],
+                "summary": "Resend confirmation email",
+                "parameters": [
+                    {
+                        "description": "Email Address",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/accounts.ResendConfirmEmailInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.OkResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/sharedlist/{sharing_code}": {
             "get": {
                 "description": "Retrieves pack metadata and contents using a sharing code",
@@ -3347,6 +3387,17 @@
                     "type": "string"
                 },
                 "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "accounts.ResendConfirmEmailInput": {
+            "type": "object",
+            "required": [
+                "email"
+            ],
+            "properties": {
+                "email": {
                     "type": "string"
                 }
             }

--- a/api-doc/swagger.yaml
+++ b/api-doc/swagger.yaml
@@ -101,6 +101,13 @@ definitions:
     - password
     - username
     type: object
+  accounts.ResendConfirmEmailInput:
+    properties:
+      email:
+        type: string
+    required:
+    - email
+    type: object
   apitypes.ErrorResponse:
     properties:
       error:
@@ -1189,6 +1196,33 @@ paths:
           schema:
             $ref: '#/definitions/apitypes.ErrorResponse'
       summary: Register new user
+      tags:
+      - Public
+  /resend-confirmemail:
+    post:
+      consumes:
+      - application/json
+      description: Resend confirmation email to a pending user account. Always returns
+        200 to prevent user enumeration.
+      parameters:
+      - description: Email Address
+        in: body
+        name: input
+        required: true
+        schema:
+          $ref: '#/definitions/accounts.ResendConfirmEmailInput'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apitypes.OkResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+      summary: Resend confirmation email
       tags:
       - Public
   /sharedlist/{sharing_code}:

--- a/main.go
+++ b/main.go
@@ -117,6 +117,12 @@ func setupPublicRoutes(router *gin.Engine) {
 		security.RefreshTokenHandler)
 	public.GET("/confirmemail", accounts.ConfirmEmail)
 	public.POST("/forgotpassword", accounts.ForgotPassword)
+	public.POST("/resend-confirmemail",
+		security.ResendConfirmRateLimiter(
+			config.ResendConfirmRateLimitRequests,
+			config.ResendConfirmRateLimitRequests,
+		),
+		accounts.ResendConfirmEmail)
 	public.GET("/sharedlist/:sharing_code", packs.SharedList)
 	public.GET("/v1/packs/:id/image", images.GetPackImage)
 	public.GET("/v1/accounts/:id/image", images.GetProfileImage)

--- a/pkg/accounts/accounts.go
+++ b/pkg/accounts/accounts.go
@@ -104,6 +104,43 @@ func sendConfirmationEmail(u User, code string) error {
 	return nil
 }
 
+func resendConfirmEmail(ctx context.Context, email string) error {
+	var user User
+	err := database.DB().QueryRowContext(ctx,
+		`SELECT id, username, email FROM account WHERE email = $1 AND status = 'pending'`,
+		email,
+	).Scan(&user.ID, &user.Username, &user.Email)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// Email not found or not pending — return nil to prevent user enumeration
+			return nil
+		}
+		return fmt.Errorf("failed to query account: %w", err)
+	}
+
+	// Generate a new confirmation code (invalidates old one)
+	confirmationCode, err := helper.GenerateRandomCode(30)
+	if err != nil {
+		return fmt.Errorf("failed to generate confirmation code: %w", err)
+	}
+
+	// Update the confirmation code in DB
+	_, err = database.DB().ExecContext(ctx,
+		`UPDATE account SET confirmation_code = $1, updated_at = $2 WHERE id = $3`,
+		confirmationCode, time.Now().Truncate(time.Second), user.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update confirmation code: %w", err)
+	}
+
+	err = sendConfirmationEmail(user, confirmationCode)
+	if err != nil {
+		return fmt.Errorf("failed to send confirmation email: %w", err)
+	}
+
+	return nil
+}
+
 func confirmEmail(ctx context.Context, id string, code string) error {
 	// LOCAL mode: Accept any code
 	if config.Stage == stageLocal && code == "LOCAL_BYPASS" {

--- a/pkg/accounts/accounts_test.go
+++ b/pkg/accounts/accounts_test.go
@@ -677,6 +677,92 @@ func TestLogin(t *testing.T) {
 	})
 }
 
+func TestResendConfirmEmail(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	router.POST("/resend-confirmemail", ResendConfirmEmail)
+
+	// The second user in the dataset has status "pending"
+	pendingUser := users[1]
+
+	t.Run("Resend for pending account returns 200", func(t *testing.T) {
+		input := ResendConfirmEmailInput{Email: pendingUser.Email}
+		jsonData, _ := json.Marshal(input)
+		req, _ := http.NewRequest(http.MethodPost, "/resend-confirmemail", bytes.NewBuffer(jsonData))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status code %d but got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+		}
+
+		var response map[string]string
+		if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+		if response["message"] == "" {
+			t.Error("Expected a message in response")
+		}
+	})
+
+	t.Run("Resend for non-existent email returns 200 (anti-enumeration)", func(t *testing.T) {
+		input := ResendConfirmEmailInput{Email: "nonexistent@example.com"}
+		jsonData, _ := json.Marshal(input)
+		req, _ := http.NewRequest(http.MethodPost, "/resend-confirmemail", bytes.NewBuffer(jsonData))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status code %d but got %d", http.StatusOK, w.Code)
+		}
+	})
+
+	t.Run("Resend for active account returns 200 (anti-enumeration)", func(t *testing.T) {
+		// The first user in the dataset has status "active"
+		input := ResendConfirmEmailInput{Email: users[0].Email}
+		jsonData, _ := json.Marshal(input)
+		req, _ := http.NewRequest(http.MethodPost, "/resend-confirmemail", bytes.NewBuffer(jsonData))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status code %d but got %d", http.StatusOK, w.Code)
+		}
+	})
+
+	t.Run("Resend with invalid email format returns 400", func(t *testing.T) {
+		input := ResendConfirmEmailInput{Email: "not-an-email"}
+		jsonData, _ := json.Marshal(input)
+		req, _ := http.NewRequest(http.MethodPost, "/resend-confirmemail", bytes.NewBuffer(jsonData))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("Expected status code %d but got %d", http.StatusBadRequest, w.Code)
+		}
+	})
+
+	t.Run("Resend with empty body returns 400", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodPost, "/resend-confirmemail", bytes.NewBufferString("{}"))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("Expected status code %d but got %d", http.StatusBadRequest, w.Code)
+		}
+	})
+}
+
 func TestPutMyPassword(t *testing.T) {
 	// Set Gin to test mode
 	gin.SetMode(gin.TestMode)

--- a/pkg/accounts/handlers.go
+++ b/pkg/accounts/handlers.go
@@ -150,6 +150,41 @@ func ForgotPassword(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "new password sent"})
 }
 
+// Resend confirmation email
+// @Summary Resend confirmation email
+// @Description Resend confirmation email to a pending user account. Always returns 200 to prevent user enumeration.
+// @Tags Public
+// @Accept  json
+// @Produce  json
+// @Param   input  body    ResendConfirmEmailInput  true  "Email Address"
+// @Success 200 {object} apitypes.OkResponse
+// @Failure 400 {object} apitypes.ErrorResponse "Bad Request"
+// @Router /resend-confirmemail [post]
+func ResendConfirmEmail(c *gin.Context) {
+	var input ResendConfirmEmailInput
+
+	if err := c.ShouldBindJSON(&input); err != nil {
+		helper.LogAndSanitize(err, "resend confirm email: bind JSON failed")
+		c.JSON(http.StatusBadRequest, gin.H{"error": helper.ErrMsgBadRequest})
+		return
+	}
+
+	if !helper.IsValidEmail(input.Email) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid email"})
+		return
+	}
+
+	err := resendConfirmEmail(c.Request.Context(), input.Email)
+	if err != nil {
+		helper.LogAndSanitize(err, "resend confirm email failed")
+	}
+
+	// Always return 200 to prevent user enumeration
+	msg := "if your email is registered and pending confirmation, " +
+		"a new confirmation email has been sent"
+	c.JSON(http.StatusOK, gin.H{"message": msg})
+}
+
 // User login
 // @Summary User login
 // @Description Log in a user by providing username and password

--- a/pkg/accounts/types.go
+++ b/pkg/accounts/types.go
@@ -80,6 +80,11 @@ type AccountUpdateInput struct {
 	InstagramURL        *string `json:"instagram_url"`
 }
 
+// ResendConfirmEmailInput represents the data required to resend a confirmation email
+type ResendConfirmEmailInput struct {
+	Email string `json:"email" binding:"required"`
+}
+
 // Token represents an authentication token
 type Token struct {
 	Token string `json:"token"`

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -26,41 +26,45 @@ type DBConfig struct {
 }
 
 var (
-	Scheme                           string
-	HostName                         string
-	DBHost                           string
-	DBUser                           string
-	DBPassword                       string
-	DBName                           string
-	DBPort                           int
-	Stage                            string
-	APISecret                        string
-	TokenLifespan                    int
-	AccessTokenMinutes               int
-	RefreshTokenDays                 int
-	RefreshTokenRememberMeDays       int
-	RefreshTokenCleanupIntervalHours int
-	RefreshRateLimitRequests         int
-	RefreshRateLimitWindowMinutes    int
-	MailServerConfig                 MailServer
-	SeedOnStartup                    bool
+	Scheme                              string
+	HostName                            string
+	DBHost                              string
+	DBUser                              string
+	DBPassword                          string
+	DBName                              string
+	DBPort                              int
+	Stage                               string
+	APISecret                           string
+	TokenLifespan                       int
+	AccessTokenMinutes                  int
+	RefreshTokenDays                    int
+	RefreshTokenRememberMeDays          int
+	RefreshTokenCleanupIntervalHours    int
+	RefreshRateLimitRequests            int
+	RefreshRateLimitWindowMinutes       int
+	ResendConfirmRateLimitRequests      int
+	ResendConfirmRateLimitWindowMinutes int
+	MailServerConfig                    MailServer
+	SeedOnStartup                       bool
 )
 
 type Config struct {
-	Scheme                           string
-	HostName                         string
-	DBConfig                         DBConfig
-	Stage                            string
-	APISecret                        string
-	TokenLifespan                    int
-	AccessTokenMinutes               int
-	RefreshTokenDays                 int
-	RefreshTokenRememberMeDays       int
-	RefreshTokenCleanupIntervalHours int
-	RefreshRateLimitRequests         int
-	RefreshRateLimitWindowMinutes    int
-	MailServer                       MailServer
-	SeedOnStartup                    bool
+	Scheme                              string
+	HostName                            string
+	DBConfig                            DBConfig
+	Stage                               string
+	APISecret                           string
+	TokenLifespan                       int
+	AccessTokenMinutes                  int
+	RefreshTokenDays                    int
+	RefreshTokenRememberMeDays          int
+	RefreshTokenCleanupIntervalHours    int
+	RefreshRateLimitRequests            int
+	RefreshRateLimitWindowMinutes       int
+	ResendConfirmRateLimitRequests      int
+	ResendConfirmRateLimitWindowMinutes int
+	MailServer                          MailServer
+	SeedOnStartup                       bool
 }
 
 func EnvInit(envFilePath string) error {
@@ -85,6 +89,8 @@ func EnvInit(envFilePath string) error {
 	RefreshTokenCleanupIntervalHours = newConfig.RefreshTokenCleanupIntervalHours
 	RefreshRateLimitRequests = newConfig.RefreshRateLimitRequests
 	RefreshRateLimitWindowMinutes = newConfig.RefreshRateLimitWindowMinutes
+	ResendConfirmRateLimitRequests = newConfig.ResendConfirmRateLimitRequests
+	ResendConfirmRateLimitWindowMinutes = newConfig.ResendConfirmRateLimitWindowMinutes
 	MailServerConfig = newConfig.MailServer
 	SeedOnStartup = newConfig.SeedOnStartup
 
@@ -119,17 +125,19 @@ func loadEnv(envFilePath string) error {
 // newConfig returns a new Config struct with default values
 func newConfig() Config {
 	return Config{
-		Scheme:                           "https",
-		TokenLifespan:                    1,
-		AccessTokenMinutes:               15,
-		RefreshTokenDays:                 1,
-		RefreshTokenRememberMeDays:       30,
-		RefreshTokenCleanupIntervalHours: 24,
-		RefreshRateLimitRequests:         10,
-		RefreshRateLimitWindowMinutes:    1,
-		APISecret:                        "defaultApiSecret",
-		Stage:                            "local",
-		HostName:                         "localhost",
+		Scheme:                              "https",
+		TokenLifespan:                       1,
+		AccessTokenMinutes:                  15,
+		RefreshTokenDays:                    1,
+		RefreshTokenRememberMeDays:          30,
+		RefreshTokenCleanupIntervalHours:    24,
+		RefreshRateLimitRequests:            10,
+		RefreshRateLimitWindowMinutes:       1,
+		ResendConfirmRateLimitRequests:      1,
+		ResendConfirmRateLimitWindowMinutes: 1,
+		APISecret:                           "defaultApiSecret",
+		Stage:                               "local",
+		HostName:                            "localhost",
 		DBConfig: DBConfig{
 			DBPort: 5432,
 		},
@@ -162,6 +170,11 @@ func setEnvVars(cfg *Config) {
 		ifEnvEmpty(os.Getenv("REFRESH_RATE_LIMIT_REQUESTS"), strconv.Itoa(cfg.RefreshRateLimitRequests)))
 	cfg.RefreshRateLimitWindowMinutes, _ = strconv.Atoi(
 		ifEnvEmpty(os.Getenv("REFRESH_RATE_LIMIT_WINDOW_MINUTES"), strconv.Itoa(cfg.RefreshRateLimitWindowMinutes)))
+	cfg.ResendConfirmRateLimitRequests, _ = strconv.Atoi(
+		ifEnvEmpty(os.Getenv("RESEND_CONFIRM_RATE_LIMIT_REQUESTS"), strconv.Itoa(cfg.ResendConfirmRateLimitRequests)))
+	resendWindowDefault := strconv.Itoa(cfg.ResendConfirmRateLimitWindowMinutes)
+	cfg.ResendConfirmRateLimitWindowMinutes, _ = strconv.Atoi(
+		ifEnvEmpty(os.Getenv("RESEND_CONFIRM_RATE_LIMIT_WINDOW_MINUTES"), resendWindowDefault))
 	cfg.MailServer.MailIdentity = os.Getenv("MAIL_IDENTITY")
 	cfg.MailServer.MailUsername = os.Getenv("MAIL_USERNAME")
 	cfg.MailServer.MailPassword = os.Getenv("MAIL_PASSWORD")

--- a/pkg/security/rate_limiter.go
+++ b/pkg/security/rate_limiter.go
@@ -60,3 +60,24 @@ func RefreshRateLimiter(requestsPerMinute, burstSize int) gin.HandlerFunc {
 		c.Next()
 	}
 }
+
+// ResendConfirmRateLimiter creates a rate limiting middleware for /resend-confirmemail endpoint
+func ResendConfirmRateLimiter(requestsPerMinute, burstSize int) gin.HandlerFunc {
+	limiter := NewIPRateLimiter(requestsPerMinute, burstSize)
+
+	return func(c *gin.Context) {
+		clientIP := c.ClientIP()
+
+		if !limiter.GetLimiter(clientIP).Allow() {
+			AuditRateLimitExceeded(c, "/resend-confirmemail")
+			c.JSON(http.StatusTooManyRequests, gin.H{
+				"error":       "Rate limit exceeded",
+				"retry_after": 60,
+			})
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/pkg/security/rate_limiter_test.go
+++ b/pkg/security/rate_limiter_test.go
@@ -129,6 +129,49 @@ func TestRefreshRateLimiter_ResetAfterWindow(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w2.Code, "Request after window should succeed")
 }
 
+func TestResendConfirmRateLimiter_AllowsUnderLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	// Rate limiter: 1 request per minute
+	router.POST("/test", ResendConfirmRateLimiter(1, 1), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "success"})
+	})
+
+	// First request should succeed
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "First request should succeed")
+}
+
+func TestResendConfirmRateLimiter_BlocksOverLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	// Rate limiter: 1 request per minute
+	router.POST("/test", ResendConfirmRateLimiter(1, 1), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "success"})
+	})
+
+	// First request should succeed
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "First request should succeed")
+
+	// Second request should be rate limited
+	req2 := httptest.NewRequest(http.MethodPost, "/test", nil)
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req2)
+
+	assert.Equal(t, http.StatusTooManyRequests, w2.Code, "Second request should be rate limited")
+	assert.Contains(t, w2.Body.String(), "Rate limit exceeded")
+	assert.Contains(t, w2.Body.String(), "retry_after")
+}
+
 func TestIPRateLimiter_GetLimiter(t *testing.T) {
 	limiter := NewIPRateLimiter(10, 10)
 


### PR DESCRIPTION
## Summary

- Add `POST /api/resend-confirmemail` public endpoint for users who didn't receive their signup confirmation email
- Generates a new confirmation code on each resend (invalidates old links for security)
- Always returns HTTP 200 with a generic message regardless of email existence (prevents user enumeration)
- IP-based rate limiting (default: 1 req/min) following the existing `RefreshRateLimiter` pattern
- Reuses existing `sendConfirmationEmail()` (handles LOCAL mode logging automatically)

Related to Angak0k/pimpmypack-front#12

🤖 Generated with [Claude Code](https://claude.com/claude-code)