### PR TITLE
fix: sanitize email headers to prevent SMTP injection

### DIFF
--- a/pkg/helper/email_templates.go
+++ b/pkg/helper/email_templates.go
@@ -3,6 +3,7 @@ package helper
 import (
 	"fmt"
 	"html"
+	"strings"
 )
 
 // BuildEmailHTML wraps body content in a branded HTML email layout.
@@ -81,6 +82,13 @@ If the button doesn't work, copy and paste this link into your browser:<br>
 	)
 }
 
+// sanitizeTextContent strips \r and \n to prevent content injection in plain-text emails.
+func sanitizeTextContent(v string) string {
+	v = strings.ReplaceAll(v, "\r", "")
+	v = strings.ReplaceAll(v, "\n", "")
+	return v
+}
+
 // BuildConfirmationEmailText returns the plain-text body for a confirmation email.
 func BuildConfirmationEmailText(username, confirmURL string) string {
 	return fmt.Sprintf(`Welcome, %s!
@@ -92,7 +100,7 @@ Confirm your email:
 
 --
 PimpMyPack - Optimize your pack, enjoy the trail.
-`, username, confirmURL)
+`, sanitizeTextContent(username), confirmURL)
 }
 
 // BuildPasswordResetEmailHTML returns the branded HTML body for a password reset email.

--- a/pkg/helper/email_templates_test.go
+++ b/pkg/helper/email_templates_test.go
@@ -72,6 +72,30 @@ func TestBuildPasswordResetEmailHTML(t *testing.T) {
 	}
 }
 
+func TestBuildConfirmationEmailText_UsernameInjection(t *testing.T) {
+	malicious := "alice\r\n\r\nInjected body content"
+	text := BuildConfirmationEmailText(malicious, "https://example.com/confirm")
+
+	// CRLF must be stripped so the username appears as a single token
+	if strings.Contains(text, "alice\r\n") || strings.Contains(text, "alice\n") {
+		t.Error("username with CRLF was not sanitized in plain-text email")
+	}
+	// After sanitization the username line should read "Welcome, aliceInjected body content!"
+	// (harmless concatenation, no extra lines injected)
+	if !strings.Contains(text, "Welcome, aliceInjected body content!") {
+		t.Error("expected sanitized username to be concatenated without newlines")
+	}
+}
+
+func TestBuildConfirmationEmailHTML_UsernameInjection(t *testing.T) {
+	malicious := "<script>alert('xss')</script>"
+	html := BuildConfirmationEmailHTML(malicious, "https://example.com/confirm")
+
+	if strings.Contains(html, "<script>") {
+		t.Error("HTML body must escape script tags in username")
+	}
+}
+
 func TestBuildPasswordResetEmailText(t *testing.T) {
 	text := BuildPasswordResetEmailText("s3cretP@ss")
 

--- a/pkg/helper/helper.go
+++ b/pkg/helper/helper.go
@@ -122,9 +122,9 @@ func BuildMIMEMessage(
 		"MIME-Version: 1.0\r\n"+
 		"Content-Type: multipart/alternative; boundary=%s\r\n"+
 		"\r\n",
-		fromName, fromAddr,
-		to,
-		subject,
+		sanitizeHeaderValue(fromName), sanitizeHeaderValue(fromAddr),
+		sanitizeHeaderValue(to),
+		sanitizeHeaderValue(subject),
 		time.Now().Format(time.RFC1123Z),
 		messageID,
 		writer.Boundary(),
@@ -166,6 +166,13 @@ func BuildMIMEMessage(
 	msg.Write(buf.Bytes())
 
 	return msg.Bytes(), nil
+}
+
+// sanitizeHeaderValue strips \r and \n characters to prevent SMTP header injection.
+func sanitizeHeaderValue(v string) string {
+	v = strings.ReplaceAll(v, "\r", "")
+	v = strings.ReplaceAll(v, "\n", "")
+	return v
 }
 
 func extractDomain(email string) string {

--- a/pkg/helper/helper_test.go
+++ b/pkg/helper/helper_test.go
@@ -189,6 +189,73 @@ func TestIsValidEmail(t *testing.T) {
 	}
 }
 
+func TestBuildMIMEMessage_HeaderInjection(t *testing.T) {
+	testCases := []struct {
+		name    string
+		to      string
+		subject string
+	}{
+		{
+			"CRLF in To prevents Bcc injection",
+			"victim@example.com\r\nBcc: attacker@evil.com",
+			"Normal Subject",
+		},
+		{
+			"LF in Subject prevents header injection",
+			"user@example.com",
+			"Hello\nBcc: attacker@evil.com",
+		},
+		{
+			"CR in To prevents Bcc injection",
+			"victim@example.com\rBcc: attacker@evil.com",
+			"Normal Subject",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg, err := BuildMIMEMessage(
+				"PimpMyPack", "noreply@pimpmypack.com",
+				tc.to, tc.subject,
+				"text body", "<p>html body</p>",
+			)
+			if err != nil {
+				t.Fatalf("BuildMIMEMessage failed: %v", err)
+			}
+			raw := string(msg)
+			// Verify no injected header line exists: no line should start with "Bcc:"
+			for _, line := range strings.Split(raw, "\n") {
+				trimmed := strings.TrimPrefix(line, "\r")
+				if strings.HasPrefix(trimmed, "Bcc:") {
+					t.Errorf("found injected Bcc header line: %q", line)
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeHeaderValue(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"normal value", "normal value"},
+		{"has\rnewline", "hasnewline"},
+		{"has\nnewline", "hasnewline"},
+		{"has\r\nboth", "hasboth"},
+		{"", ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			got := sanitizeHeaderValue(tc.input)
+			if got != tc.expected {
+				t.Errorf("sanitizeHeaderValue(%q) = %q, want %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+
 func TestIsValidUsername(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
## Summary

- Sanitize `To`, `Subject`, and `From` header fields in `BuildMIMEMessage` by stripping `\r` and `\n` characters to prevent SMTP header injection (CWE-640)
- Sanitize `username` in plain-text confirmation email template to prevent content injection via CRLF
- Add tests verifying that injected `Bcc:` headers, XSS in HTML templates, and CRLF in plain-text bodies are properly neutralized

Fixes https://github.com/Angak0k/pimpmypack/security/code-scanning/7

🤖 Generated with [Claude Code](https://claude.com/claude-code)