### PR TITLE
fix: validate recipient email before passing to smtp.SendMail

### DIFF
--- a/pkg/helper/helper.go
+++ b/pkg/helper/helper.go
@@ -85,6 +85,10 @@ type SMTPClient struct {
 // MailIdentity must be a valid email address (validated at startup) — used as envelope sender and From address.
 // MailUsername is the SMTP authentication login credential.
 func (s *SMTPClient) SendEmail(to, subject, textBody, htmlBody string) error {
+	if !IsValidEmail(to) {
+		return fmt.Errorf("invalid recipient email address: %s", to)
+	}
+
 	auth := smtp.PlainAuth("", s.Server.MailUsername, s.Server.MailPassword, s.Server.MailServer)
 
 	msg, err := BuildMIMEMessage(


### PR DESCRIPTION
## Summary

- Adds `IsValidEmail(to)` check at the top of `SMTPClient.SendEmail` to validate the recipient address before it reaches `smtp.SendMail`
- Resolves CodeQL code-scanning alert [#7](https://github.com/Angak0k/pimpmypack/security/code-scanning/7) (`go/email-injection`) which flagged untainted user input flowing into the SMTP envelope recipient

🤖 Generated with [Claude Code](https://claude.com/claude-code)