### PR TITLE
feat: add List-Unsubscribe headers to improve Gmail deliverability

### DIFF
--- a/pkg/helper/helper.go
+++ b/pkg/helper/helper.go
@@ -123,6 +123,8 @@ func BuildMIMEMessage(
 		"Subject: %s\r\n"+
 		"Date: %s\r\n"+
 		"Message-ID: <%s>\r\n"+
+		"List-Unsubscribe: <mailto:%s?subject=unsubscribe>\r\n"+
+		"List-Unsubscribe-Post: List-Unsubscribe=One-Click\r\n"+
 		"MIME-Version: 1.0\r\n"+
 		"Content-Type: multipart/alternative; boundary=%s\r\n"+
 		"\r\n",
@@ -131,6 +133,7 @@ func BuildMIMEMessage(
 		sanitizeHeaderValue(subject),
 		time.Now().Format(time.RFC1123Z),
 		messageID,
+		sanitizeHeaderValue(fromAddr),
 		writer.Boundary(),
 	)
 

--- a/pkg/helper/helper_test.go
+++ b/pkg/helper/helper_test.go
@@ -124,6 +124,8 @@ func TestBuildMIMEMessage(t *testing.T) {
 		{"Message-ID header", "Message-ID: <"},
 		{"MIME-Version", "MIME-Version: 1.0"},
 		{"multipart boundary", "Content-Type: multipart/alternative; boundary="},
+		{"List-Unsubscribe header", "List-Unsubscribe: <mailto:noreply@pimpmypack.com?subject=unsubscribe>"},
+		{"List-Unsubscribe-Post header", "List-Unsubscribe-Post: List-Unsubscribe=One-Click"},
 		{"text/plain part", "Content-Type: text/plain; charset=utf-8"},
 		{"text/html part", "Content-Type: text/html; charset=utf-8"},
 		{"text body", "Plain text body"},


### PR DESCRIPTION
## Summary

- Adds `List-Unsubscribe` and `List-Unsubscribe-Post` headers to all outgoing emails
- Gmail requires these headers to avoid spam-classifying messages and to surface the one-click unsubscribe button in its UI
- Uses the sender address (`MAIL_IDENTITY`) as the mailto unsubscribe target

🤖 Generated with [Claude Code](https://claude.com/claude-code)