### PR TITLE
feat: allow login with email or username

### DIFF
--- a/api-doc/docs.go
+++ b/api-doc/docs.go
@@ -1181,6 +1181,18 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/apitypes.ErrorResponse"
                         }
+                    },
+                    "409": {
+                        "description": "Email already in use",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
                     }
                 }
             }

--- a/api-doc/docs.go
+++ b/api-doc/docs.go
@@ -1095,7 +1095,7 @@ const docTemplate = `{
         },
         "/login": {
             "post": {
-                "description": "Log in a user by providing username and password\nReturns access token (short-lived) and refresh token (long-lived)\nUse remember_me to extend refresh token lifetime",
+                "description": "Log in a user by providing username (or email) and password\nThe username field accepts either a username or an email address\nReturns access token (short-lived) and refresh token (long-lived)\nUse remember_me to extend refresh token lifetime",
                 "consumes": [
                     "application/json"
                 ],

--- a/api-doc/swagger.json
+++ b/api-doc/swagger.json
@@ -1178,6 +1178,18 @@
                         "schema": {
                             "$ref": "#/definitions/apitypes.ErrorResponse"
                         }
+                    },
+                    "409": {
+                        "description": "Email already in use",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
                     }
                 }
             }

--- a/api-doc/swagger.json
+++ b/api-doc/swagger.json
@@ -1092,7 +1092,7 @@
         },
         "/login": {
             "post": {
-                "description": "Log in a user by providing username and password\nReturns access token (short-lived) and refresh token (long-lived)\nUse remember_me to extend refresh token lifetime",
+                "description": "Log in a user by providing username (or email) and password\nThe username field accepts either a username or an email address\nReturns access token (short-lived) and refresh token (long-lived)\nUse remember_me to extend refresh token lifetime",
                 "consumes": [
                     "application/json"
                 ],

--- a/api-doc/swagger.yaml
+++ b/api-doc/swagger.yaml
@@ -1196,6 +1196,14 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/apitypes.ErrorResponse'
+        "409":
+          description: Email already in use
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
       summary: Register new user
       tags:
       - Public

--- a/api-doc/swagger.yaml
+++ b/api-doc/swagger.yaml
@@ -1139,7 +1139,8 @@ paths:
       consumes:
       - application/json
       description: |-
-        Log in a user by providing username and password
+        Log in a user by providing username (or email) and password
+        The username field accepts either a username or an email address
         Returns access token (short-lived) and refresh token (long-lived)
         Use remember_me to extend refresh token lifetime
       parameters:

--- a/main.go
+++ b/main.go
@@ -152,6 +152,7 @@ func setupProtectedRoutes(router *gin.Engine) {
 	protected.POST("/myinventory", inventories.PostMyInventory)
 	protected.PUT("/myinventory/:id", inventories.PutMyInventoryByID)
 	protected.DELETE("/myinventory/:id", inventories.DeleteMyInventoryByID)
+	protected.GET("/pack-options", packs.GetPackOptions)
 	protected.POST("/importfromlighterpack", packs.ImportFromLighterPack)
 	protected.POST("/mypack/:id/image", images.UploadPackImage)
 	protected.DELETE("/mypack/:id/image", images.DeletePackImage)

--- a/pkg/accounts/accounts.go
+++ b/pkg/accounts/accounts.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Angak0k/pimpmypack/pkg/database"
 	"github.com/Angak0k/pimpmypack/pkg/helper"
 	"github.com/Angak0k/pimpmypack/pkg/security"
+	"github.com/lib/pq"
 )
 
 // ErrNoAccountFound is returned when no account is found for a given ID.
@@ -23,6 +24,9 @@ const stageLocal = "LOCAL"
 
 // ErrInvalidCredentials is returned when login credentials are invalid.
 var ErrInvalidCredentials = errors.New("invalid credentials")
+
+// ErrEmailAlreadyExists is returned when a registration is attempted with an already-used email.
+var ErrEmailAlreadyExists = errors.New("email already exists")
 
 func registerUser(ctx context.Context, u User) (bool, error) {
 	var id int
@@ -47,6 +51,10 @@ func registerUser(ctx context.Context, u User) (bool, error) {
 		u.CreatedAt,
 		u.UpdatedAt).Scan(&id)
 	if err != nil {
+		var pqErr *pq.Error
+		if errors.As(err, &pqErr) && pqErr.Code == "23505" && pqErr.Constraint == "account_email_unique" {
+			return false, ErrEmailAlreadyExists
+		}
 		return false, fmt.Errorf("failed to insert user: %w", err)
 	}
 

--- a/pkg/accounts/accounts.go
+++ b/pkg/accounts/accounts.go
@@ -252,7 +252,7 @@ func loginCheck(
 	row := database.DB().QueryRowContext(ctx,
 		`SELECT p.password, p.user_id, a.status
 		FROM password AS p JOIN account AS a ON p.user_id = a.id
-		WHERE a.username = $1;`,
+		WHERE a.username = $1 OR a.email = $1;`,
 		username)
 	err = row.Scan(&storedPassword, &id, &status)
 

--- a/pkg/accounts/accounts_test.go
+++ b/pkg/accounts/accounts_test.go
@@ -589,6 +589,106 @@ func testLoginWithIncorrectPassword(t *testing.T, router *gin.Engine, username s
 	}
 }
 
+func testLoginWithEmail(t *testing.T, router *gin.Engine, user User) {
+	// Reset user status to active
+	_, err := database.DB().Exec("UPDATE account SET status = 'active' WHERE username = $1;", user.Username)
+	if err != nil {
+		t.Fatalf("failed to reset user status: %v", err)
+	}
+
+	emailLogin := LoginInput{
+		Username: user.Email,
+		Password: user.Password,
+	}
+	emailJSON, err := json.Marshal(emailLogin)
+	if err != nil {
+		t.Fatalf("Failed to marshal login data: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "/login", bytes.NewBuffer(emailJSON))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status code %d but got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to unmarshal response body: %v", err)
+	}
+	validateTokenPairResponse(t, response)
+}
+
+func testLoginWithEmailPendingUser(t *testing.T, router *gin.Engine, user User) {
+	// Set status to pending
+	_, err := database.DB().Exec("UPDATE account SET status = 'pending' WHERE username = $1;", user.Username)
+	if err != nil {
+		t.Fatalf("failed to set user status to pending: %v", err)
+	}
+
+	emailLogin := LoginInput{
+		Username: user.Email,
+		Password: user.Password,
+	}
+	emailJSON, err := json.Marshal(emailLogin)
+	if err != nil {
+		t.Fatalf("Failed to marshal login data: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "/login", bytes.NewBuffer(emailJSON))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("Expected status code %d but got %d. Body: %s", http.StatusUnauthorized, w.Code, w.Body.String())
+	}
+}
+
+func testLoginWithNonexistentEmail(t *testing.T, router *gin.Engine) {
+	emailLogin := LoginInput{
+		Username: "nonexistent-" + random.UniqueId() + "@example.com",
+		Password: "anypassword",
+	}
+	emailJSON, err := json.Marshal(emailLogin)
+	if err != nil {
+		t.Fatalf("Failed to marshal login data: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "/login", bytes.NewBuffer(emailJSON))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("Expected status code %d but got %d. Body: %s", http.StatusUnauthorized, w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+	if errMsg, ok := response["error"].(string); ok {
+		if errMsg != "credentials are incorrect" {
+			t.Errorf("Expected generic error message but got: %s", errMsg)
+		}
+	}
+}
+
 // validateTokenPairResponse validates the token pair response format
 func validateTokenPairResponse(t *testing.T, response map[string]interface{}) {
 	t.Helper()
@@ -666,6 +766,18 @@ func TestLogin(t *testing.T) {
 		if w.Code != http.StatusUnauthorized {
 			t.Errorf("Expected status code %d but got %d", http.StatusOK, w.Code)
 		}
+	})
+
+	t.Run("Login with email", func(t *testing.T) {
+		testLoginWithEmail(t, router, newUser)
+	})
+
+	t.Run("Login with email of pending user", func(t *testing.T) {
+		testLoginWithEmailPendingUser(t, router, newUser)
+	})
+
+	t.Run("Login with nonexistent email", func(t *testing.T) {
+		testLoginWithNonexistentEmail(t, router)
 	})
 
 	t.Run("Login with invalid username", func(t *testing.T) {

--- a/pkg/accounts/accounts_test.go
+++ b/pkg/accounts/accounts_test.go
@@ -719,10 +719,16 @@ func testLoginWithNonexistentEmail(t *testing.T, router *gin.Engine) {
 	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to unmarshal response: %v", err)
 	}
-	if errMsg, ok := response["error"].(string); ok {
-		if errMsg != "credentials are incorrect" {
-			t.Errorf("Expected generic error message but got: %s", errMsg)
-		}
+	errorVal, exists := response["error"]
+	if !exists {
+		t.Fatalf("Expected 'error' field in response but it was missing. Full response: %+v", response)
+	}
+	errMsg, ok := errorVal.(string)
+	if !ok {
+		t.Fatalf("Expected 'error' field to be a string but got %T. Value: %v", errorVal, errorVal)
+	}
+	if errMsg != "credentials are incorrect" {
+		t.Errorf("Expected generic error message %q but got: %q", "credentials are incorrect", errMsg)
 	}
 }
 

--- a/pkg/accounts/accounts_test.go
+++ b/pkg/accounts/accounts_test.go
@@ -471,73 +471,117 @@ func TestRegisterKO(t *testing.T) {
 	// Define the endpoint for Register handler
 	router.POST("/register", Register)
 	t.Run("Register account with duplicate email", func(t *testing.T) {
-		// Use the email of the first user in the dataset (already exists)
-		newAccount := RegisterInput{
-			Username:  "user-" + random.UniqueId(),
-			Password:  "password",
-			Email:     users[0].Email,
-			Firstname: "Duplicate",
-			Lastname:  "Email",
-		}
-
-		jsonData, err := json.Marshal(newAccount)
-		if err != nil {
-			t.Fatalf("Failed to marshal account data: %v", err)
-		}
-
-		req, err := http.NewRequest(http.MethodPost, "/register", bytes.NewBuffer(jsonData))
-		if err != nil {
-			t.Fatalf("Failed to create request: %v", err)
-		}
-		req.Header.Set("Content-Type", "application/json")
-
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		if w.Code != http.StatusConflict {
-			t.Errorf("Expected status code %d but got %d. Body: %s", http.StatusConflict, w.Code, w.Body.String())
-		}
-
-		var response map[string]string
-		if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
-			t.Fatalf("Failed to unmarshal response: %v", err)
-		}
-		if response["error"] != "email already in use" {
-			t.Errorf("Expected error 'email already in use' but got '%s'", response["error"])
-		}
+		testRegisterWithDuplicateEmail(t, router)
 	})
-
+	t.Run("Register account with @ in username", func(t *testing.T) {
+		testRegisterWithAtInUsername(t, router)
+	})
 	t.Run("Register account with bad email", func(t *testing.T) {
-		// Sample account data
-		newAccount := RegisterInput{
-			Username:  "user-" + random.UniqueId(),
-			Password:  "password",
-			Email:     "jane.doe@exemple",
-			Firstname: "Jane",
-			Lastname:  "Doe",
-		}
-
-		// Convert account data to JSON
-		jsonData, err := json.Marshal(newAccount)
-		if err != nil {
-			t.Fatalf("Failed to marshal account data: %v", err)
-		}
-
-		// Set up a test scenario: sending a POST request with JSON data
-		req, err := http.NewRequest(http.MethodPost, "/register", bytes.NewBuffer(jsonData))
-		if err != nil {
-			t.Fatalf("Failed to create request: %v", err)
-		}
-		req.Header.Set("Content-Type", "application/json")
-
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		// Check the HTTP status code
-		if w.Code != http.StatusBadRequest {
-			t.Errorf("Expected status code %d but got %d", http.StatusBadRequest, w.Code)
-		}
+		testRegisterWithBadEmail(t, router)
 	})
+}
+
+func testRegisterWithDuplicateEmail(t *testing.T, router *gin.Engine) {
+	t.Helper()
+	newAccount := RegisterInput{
+		Username:  "user-" + random.UniqueId(),
+		Password:  "password",
+		Email:     users[0].Email,
+		Firstname: "Duplicate",
+		Lastname:  "Email",
+	}
+
+	jsonData, err := json.Marshal(newAccount)
+	if err != nil {
+		t.Fatalf("Failed to marshal account data: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "/register", bytes.NewBuffer(jsonData))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("Expected status code %d but got %d. Body: %s", http.StatusConflict, w.Code, w.Body.String())
+	}
+
+	var response map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+	if response["error"] != "email already in use" {
+		t.Errorf("Expected error 'email already in use' but got '%s'", response["error"])
+	}
+}
+
+func testRegisterWithAtInUsername(t *testing.T, router *gin.Engine) {
+	t.Helper()
+	newAccount := RegisterInput{
+		Username:  "user@example.com",
+		Password:  "password",
+		Email:     "valid-" + random.UniqueId() + "@example.com",
+		Firstname: "At",
+		Lastname:  "Username",
+	}
+
+	jsonData, err := json.Marshal(newAccount)
+	if err != nil {
+		t.Fatalf("Failed to marshal account data: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "/register", bytes.NewBuffer(jsonData))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status code %d but got %d. Body: %s", http.StatusBadRequest, w.Code, w.Body.String())
+	}
+
+	var response map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+	if response["error"] != "username must not contain @" {
+		t.Errorf("Expected error 'username must not contain @' but got '%s'", response["error"])
+	}
+}
+
+func testRegisterWithBadEmail(t *testing.T, router *gin.Engine) {
+	t.Helper()
+	newAccount := RegisterInput{
+		Username:  "user-" + random.UniqueId(),
+		Password:  "password",
+		Email:     "jane.doe@exemple",
+		Firstname: "Jane",
+		Lastname:  "Doe",
+	}
+
+	jsonData, err := json.Marshal(newAccount)
+	if err != nil {
+		t.Fatalf("Failed to marshal account data: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "/register", bytes.NewBuffer(jsonData))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status code %d but got %d", http.StatusBadRequest, w.Code)
+	}
 }
 
 func testLoginWithInvalidUsername(t *testing.T, router *gin.Engine) {

--- a/pkg/accounts/accounts_test.go
+++ b/pkg/accounts/accounts_test.go
@@ -470,6 +470,43 @@ func TestRegisterKO(t *testing.T) {
 
 	// Define the endpoint for Register handler
 	router.POST("/register", Register)
+	t.Run("Register account with duplicate email", func(t *testing.T) {
+		// Use the email of the first user in the dataset (already exists)
+		newAccount := RegisterInput{
+			Username:  "user-" + random.UniqueId(),
+			Password:  "password",
+			Email:     users[0].Email,
+			Firstname: "Duplicate",
+			Lastname:  "Email",
+		}
+
+		jsonData, err := json.Marshal(newAccount)
+		if err != nil {
+			t.Fatalf("Failed to marshal account data: %v", err)
+		}
+
+		req, err := http.NewRequest(http.MethodPost, "/register", bytes.NewBuffer(jsonData))
+		if err != nil {
+			t.Fatalf("Failed to create request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusConflict {
+			t.Errorf("Expected status code %d but got %d. Body: %s", http.StatusConflict, w.Code, w.Body.String())
+		}
+
+		var response map[string]string
+		if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+		if response["error"] != "email already in use" {
+			t.Errorf("Expected error 'email already in use' but got '%s'", response["error"])
+		}
+	})
+
 	t.Run("Register account with bad email", func(t *testing.T) {
 		// Sample account data
 		newAccount := RegisterInput{

--- a/pkg/accounts/handlers.go
+++ b/pkg/accounts/handlers.go
@@ -22,6 +22,8 @@ import (
 // @Param   input  body    RegisterInput  true  "Register Informations"
 // @Success 200 {object} apitypes.OkResponse
 // @Failure 400 {object} apitypes.ErrorResponse
+// @Failure 409 {object} apitypes.ErrorResponse "Email already in use"
+// @Failure 500 {object} apitypes.ErrorResponse
 // @Router /register [post]
 func Register(c *gin.Context) {
 	var input RegisterInput
@@ -34,6 +36,11 @@ func Register(c *gin.Context) {
 
 	if !helper.IsValidEmail(input.Email) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid email"})
+		return
+	}
+
+	if !helper.IsValidUsername(input.Username) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "username must not contain @"})
 		return
 	}
 
@@ -57,7 +64,7 @@ func Register(c *gin.Context) {
 			return
 		}
 		helper.LogAndSanitize(err, "register: user registration failed")
-		c.JSON(http.StatusBadRequest, gin.H{"error": helper.ErrMsgInternalServer})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
 		return
 	}
 
@@ -457,20 +464,25 @@ func PostAccount(c *gin.Context) {
 		return
 	}
 
-	if helper.IsValidEmail(newAccount.Email) {
-		// Insert the new account into the database.
-		err := insertAccount(c.Request.Context(), &newAccount)
-		if err != nil {
-			helper.LogAndSanitize(err, "post account: insert account failed")
-			c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
-			return
-		}
-
-		c.IndentedJSON(http.StatusCreated, newAccount)
-	} else {
+	if !helper.IsValidEmail(newAccount.Email) {
 		c.IndentedJSON(http.StatusBadRequest, gin.H{"error": "invalid email"})
 		return
 	}
+
+	if !helper.IsValidUsername(newAccount.Username) {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"error": "username must not contain @"})
+		return
+	}
+
+	// Insert the new account into the database.
+	err := insertAccount(c.Request.Context(), &newAccount)
+	if err != nil {
+		helper.LogAndSanitize(err, "post account: insert account failed")
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	c.IndentedJSON(http.StatusCreated, newAccount)
 }
 
 // Update account by ID

--- a/pkg/accounts/handlers.go
+++ b/pkg/accounts/handlers.go
@@ -32,37 +32,41 @@ func Register(c *gin.Context) {
 		return
 	}
 
-	user := User{}
-
-	if helper.IsValidEmail(input.Email) {
-		user.Email = input.Email
-		user.Username = input.Username
-		user.Password = input.Password
-		user.Firstname = input.Firstname
-		user.Lastname = input.Lastname
-		user.Role = "standard"
-		user.Status = "pending"
-		user.CreatedAt = time.Now().Truncate(time.Second)
-		user.UpdatedAt = time.Now().Truncate(time.Second)
-
-		emailSended, err := registerUser(c.Request.Context(), user)
-
-		if err != nil {
-			helper.LogAndSanitize(err, "register: user registration failed")
-			c.JSON(http.StatusBadRequest, gin.H{"error": helper.ErrMsgInternalServer})
-			return
-		}
-
-		if !emailSended {
-			c.JSON(http.StatusAccepted, gin.H{"message": "registration succeed but failed to send confirmation email"})
-			return
-		}
-
-		c.JSON(http.StatusOK, gin.H{"message": "registration succeed, please check your email to confirm your account"})
-	} else {
+	if !helper.IsValidEmail(input.Email) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid email"})
 		return
 	}
+
+	user := User{
+		Email:     input.Email,
+		Username:  input.Username,
+		Password:  input.Password,
+		Firstname: input.Firstname,
+		Lastname:  input.Lastname,
+		Role:      "standard",
+		Status:    "pending",
+		CreatedAt: time.Now().Truncate(time.Second),
+		UpdatedAt: time.Now().Truncate(time.Second),
+	}
+
+	emailSended, err := registerUser(c.Request.Context(), user)
+
+	if err != nil {
+		if errors.Is(err, ErrEmailAlreadyExists) {
+			c.JSON(http.StatusConflict, gin.H{"error": "email already in use"})
+			return
+		}
+		helper.LogAndSanitize(err, "register: user registration failed")
+		c.JSON(http.StatusBadRequest, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	if !emailSended {
+		c.JSON(http.StatusAccepted, gin.H{"message": "registration succeed but failed to send confirmation email"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "registration succeed, please check your email to confirm your account"})
 }
 
 // Confirm email address

--- a/pkg/accounts/handlers.go
+++ b/pkg/accounts/handlers.go
@@ -187,7 +187,8 @@ func ResendConfirmEmail(c *gin.Context) {
 
 // User login
 // @Summary User login
-// @Description Log in a user by providing username and password
+// @Description Log in a user by providing username (or email) and password
+// @Description The username field accepts either a username or an email address
 // @Description Returns access token (short-lived) and refresh token (long-lived)
 // @Description Use remember_me to extend refresh token lifetime
 // @Tags Public

--- a/pkg/database/migration/migration_scripts/000018_account_email_unique.down.sql
+++ b/pkg/database/migration/migration_scripts/000018_account_email_unique.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE account DROP CONSTRAINT IF EXISTS account_email_unique;

--- a/pkg/database/migration/migration_scripts/000018_account_email_unique.up.sql
+++ b/pkg/database/migration/migration_scripts/000018_account_email_unique.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE account ADD CONSTRAINT account_email_unique UNIQUE (email);

--- a/pkg/database/migration/migration_scripts/000019_account_username_no_at.down.sql
+++ b/pkg/database/migration/migration_scripts/000019_account_username_no_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE account DROP CONSTRAINT IF EXISTS account_username_no_at;

--- a/pkg/database/migration/migration_scripts/000019_account_username_no_at.up.sql
+++ b/pkg/database/migration/migration_scripts/000019_account_username_no_at.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE account ADD CONSTRAINT account_username_no_at CHECK (username NOT LIKE '%@%');

--- a/pkg/helper/helper.go
+++ b/pkg/helper/helper.go
@@ -66,6 +66,11 @@ func IsValidEmail(email string) bool {
 	return emailRegex.MatchString(email)
 }
 
+// IsValidUsername checks that a username does not contain '@' to avoid ambiguity with email login.
+func IsValidUsername(username string) bool {
+	return !strings.Contains(username, "@")
+}
+
 // EmailSender defines the interface for sending emails. Needed for testing without real SMTP server.
 type EmailSender interface {
 	SendEmail(to, subject, textBody, htmlBody string) error

--- a/pkg/helper/helper_test.go
+++ b/pkg/helper/helper_test.go
@@ -188,3 +188,28 @@ func TestIsValidEmail(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidUsername(t *testing.T) {
+	testCases := []struct {
+		name     string
+		username string
+		expected bool
+	}{
+		{"simple username", "johndoe", true},
+		{"username with numbers", "john123", true},
+		{"username with hyphens", "john-doe", true},
+		{"username with underscores", "john_doe", true},
+		{"email-like username", "john@example.com", false},
+		{"username with @ in middle", "john@doe", false},
+		{"username starting with @", "@johndoe", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			output := IsValidUsername(tc.username)
+			if output != tc.expected {
+				t.Errorf("IsValidUsername(%s): expected %t, got %t", tc.username, tc.expected, output)
+			}
+		})
+	}
+}

--- a/tests/api-scenarios/007-account-profile-social.yaml
+++ b/tests/api-scenarios/007-account-profile-social.yaml
@@ -51,10 +51,10 @@ scenarios:
         expected: 200
       - type: json_path
         path: "$.youtube_url"
-        equals: "null"
+        equals: "<nil>"
       - type: json_path
         path: "$.instagram_url"
-        equals: "null"
+        equals: "<nil>"
       - type: json_path
         path: "$.has_profile_image"
         equals: "false"
@@ -116,7 +116,7 @@ scenarios:
         expected: 200
       - type: json_path
         path: "$.youtube_url"
-        equals: "null"
+        equals: "<nil>"
       - type: json_path
         path: "$.instagram_url"
         equals: "https://instagram.com/testuser"

--- a/tests/cmd/apitest/internal/client/http.go
+++ b/tests/cmd/apitest/internal/client/http.go
@@ -29,13 +29,13 @@ func New(baseURL string) *HTTPClient {
 	}
 }
 
-// MakeRequest executes an HTTP request and returns the status code and response body
+// MakeRequest executes an HTTP request and returns the status code, response body, and content type
 func (c *HTTPClient) MakeRequest(
 	ctx context.Context,
 	method, endpoint string,
 	headers map[string]string,
 	body map[string]any,
-) (int, []byte, error) {
+) (int, []byte, string, error) {
 	// Build full URL
 	url := c.baseURL + endpoint
 
@@ -44,7 +44,7 @@ func (c *HTTPClient) MakeRequest(
 	if body != nil {
 		bodyBytes, err := json.Marshal(body)
 		if err != nil {
-			return 0, nil, fmt.Errorf("failed to marshal request body: %w", err)
+			return 0, nil, "", fmt.Errorf("failed to marshal request body: %w", err)
 		}
 		bodyReader = bytes.NewReader(bodyBytes)
 	}
@@ -52,7 +52,7 @@ func (c *HTTPClient) MakeRequest(
 	// Create HTTP request
 	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to create request: %w", err)
+		return 0, nil, "", fmt.Errorf("failed to create request: %w", err)
 	}
 
 	// Set default headers
@@ -68,17 +68,17 @@ func (c *HTTPClient) MakeRequest(
 	// Execute request
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to execute request: %w", err)
+		return 0, nil, "", fmt.Errorf("failed to execute request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	// Read response body
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to read response body: %w", err)
+		return 0, nil, "", fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	return resp.StatusCode, respBody, nil
+	return resp.StatusCode, respBody, resp.Header.Get("Content-Type"), nil
 }
 
 // MakeRequestWithFile executes an HTTP request with a file upload
@@ -87,14 +87,14 @@ func (c *HTTPClient) MakeRequestWithFile(
 	method, endpoint string,
 	headers map[string]string,
 	filePath, fieldName string,
-) (int, []byte, error) {
+) (int, []byte, string, error) {
 	// Build full URL
 	url := c.baseURL + endpoint
 
 	// Open the file
 	file, err := os.Open(filePath)
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to open file: %w", err)
+		return 0, nil, "", fmt.Errorf("failed to open file: %w", err)
 	}
 	defer file.Close()
 
@@ -105,23 +105,23 @@ func (c *HTTPClient) MakeRequestWithFile(
 	// Create form file field
 	part, err := writer.CreateFormFile(fieldName, filepath.Base(filePath))
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to create form file: %w", err)
+		return 0, nil, "", fmt.Errorf("failed to create form file: %w", err)
 	}
 
 	// Copy file content to form
 	if _, err := io.Copy(part, file); err != nil {
-		return 0, nil, fmt.Errorf("failed to copy file content: %w", err)
+		return 0, nil, "", fmt.Errorf("failed to copy file content: %w", err)
 	}
 
 	// Close multipart writer to finalize the form
 	if err := writer.Close(); err != nil {
-		return 0, nil, fmt.Errorf("failed to close multipart writer: %w", err)
+		return 0, nil, "", fmt.Errorf("failed to close multipart writer: %w", err)
 	}
 
 	// Create HTTP request
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to create request: %w", err)
+		return 0, nil, "", fmt.Errorf("failed to create request: %w", err)
 	}
 
 	// Set multipart content type
@@ -135,17 +135,17 @@ func (c *HTTPClient) MakeRequestWithFile(
 	// Execute request
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to execute request: %w", err)
+		return 0, nil, "", fmt.Errorf("failed to execute request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	// Read response body
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to read response body: %w", err)
+		return 0, nil, "", fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	return resp.StatusCode, respBody, nil
+	return resp.StatusCode, respBody, resp.Header.Get("Content-Type"), nil
 }
 
 // CheckServer verifies the server is reachable

--- a/tests/cmd/apitest/internal/runner/assertions.go
+++ b/tests/cmd/apitest/internal/runner/assertions.go
@@ -9,15 +9,29 @@ import (
 )
 
 // ValidateAssertion checks if a response matches the assertion criteria
-func ValidateAssertion(assertion Assertion, statusCode int, body []byte) error {
+func ValidateAssertion(assertion Assertion, statusCode int, body []byte, contentType string) error {
 	switch assertion.Type {
 	case "status_code":
 		return validateStatusCode(assertion, statusCode)
 	case "json_path":
 		return validateJSONPath(assertion, body)
+	case "content_type":
+		return validateContentType(assertion, contentType)
 	default:
 		return fmt.Errorf("unknown assertion type: %s", assertion.Type)
 	}
+}
+
+// validateContentType checks the Content-Type response header
+func validateContentType(assertion Assertion, actual string) error {
+	expected, ok := assertion.Expected.(string)
+	if !ok {
+		return fmt.Errorf("content_type expected value must be a string, got %T", assertion.Expected)
+	}
+	if !strings.HasPrefix(actual, expected) {
+		return fmt.Errorf("expected content type '%s', got '%s'", expected, actual)
+	}
+	return nil
 }
 
 // validateStatusCode checks the HTTP status code

--- a/tests/cmd/apitest/internal/runner/runner.go
+++ b/tests/cmd/apitest/internal/runner/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/Angak0k/pimpmypack/tests/cmd/apitest/internal/client"
@@ -12,10 +13,11 @@ import (
 
 // Runner executes test scenarios
 type Runner struct {
-	client    *client.HTTPClient
-	state     *State
-	formatter *output.Formatter
-	verbose   bool
+	client      *client.HTTPClient
+	state       *State
+	formatter   *output.Formatter
+	verbose     bool
+	scenarioDir string
 
 	TotalTests  int
 	PassedTests int
@@ -56,6 +58,7 @@ func (r *Runner) Run(scenarioFile string) error {
 		return fmt.Errorf("failed to load scenario: %w", err)
 	}
 
+	r.scenarioDir = filepath.Dir(scenarioFile)
 	r.formatter.PrintHeader("Scenario: " + scenario.Name)
 
 	startTime := time.Now()
@@ -93,14 +96,30 @@ func (r *Runner) executeStep(step Step) (int, error) {
 	// 1. Substitute variables in request
 	req := r.substituteRequest(step.Request)
 
+	// Convert multipart to File if present
+	if req.File == nil && len(req.Multipart) > 0 {
+		for fieldName, mf := range req.Multipart {
+			filePath := mf.File
+			if !filepath.IsAbs(filePath) {
+				filePath = filepath.Join(r.scenarioDir, filePath)
+			}
+			req.File = &FileUpload{
+				Field: fieldName,
+				Path:  filePath,
+			}
+			break // Only one file upload per request
+		}
+	}
+
 	// 2. Make HTTP request (with file upload if specified)
 	var statusCode int
 	var body []byte
+	var contentType string
 	var err error
 
 	if req.File != nil {
 		// File upload request
-		statusCode, body, err = r.client.MakeRequestWithFile(
+		statusCode, body, contentType, err = r.client.MakeRequestWithFile(
 			ctx,
 			req.Method,
 			req.Endpoint,
@@ -110,7 +129,7 @@ func (r *Runner) executeStep(step Step) (int, error) {
 		)
 	} else {
 		// Regular JSON request
-		statusCode, body, err = r.client.MakeRequest(ctx, req.Method, req.Endpoint, req.Headers, req.Body)
+		statusCode, body, contentType, err = r.client.MakeRequest(ctx, req.Method, req.Endpoint, req.Headers, req.Body)
 	}
 
 	if err != nil {
@@ -121,7 +140,7 @@ func (r *Runner) executeStep(step Step) (int, error) {
 	for _, assertion := range step.Assertions {
 		// Substitute variables in assertion values
 		substitutedAssertion := r.substituteAssertion(assertion)
-		if err := ValidateAssertion(substitutedAssertion, statusCode, body); err != nil {
+		if err := ValidateAssertion(substitutedAssertion, statusCode, body, contentType); err != nil {
 			return statusCode, err
 		}
 	}
@@ -137,11 +156,12 @@ func (r *Runner) executeStep(step Step) (int, error) {
 // substituteRequest replaces variables in a request
 func (r *Runner) substituteRequest(req Request) Request {
 	return Request{
-		Method:   req.Method,
-		Endpoint: r.state.Substitute(req.Endpoint),
-		Headers:  r.state.SubstituteStringMap(req.Headers),
-		Body:     r.state.SubstituteMap(req.Body),
-		File:     req.File, // Preserve file upload info
+		Method:    req.Method,
+		Endpoint:  r.state.Substitute(req.Endpoint),
+		Headers:   r.state.SubstituteStringMap(req.Headers),
+		Body:      r.state.SubstituteMap(req.Body),
+		File:      req.File, // Preserve file upload info
+		Multipart: req.Multipart,
 	}
 }
 

--- a/tests/cmd/apitest/internal/runner/scenario.go
+++ b/tests/cmd/apitest/internal/runner/scenario.go
@@ -23,13 +23,19 @@ type Step struct {
 	Store      map[string]string `yaml:"store"`
 }
 
+// MultipartFile defines a file reference within a multipart upload
+type MultipartFile struct {
+	File string `yaml:"file"`
+}
+
 // Request defines an HTTP request to be made
 type Request struct {
-	Method   string            `yaml:"method"`
-	Endpoint string            `yaml:"endpoint"`
-	Headers  map[string]string `yaml:"headers,omitempty"`
-	Body     map[string]any    `yaml:"body,omitempty"`
-	File     *FileUpload       `yaml:"file,omitempty"`
+	Method    string                    `yaml:"method"`
+	Endpoint  string                    `yaml:"endpoint"`
+	Headers   map[string]string         `yaml:"headers,omitempty"`
+	Body      map[string]any            `yaml:"body,omitempty"`
+	File      *FileUpload               `yaml:"file,omitempty"`
+	Multipart map[string]*MultipartFile `yaml:"multipart,omitempty"`
 }
 
 // FileUpload defines a file to be uploaded


### PR DESCRIPTION
## Summary

- The `POST /api/login` endpoint now accepts either a username or an email address in the `username` field
- Uses a single SQL query with `OR` clause — no ambiguity since usernames cannot contain `@`
- No breaking API change: existing clients continue to work unchanged
- Related to https://github.com/Angak0k/pimpmypack-front/issues/13 (backend part)

## Improvements from PR review

- **Email uniqueness**: added `UNIQUE` constraint on `account.email` (migration 000018) and return `409 Conflict` on duplicate email registration
- **Username `@` safety**: added DB `CHECK` constraint forbidding `@` in usernames (migration 000019), plus application-level validation on both `Register` and admin `PostAccount` handlers
- **Error response consistency**: registration now returns `500` instead of `400` for unexpected server errors
- **Swagger documentation**: added `409` and `500` failure responses on the `/register` endpoint
- **Test robustness**: made error field assertions explicit (fail if field is missing or wrong type)

## Fixes discovered during local API testing

- **Missing route**: `GET /v1/pack-options` was not registered in `main.go` (handler existed but route was missing)
- **API test runner**: added support for `multipart:` YAML syntax in test scenarios (file uploads)
- **API test runner**: added `content_type` assertion type and threaded `Content-Type` header through client → runner → assertions
- **Test fixture**: fixed null value assertion (`<nil>` vs `null`) in profile social URLs scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)