### PR TITLE
feat: improve email formatting to avoid spam classification

### DIFF
--- a/pkg/accounts/accounts.go
+++ b/pkg/accounts/accounts.go
@@ -88,15 +88,17 @@ func sendConfirmationEmail(u User, code string) error {
 	}
 
 	// Send confirmation email
+	confirmURL := config.Scheme + "://" + config.HostName + "/confirmemail.html?id=" +
+		strconv.FormatUint(uint64(u.ID), 10) + "&code=" + code
+
 	mailRcpt := u.Email
 	mailSubject := "PimpMyPack - Confirm your email address"
-	mailBody := "Please confirm your email address by clicking on the following link: " +
-		config.Scheme + "://" + config.HostName + "/confirmemail.html?id=" +
-		strconv.FormatUint(uint64(u.ID), 10) + "&code=" + code
+	mailTextBody := helper.BuildConfirmationEmailText(u.Username, confirmURL)
+	mailHTMLBody := helper.BuildConfirmationEmailHTML(u.Username, confirmURL)
 
 	smtpClient := helper.SMTPClient{Server: config.MailServerConfig}
 
-	err := smtpClient.SendEmail(mailRcpt, mailSubject, mailBody)
+	err := smtpClient.SendEmail(mailRcpt, mailSubject, mailTextBody, mailHTMLBody)
 	if err != nil {
 		return fmt.Errorf("failed to send confirmation email: %w", err)
 	}
@@ -227,12 +229,12 @@ func forgotPassword(ctx context.Context, email string) error {
 
 	mailRcpt := email
 	mailSubject := "PimpMyPack - Your password has been reset"
-	mailBody := "Hi! your password has been reset. If you did not request this, " +
-		"please contact us.\n\nYour new password is: " + newPassword
+	mailTextBody := helper.BuildPasswordResetEmailText(newPassword)
+	mailHTMLBody := helper.BuildPasswordResetEmailHTML(newPassword)
 
 	smtpClient := helper.SMTPClient{Server: config.MailServerConfig}
 
-	err = smtpClient.SendEmail(mailRcpt, mailSubject, mailBody)
+	err = smtpClient.SendEmail(mailRcpt, mailSubject, mailTextBody, mailHTMLBody)
 	if err != nil {
 		return fmt.Errorf("failed to send password reset email: %w", err)
 	}

--- a/pkg/helper/email_templates.go
+++ b/pkg/helper/email_templates.go
@@ -1,0 +1,131 @@
+package helper
+
+import "fmt"
+
+// BuildEmailHTML wraps body content in a branded HTML email layout.
+func BuildEmailHTML(title, preheaderText, bodyContent string) string {
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<title>%s</title>
+<!--[if mso]>
+<style type="text/css">
+table {border-collapse: collapse;}
+</style>
+<![endif]-->
+</head>
+<body style="margin:0;padding:0;background-color:#f5f5f4;
+font-family:'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+<!-- Preheader (hidden) -->
+<div style="display:none;max-height:0;overflow:hidden;">%s</div>
+<!-- Wrapper -->
+<table role="presentation" width="100%%" cellpadding="0" cellspacing="0" border="0" style="background-color:#f5f5f4;">
+<tr><td align="center" style="padding:24px 16px;">
+<!-- Container 600px -->
+<table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%%;">
+<!-- Header -->
+<tr><td style="background-color:#14532d;padding:24px 32px;border-radius:12px 12px 0 0;text-align:center;">
+<span style="font-size:24px;font-weight:700;color:#ffffff;letter-spacing:0.5px;">PimpMyPack</span>
+</td></tr>
+<!-- Body -->
+<tr><td style="background-color:#ffffff;padding:32px;border-radius:0 0 12px 12px;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+%s
+</td></tr>
+<!-- Footer -->
+<tr><td style="padding:24px 32px;text-align:center;">
+<p style="margin:0;font-size:13px;color:#78716c;line-height:1.5;">
+&copy; PimpMyPack &mdash; Optimize your pack, enjoy the trail.
+</p>
+</td></tr>
+</table>
+</td></tr>
+</table>
+</body>
+</html>`, title, preheaderText, bodyContent)
+}
+
+// BuildConfirmationEmailHTML returns the branded HTML body for a confirmation email.
+func BuildConfirmationEmailHTML(username, confirmURL string) string {
+	body := fmt.Sprintf(`<h1 style="margin:0 0 16px;font-size:22px;color:#292524;">Welcome, %s!</h1>
+<p style="margin:0 0 24px;font-size:16px;color:#292524;line-height:1.6;">
+Thanks for signing up for PimpMyPack. Please confirm your email address to activate your account.
+</p>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 auto 24px;">
+<tr><td style="border-radius:8px;background-color:#16a34a;text-align:center;">
+<a href="%s" target="_blank"
+style="display:inline-block;padding:14px 32px;font-size:16px;
+font-weight:600;color:#ffffff;text-decoration:none;
+border-radius:8px;">Confirm my email</a>
+</td></tr>
+</table>
+<p style="margin:0;font-size:13px;color:#78716c;line-height:1.5;word-break:break-all;">
+If the button doesn't work, copy and paste this link into your browser:<br>
+<a href="%s" style="color:#16a34a;">%s</a>
+</p>`, username, confirmURL, confirmURL, confirmURL)
+
+	return BuildEmailHTML(
+		"Confirm your email — PimpMyPack",
+		"Please confirm your email address to activate your PimpMyPack account.",
+		body,
+	)
+}
+
+// BuildConfirmationEmailText returns the plain-text body for a confirmation email.
+func BuildConfirmationEmailText(username, confirmURL string) string {
+	return fmt.Sprintf(`Welcome, %s!
+
+Thanks for signing up for PimpMyPack. Please confirm your email address to activate your account.
+
+Confirm your email:
+%s
+
+--
+PimpMyPack - Optimize your pack, enjoy the trail.
+`, username, confirmURL)
+}
+
+// BuildPasswordResetEmailHTML returns the branded HTML body for a password reset email.
+func BuildPasswordResetEmailHTML(newPassword string) string {
+	body := fmt.Sprintf(`<h1 style="margin:0 0 16px;font-size:22px;color:#292524;">Password Reset</h1>
+<p style="margin:0 0 16px;font-size:16px;color:#292524;line-height:1.6;">
+Your password has been reset. Here is your new temporary password:
+</p>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%%" style="margin:0 0 24px;">
+<tr><td style="background-color:#fafaf9;border:1px solid #e7e5e4;
+border-radius:8px;padding:16px 24px;text-align:center;">
+<code style="font-size:20px;font-family:'Courier New',Courier,monospace;color:#292524;letter-spacing:1px;">%s</code>
+</td></tr>
+</table>
+<p style="margin:0 0 8px;font-size:16px;color:#292524;line-height:1.6;">
+We recommend changing your password after logging in.
+</p>
+<p style="margin:0;font-size:13px;color:#78716c;line-height:1.5;">
+If you did not request this password reset, please contact us immediately.
+</p>`, newPassword)
+
+	return BuildEmailHTML(
+		"Password Reset — PimpMyPack",
+		"Your PimpMyPack password has been reset.",
+		body,
+	)
+}
+
+// BuildPasswordResetEmailText returns the plain-text body for a password reset email.
+func BuildPasswordResetEmailText(newPassword string) string {
+	return fmt.Sprintf(`Password Reset
+
+Your password has been reset. Here is your new temporary password:
+
+    %s
+
+We recommend changing your password after logging in.
+
+If you did not request this password reset, please contact us immediately.
+
+--
+PimpMyPack - Optimize your pack, enjoy the trail.
+`, newPassword)
+}

--- a/pkg/helper/email_templates.go
+++ b/pkg/helper/email_templates.go
@@ -1,9 +1,15 @@
 package helper
 
-import "fmt"
+import (
+	"fmt"
+	"html"
+)
 
 // BuildEmailHTML wraps body content in a branded HTML email layout.
+// title and preheaderText are HTML-escaped; bodyContent is trusted pre-built HTML.
 func BuildEmailHTML(title, preheaderText, bodyContent string) string {
+	safeTitle := html.EscapeString(title)
+	safePreheader := html.EscapeString(preheaderText)
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -44,11 +50,13 @@ font-family:'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
 </td></tr>
 </table>
 </body>
-</html>`, title, preheaderText, bodyContent)
+</html>`, safeTitle, safePreheader, bodyContent)
 }
 
 // BuildConfirmationEmailHTML returns the branded HTML body for a confirmation email.
 func BuildConfirmationEmailHTML(username, confirmURL string) string {
+	safeName := html.EscapeString(username)
+	safeURL := html.EscapeString(confirmURL)
 	body := fmt.Sprintf(`<h1 style="margin:0 0 16px;font-size:22px;color:#292524;">Welcome, %s!</h1>
 <p style="margin:0 0 24px;font-size:16px;color:#292524;line-height:1.6;">
 Thanks for signing up for PimpMyPack. Please confirm your email address to activate your account.
@@ -64,7 +72,7 @@ border-radius:8px;">Confirm my email</a>
 <p style="margin:0;font-size:13px;color:#78716c;line-height:1.5;word-break:break-all;">
 If the button doesn't work, copy and paste this link into your browser:<br>
 <a href="%s" style="color:#16a34a;">%s</a>
-</p>`, username, confirmURL, confirmURL, confirmURL)
+</p>`, safeName, safeURL, safeURL, safeURL)
 
 	return BuildEmailHTML(
 		"Confirm your email — PimpMyPack",
@@ -89,6 +97,7 @@ PimpMyPack - Optimize your pack, enjoy the trail.
 
 // BuildPasswordResetEmailHTML returns the branded HTML body for a password reset email.
 func BuildPasswordResetEmailHTML(newPassword string) string {
+	safePassword := html.EscapeString(newPassword)
 	body := fmt.Sprintf(`<h1 style="margin:0 0 16px;font-size:22px;color:#292524;">Password Reset</h1>
 <p style="margin:0 0 16px;font-size:16px;color:#292524;line-height:1.6;">
 Your password has been reset. Here is your new temporary password:
@@ -104,7 +113,7 @@ We recommend changing your password after logging in.
 </p>
 <p style="margin:0;font-size:13px;color:#78716c;line-height:1.5;">
 If you did not request this password reset, please contact us immediately.
-</p>`, newPassword)
+</p>`, safePassword)
 
 	return BuildEmailHTML(
 		"Password Reset — PimpMyPack",

--- a/pkg/helper/email_templates_test.go
+++ b/pkg/helper/email_templates_test.go
@@ -1,0 +1,94 @@
+package helper
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildConfirmationEmailHTML(t *testing.T) {
+	html := BuildConfirmationEmailHTML("testuser", "https://example.com/confirm?id=1&code=abc")
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		{"username", "testuser"},
+		{"confirm URL href", `href="https://example.com/confirm?id=1&code=abc"`},
+		{"CTA button text", "Confirm my email"},
+		{"branding", "PimpMyPack"},
+		{"brand header color", "#14532d"},
+		{"button color", "#16a34a"},
+	}
+
+	for _, c := range checks {
+		t.Run(c.name, func(t *testing.T) {
+			if !strings.Contains(html, c.substr) {
+				t.Errorf("expected HTML to contain %q", c.substr)
+			}
+		})
+	}
+}
+
+func TestBuildConfirmationEmailText(t *testing.T) {
+	text := BuildConfirmationEmailText("testuser", "https://example.com/confirm?id=1&code=abc")
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		{"username", "testuser"},
+		{"confirm URL", "https://example.com/confirm?id=1&code=abc"},
+		{"branding", "PimpMyPack"},
+	}
+
+	for _, c := range checks {
+		t.Run(c.name, func(t *testing.T) {
+			if !strings.Contains(text, c.substr) {
+				t.Errorf("expected text to contain %q", c.substr)
+			}
+		})
+	}
+}
+
+func TestBuildPasswordResetEmailHTML(t *testing.T) {
+	html := BuildPasswordResetEmailHTML("s3cretP@ss")
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		{"password", "s3cretP@ss"},
+		{"warning", "did not request"},
+		{"branding", "PimpMyPack"},
+		{"recommendation", "recommend changing"},
+	}
+
+	for _, c := range checks {
+		t.Run(c.name, func(t *testing.T) {
+			if !strings.Contains(html, c.substr) {
+				t.Errorf("expected HTML to contain %q", c.substr)
+			}
+		})
+	}
+}
+
+func TestBuildPasswordResetEmailText(t *testing.T) {
+	text := BuildPasswordResetEmailText("s3cretP@ss")
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		{"password", "s3cretP@ss"},
+		{"warning", "did not request"},
+		{"branding", "PimpMyPack"},
+	}
+
+	for _, c := range checks {
+		t.Run(c.name, func(t *testing.T) {
+			if !strings.Contains(text, c.substr) {
+				t.Errorf("expected text to contain %q", c.substr)
+			}
+		})
+	}
+}

--- a/pkg/helper/email_templates_test.go
+++ b/pkg/helper/email_templates_test.go
@@ -13,7 +13,7 @@ func TestBuildConfirmationEmailHTML(t *testing.T) {
 		substr string
 	}{
 		{"username", "testuser"},
-		{"confirm URL href", `href="https://example.com/confirm?id=1&code=abc"`},
+		{"confirm URL href", `href="https://example.com/confirm?id=1&amp;code=abc"`},
 		{"CTA button text", "Confirm my email"},
 		{"branding", "PimpMyPack"},
 		{"brand header color", "#14532d"},

--- a/pkg/helper/helper.go
+++ b/pkg/helper/helper.go
@@ -80,14 +80,33 @@ type SMTPClient struct {
 func (s *SMTPClient) SendEmail(to, subject, textBody, htmlBody string) error {
 	auth := smtp.PlainAuth("", s.Server.MailUsername, s.Server.MailPassword, s.Server.MailServer)
 
-	domain := extractDomain(s.Server.MailUsername)
+	msg, err := BuildMIMEMessage(
+		s.Server.MailIdentity, s.Server.MailUsername,
+		to, subject, textBody, htmlBody,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to build email message: %w", err)
+	}
+
+	return smtp.SendMail(
+		s.Server.MailServer+":"+strconv.Itoa(s.Server.MailPort),
+		auth,
+		s.Server.MailUsername,
+		[]string{to},
+		msg,
+	)
+}
+
+// BuildMIMEMessage constructs a multipart/alternative MIME email message with proper headers.
+func BuildMIMEMessage(
+	fromName, fromAddr, to, subject, textBody, htmlBody string,
+) ([]byte, error) {
+	domain := extractDomain(fromAddr)
 	messageID := generateMessageID(domain)
 
-	// Build multipart/alternative MIME body
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
 
-	// Write top-level headers
 	headers := fmt.Sprintf("From: %s <%s>\r\n"+
 		"To: %s\r\n"+
 		"Subject: %s\r\n"+
@@ -96,7 +115,7 @@ func (s *SMTPClient) SendEmail(to, subject, textBody, htmlBody string) error {
 		"MIME-Version: 1.0\r\n"+
 		"Content-Type: multipart/alternative; boundary=%s\r\n"+
 		"\r\n",
-		s.Server.MailIdentity, s.Server.MailUsername,
+		fromName, fromAddr,
 		to,
 		subject,
 		time.Now().Format(time.RFC1123Z),
@@ -110,42 +129,36 @@ func (s *SMTPClient) SendEmail(to, subject, textBody, htmlBody string) error {
 	// text/plain part
 	textHeader := make(textproto.MIMEHeader)
 	textHeader.Set("Content-Type", "text/plain; charset=utf-8")
-	textHeader.Set("Content-Transfer-Encoding", "quoted-printable")
+	textHeader.Set("Content-Transfer-Encoding", "8bit")
 
 	textPart, err := writer.CreatePart(textHeader)
 	if err != nil {
-		return fmt.Errorf("failed to create text part: %w", err)
+		return nil, fmt.Errorf("failed to create text part: %w", err)
 	}
 	if _, err := textPart.Write([]byte(textBody)); err != nil {
-		return fmt.Errorf("failed to write text part: %w", err)
+		return nil, fmt.Errorf("failed to write text part: %w", err)
 	}
 
 	// text/html part
 	htmlHeader := make(textproto.MIMEHeader)
 	htmlHeader.Set("Content-Type", "text/html; charset=utf-8")
-	htmlHeader.Set("Content-Transfer-Encoding", "quoted-printable")
+	htmlHeader.Set("Content-Transfer-Encoding", "8bit")
 
 	htmlPart, err := writer.CreatePart(htmlHeader)
 	if err != nil {
-		return fmt.Errorf("failed to create html part: %w", err)
+		return nil, fmt.Errorf("failed to create html part: %w", err)
 	}
 	if _, err := htmlPart.Write([]byte(htmlBody)); err != nil {
-		return fmt.Errorf("failed to write html part: %w", err)
+		return nil, fmt.Errorf("failed to write html part: %w", err)
 	}
 
 	if err := writer.Close(); err != nil {
-		return fmt.Errorf("failed to close multipart writer: %w", err)
+		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
 	}
 
 	msg.Write(buf.Bytes())
 
-	return smtp.SendMail(
-		s.Server.MailServer+":"+strconv.Itoa(s.Server.MailPort),
-		auth,
-		s.Server.MailUsername,
-		[]string{to},
-		msg.Bytes(),
-	)
+	return msg.Bytes(), nil
 }
 
 func extractDomain(email string) string {
@@ -159,6 +172,8 @@ func extractDomain(email string) string {
 func generateMessageID(domain string) string {
 	ts := time.Now().UnixNano()
 	randBytes := make([]byte, 8)
-	_, _ = rand.Read(randBytes)
+	if _, err := rand.Read(randBytes); err != nil {
+		return fmt.Sprintf("%d@%s", ts, domain)
+	}
 	return fmt.Sprintf("%d.%x@%s", ts, randBytes, domain)
 }

--- a/pkg/helper/helper.go
+++ b/pkg/helper/helper.go
@@ -1,12 +1,17 @@
 package helper
 
 import (
+	"bytes"
 	"crypto/rand"
+	"fmt"
 	"math/big"
+	"mime/multipart"
 	"net/smtp"
+	"net/textproto"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Angak0k/pimpmypack/pkg/config"
 )
@@ -63,7 +68,7 @@ func IsValidEmail(email string) bool {
 
 // EmailSender defines the interface for sending emails. Needed for testing without real SMTP server.
 type EmailSender interface {
-	SendEmail(to, subject, body string) error
+	SendEmail(to, subject, textBody, htmlBody string) error
 }
 
 // SMTPClient struct implements EmailSender interface.
@@ -71,19 +76,89 @@ type SMTPClient struct {
 	Server config.MailServer
 }
 
-// SendMail sends an email using the SMTP protocol.
-func (s *SMTPClient) SendEmail(to, subject, body string) error {
+// SendEmail sends an email using the SMTP protocol with proper MIME multipart/alternative formatting.
+func (s *SMTPClient) SendEmail(to, subject, textBody, htmlBody string) error {
 	auth := smtp.PlainAuth("", s.Server.MailUsername, s.Server.MailPassword, s.Server.MailServer)
-	msg := []byte("To: " + to + "\r\n" +
-		"Subject: " + subject + "\r\n" +
-		"\r\n" +
-		body + "\r\n")
+
+	domain := extractDomain(s.Server.MailUsername)
+	messageID := generateMessageID(domain)
+
+	// Build multipart/alternative MIME body
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	// Write top-level headers
+	headers := fmt.Sprintf("From: %s <%s>\r\n"+
+		"To: %s\r\n"+
+		"Subject: %s\r\n"+
+		"Date: %s\r\n"+
+		"Message-ID: <%s>\r\n"+
+		"MIME-Version: 1.0\r\n"+
+		"Content-Type: multipart/alternative; boundary=%s\r\n"+
+		"\r\n",
+		s.Server.MailIdentity, s.Server.MailUsername,
+		to,
+		subject,
+		time.Now().Format(time.RFC1123Z),
+		messageID,
+		writer.Boundary(),
+	)
+
+	var msg bytes.Buffer
+	msg.WriteString(headers)
+
+	// text/plain part
+	textHeader := make(textproto.MIMEHeader)
+	textHeader.Set("Content-Type", "text/plain; charset=utf-8")
+	textHeader.Set("Content-Transfer-Encoding", "quoted-printable")
+
+	textPart, err := writer.CreatePart(textHeader)
+	if err != nil {
+		return fmt.Errorf("failed to create text part: %w", err)
+	}
+	if _, err := textPart.Write([]byte(textBody)); err != nil {
+		return fmt.Errorf("failed to write text part: %w", err)
+	}
+
+	// text/html part
+	htmlHeader := make(textproto.MIMEHeader)
+	htmlHeader.Set("Content-Type", "text/html; charset=utf-8")
+	htmlHeader.Set("Content-Transfer-Encoding", "quoted-printable")
+
+	htmlPart, err := writer.CreatePart(htmlHeader)
+	if err != nil {
+		return fmt.Errorf("failed to create html part: %w", err)
+	}
+	if _, err := htmlPart.Write([]byte(htmlBody)); err != nil {
+		return fmt.Errorf("failed to write html part: %w", err)
+	}
+
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	msg.Write(buf.Bytes())
 
 	return smtp.SendMail(
 		s.Server.MailServer+":"+strconv.Itoa(s.Server.MailPort),
 		auth,
-		s.Server.MailIdentity,
+		s.Server.MailUsername,
 		[]string{to},
-		msg,
+		msg.Bytes(),
 	)
+}
+
+func extractDomain(email string) string {
+	parts := strings.SplitN(email, "@", 2)
+	if len(parts) == 2 {
+		return parts[1]
+	}
+	return "localhost"
+}
+
+func generateMessageID(domain string) string {
+	ts := time.Now().UnixNano()
+	randBytes := make([]byte, 8)
+	_, _ = rand.Read(randBytes)
+	return fmt.Sprintf("%d.%x@%s", ts, randBytes, domain)
 }

--- a/pkg/helper/helper_test.go
+++ b/pkg/helper/helper_test.go
@@ -3,6 +3,7 @@ package helper
 import (
 	"log"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/Angak0k/pimpmypack/pkg/config"
@@ -83,7 +84,7 @@ func TestSendEmail(t *testing.T) {
 
 	err := mockSender.SendEmail("example@example.com", "Test Subject", "This is a test.", "<p>This is a test.</p>")
 	if err != nil {
-		t.Errorf("SendMail failed: %v", err)
+		t.Errorf("SendEmail failed: %v", err)
 	}
 
 	// Verify that the email was "sent"
@@ -97,6 +98,45 @@ func TestSendEmail(t *testing.T) {
 	}
 	if sent.HTMLBody != "<p>This is a test.</p>" {
 		t.Errorf("Expected HTML body '<p>This is a test.</p>', got '%s'", sent.HTMLBody)
+	}
+}
+
+func TestBuildMIMEMessage(t *testing.T) {
+	msg, err := BuildMIMEMessage(
+		"PimpMyPack", "noreply@pimpmypack.com",
+		"user@example.com", "Test Subject",
+		"Plain text body", "<p>HTML body</p>",
+	)
+	if err != nil {
+		t.Fatalf("BuildMIMEMessage failed: %v", err)
+	}
+
+	raw := string(msg)
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		{"From header", "From: PimpMyPack <noreply@pimpmypack.com>"},
+		{"To header", "To: user@example.com"},
+		{"Subject header", "Subject: Test Subject"},
+		{"Date header", "Date: "},
+		{"Message-ID header", "Message-ID: <"},
+		{"MIME-Version", "MIME-Version: 1.0"},
+		{"multipart boundary", "Content-Type: multipart/alternative; boundary="},
+		{"text/plain part", "Content-Type: text/plain; charset=utf-8"},
+		{"text/html part", "Content-Type: text/html; charset=utf-8"},
+		{"text body", "Plain text body"},
+		{"html body", "<p>HTML body</p>"},
+		{"8bit encoding", "Content-Transfer-Encoding: 8bit"},
+	}
+
+	for _, c := range checks {
+		t.Run(c.name, func(t *testing.T) {
+			if !strings.Contains(raw, c.substr) {
+				t.Errorf("expected message to contain %q", c.substr)
+			}
+		})
 	}
 }
 

--- a/pkg/helper/helper_test.go
+++ b/pkg/helper/helper_test.go
@@ -65,21 +65,23 @@ type MockEmailSender struct {
 
 // Email represents an email message for testing.
 type Email struct {
-	To      string
-	Subject string
-	Body    string
+	To       string
+	Subject  string
+	TextBody string
+	HTMLBody string
 }
 
-// SendMail records the email sending action without actually sending an email.
-func (m *MockEmailSender) SendEmail(to, subject, body string) error {
-	m.SentEmails = append(m.SentEmails, Email{To: to, Subject: subject, Body: body})
+// SendEmail records the email sending action without actually sending an email.
+func (m *MockEmailSender) SendEmail(to, subject, textBody, htmlBody string) error {
+	m.SentEmails = append(m.SentEmails, Email{To: to, Subject: subject, TextBody: textBody, HTMLBody: htmlBody})
 	return nil // Return nil to simulate a successful send
 }
+
 func TestSendEmail(t *testing.T) {
 	// Create a new instance of the mock
 	mockSender := &MockEmailSender{}
 
-	err := mockSender.SendEmail("example@example.com", "Test Subject", "This is a test.")
+	err := mockSender.SendEmail("example@example.com", "Test Subject", "This is a test.", "<p>This is a test.</p>")
 	if err != nil {
 		t.Errorf("SendMail failed: %v", err)
 	}
@@ -87,6 +89,14 @@ func TestSendEmail(t *testing.T) {
 	// Verify that the email was "sent"
 	if len(mockSender.SentEmails) != 1 {
 		t.Errorf("Expected 1 email to be sent, got %d", len(mockSender.SentEmails))
+	}
+
+	sent := mockSender.SentEmails[0]
+	if sent.TextBody != "This is a test." {
+		t.Errorf("Expected text body 'This is a test.', got '%s'", sent.TextBody)
+	}
+	if sent.HTMLBody != "<p>This is a test.</p>" {
+		t.Errorf("Expected HTML body '<p>This is a test.</p>', got '%s'", sent.HTMLBody)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Rewrite `SendEmail` to use proper MIME `multipart/alternative` format with required headers (`From`, `Date`, `Message-ID`, `MIME-Version`, `Content-Type`)
- Add branded HTML email templates for confirmation and password reset emails, matching the PimpMyPack front-end design system (forest green header, green CTA buttons, table-based layout)
- Fix envelope sender bug: uses `MailUsername` (valid email) instead of `MailIdentity` (display name)
- Update `EmailSender` interface to accept both `textBody` and `htmlBody` parameters

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)