### PR TITLE
feat: import pack from PimpMyPack sharing URL

### DIFF
--- a/api-doc/docs.go
+++ b/api-doc/docs.go
@@ -411,7 +411,7 @@ const docTemplate = `{
                     "200": {
                         "description": "CSV data imported successfully with pack ID",
                         "schema": {
-                            "$ref": "#/definitions/packs.ImportLighterPackResponse"
+                            "$ref": "#/definitions/packs.ImportExternalPackResponse"
                         }
                     },
                     "400": {
@@ -468,7 +468,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/packs.ImportLighterPackResponse"
+                            "$ref": "#/definitions/packs.ImportExternalPackResponse"
                         }
                     },
                     "400": {
@@ -485,6 +485,63 @@ const docTemplate = `{
                     },
                     "502": {
                         "description": "Failed to fetch page",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/importfrompimpmypackurl": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Import items from a PimpMyPack sharing URL into a new pack",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packs"
+                ],
+                "summary": "Import a pack from a PimpMyPack sharing URL",
+                "parameters": [
+                    {
+                        "description": "PimpMyPack URL",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/packs.ImportFromURLRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/packs.ImportExternalPackResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid URL",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Shared pack not found",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/apitypes.ErrorResponse"
                         }
@@ -2643,6 +2700,17 @@ const docTemplate = `{
                 }
             }
         },
+        "packs.ImportExternalPackResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "pack_id": {
+                    "type": "integer"
+                }
+            }
+        },
         "packs.ImportFromURLRequest": {
             "type": "object",
             "required": [
@@ -2651,17 +2719,6 @@ const docTemplate = `{
             "properties": {
                 "url": {
                     "type": "string"
-                }
-            }
-        },
-        "packs.ImportLighterPackResponse": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string"
-                },
-                "pack_id": {
-                    "type": "integer"
                 }
             }
         },

--- a/api-doc/swagger.json
+++ b/api-doc/swagger.json
@@ -408,7 +408,7 @@
                     "200": {
                         "description": "CSV data imported successfully with pack ID",
                         "schema": {
-                            "$ref": "#/definitions/packs.ImportLighterPackResponse"
+                            "$ref": "#/definitions/packs.ImportExternalPackResponse"
                         }
                     },
                     "400": {
@@ -465,7 +465,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/packs.ImportLighterPackResponse"
+                            "$ref": "#/definitions/packs.ImportExternalPackResponse"
                         }
                     },
                     "400": {
@@ -482,6 +482,63 @@
                     },
                     "502": {
                         "description": "Failed to fetch page",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/importfrompimpmypackurl": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Import items from a PimpMyPack sharing URL into a new pack",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packs"
+                ],
+                "summary": "Import a pack from a PimpMyPack sharing URL",
+                "parameters": [
+                    {
+                        "description": "PimpMyPack URL",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/packs.ImportFromURLRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/packs.ImportExternalPackResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid URL",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Shared pack not found",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/apitypes.ErrorResponse"
                         }
@@ -2640,6 +2697,17 @@
                 }
             }
         },
+        "packs.ImportExternalPackResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "pack_id": {
+                    "type": "integer"
+                }
+            }
+        },
         "packs.ImportFromURLRequest": {
             "type": "object",
             "required": [
@@ -2648,17 +2716,6 @@
             "properties": {
                 "url": {
                     "type": "string"
-                }
-            }
-        },
-        "packs.ImportLighterPackResponse": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string"
-                },
-                "pack_id": {
-                    "type": "integer"
                 }
             }
         },

--- a/api-doc/swagger.yaml
+++ b/api-doc/swagger.yaml
@@ -185,19 +185,19 @@ definitions:
     - category
     - item_name
     type: object
+  packs.ImportExternalPackResponse:
+    properties:
+      message:
+        type: string
+      pack_id:
+        type: integer
+    type: object
   packs.ImportFromURLRequest:
     properties:
       url:
         type: string
     required:
     - url
-    type: object
-  packs.ImportLighterPackResponse:
-    properties:
-      message:
-        type: string
-      pack_id:
-        type: integer
     type: object
   packs.Pack:
     properties:
@@ -663,7 +663,7 @@ paths:
         "200":
           description: CSV data imported successfully with pack ID
           schema:
-            $ref: '#/definitions/packs.ImportLighterPackResponse'
+            $ref: '#/definitions/packs.ImportExternalPackResponse'
         "400":
           description: Invalid CSV format
           schema:
@@ -699,7 +699,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/packs.ImportLighterPackResponse'
+            $ref: '#/definitions/packs.ImportExternalPackResponse'
         "400":
           description: Invalid URL
           schema:
@@ -715,6 +715,42 @@ paths:
       security:
       - Bearer: []
       summary: Import a pack from a LighterPack sharing URL
+      tags:
+      - Packs
+  /v1/importfrompimpmypackurl:
+    post:
+      consumes:
+      - application/json
+      description: Import items from a PimpMyPack sharing URL into a new pack
+      parameters:
+      - description: PimpMyPack URL
+        in: body
+        name: input
+        required: true
+        schema:
+          $ref: '#/definitions/packs.ImportFromURLRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/packs.ImportExternalPackResponse'
+        "400":
+          description: Invalid URL
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "404":
+          description: Shared pack not found
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+      security:
+      - Bearer: []
+      summary: Import a pack from a PimpMyPack sharing URL
       tags:
       - Packs
   /v1/myaccount:

--- a/main.go
+++ b/main.go
@@ -155,6 +155,7 @@ func setupProtectedRoutes(router *gin.Engine) {
 	protected.GET("/pack-options", packs.GetPackOptions)
 	protected.POST("/importfromlighterpack", packs.ImportFromLighterPack)
 	protected.POST("/importfromlighterpackurl", packs.ImportFromLighterPackURL)
+	protected.POST("/importfrompimpmypackurl", packs.ImportFromPimpMyPackURL)
 	protected.POST("/mypack/:id/image", images.UploadPackImage)
 	protected.DELETE("/mypack/:id/image", images.DeletePackImage)
 	protected.POST("/myaccount/image", images.UploadMyProfileImage)

--- a/pkg/packs/handlers.go
+++ b/pkg/packs/handlers.go
@@ -1183,7 +1183,7 @@ func packAction(c *gin.Context, actionName string,
 // @Failure 500 {object} apitypes.ErrorResponse "Internal Server Error"
 // @Router /v1/importfromlighterpack [post]
 func ImportFromLighterPack(c *gin.Context) {
-	var lighterPack ExternalPack
+	var externalPack ExternalPack
 
 	userID, err := security.ExtractTokenID(c)
 	if err != nil {
@@ -1217,7 +1217,7 @@ func ImportFromLighterPack(c *gin.Context) {
 
 	// Iterate through CSV records and process them
 	for {
-		var lighterPackItem ExternalPackItem
+		var packItem ExternalPackItem
 		record, err := reader.Read()
 		if errors.Is(err, io.EOF) {
 			break
@@ -1234,19 +1234,19 @@ func ImportFromLighterPack(c *gin.Context) {
 			return
 		}
 
-		lighterPackItem, err = readLineFromCSV(record)
+		packItem, err = readLineFromCSV(record)
 		if err != nil {
 			helper.LogAndSanitize(err, "import from lighterpack: read line from CSV failed")
 			c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
 			return
 		}
 
-		lighterPack = append(lighterPack, lighterPackItem)
+		externalPack = append(externalPack, packItem)
 	}
 
 	// Perform database insertion
 	packID, err := insertExternalPack(
-		c.Request.Context(), &lighterPack, userID, "LighterPack Import", "LighterPack Import")
+		c.Request.Context(), &externalPack, userID, "LighterPack Import", "LighterPack Import")
 	if err != nil {
 		helper.LogAndSanitize(err, "import from lighterpack: insert lighterpack failed")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
@@ -1362,6 +1362,11 @@ func ImportFromPimpMyPackURL(c *gin.Context) {
 		}
 		helper.LogAndSanitize(err, "import from pimpmypack url: return shared pack failed")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	if len(sharedPack.Contents) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "shared pack has no items"})
 		return
 	}
 

--- a/pkg/packs/handlers.go
+++ b/pkg/packs/handlers.go
@@ -1177,13 +1177,13 @@ func packAction(c *gin.Context, actionName string,
 // @Accept  multipart/form-data
 // @Produce  json
 // @Param file formData file true "CSV file"
-// @Success 200 {object} ImportLighterPackResponse "CSV data imported successfully with pack ID"
+// @Success 200 {object} ImportExternalPackResponse "CSV data imported successfully with pack ID"
 // @Failure 400 {object} apitypes.ErrorResponse "Invalid CSV format"
 // @Failure 401 {object} apitypes.ErrorResponse "Unauthorized"
 // @Failure 500 {object} apitypes.ErrorResponse "Internal Server Error"
 // @Router /v1/importfromlighterpack [post]
 func ImportFromLighterPack(c *gin.Context) {
-	var lighterPack LighterPack
+	var lighterPack ExternalPack
 
 	userID, err := security.ExtractTokenID(c)
 	if err != nil {
@@ -1217,7 +1217,7 @@ func ImportFromLighterPack(c *gin.Context) {
 
 	// Iterate through CSV records and process them
 	for {
-		var lighterPackItem LighterPackItem
+		var lighterPackItem ExternalPackItem
 		record, err := reader.Read()
 		if errors.Is(err, io.EOF) {
 			break
@@ -1245,7 +1245,8 @@ func ImportFromLighterPack(c *gin.Context) {
 	}
 
 	// Perform database insertion
-	packID, err := insertLighterPack(c.Request.Context(), &lighterPack, userID, "LighterPack Import", "LighterPack Import")
+	packID, err := insertExternalPack(
+		c.Request.Context(), &lighterPack, userID, "LighterPack Import", "LighterPack Import")
 	if err != nil {
 		helper.LogAndSanitize(err, "import from lighterpack: insert lighterpack failed")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
@@ -1265,7 +1266,7 @@ func ImportFromLighterPack(c *gin.Context) {
 // @Produce json
 // @Security Bearer
 // @Param input body ImportFromURLRequest true "LighterPack URL"
-// @Success 200 {object} ImportLighterPackResponse
+// @Success 200 {object} ImportExternalPackResponse
 // @Failure 400 {object} apitypes.ErrorResponse "Invalid URL"
 // @Failure 422 {object} apitypes.ErrorResponse "Failed to parse page"
 // @Failure 502 {object} apitypes.ErrorResponse "Failed to fetch page"
@@ -1305,7 +1306,7 @@ func ImportFromLighterPackURL(c *gin.Context) {
 		return
 	}
 
-	packID, err := insertLighterPack(c.Request.Context(), &items, userID, packName, packDescription)
+	packID, err := insertExternalPack(c.Request.Context(), &items, userID, packName, packDescription)
 	if err != nil {
 		helper.LogAndSanitize(err, "import from lighterpack url: insert lighterpack failed")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
@@ -1314,6 +1315,70 @@ func ImportFromLighterPackURL(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"message": "LighterPack URL imported successfully",
+		"pack_id": packID,
+	})
+}
+
+// Import from PimpMyPack URL
+// @Summary Import a pack from a PimpMyPack sharing URL
+// @Description Import items from a PimpMyPack sharing URL into a new pack
+// @Tags Packs
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param input body ImportFromURLRequest true "PimpMyPack URL"
+// @Success 200 {object} ImportExternalPackResponse
+// @Failure 400 {object} apitypes.ErrorResponse "Invalid URL"
+// @Failure 404 {object} apitypes.ErrorResponse "Shared pack not found"
+// @Failure 500 {object} apitypes.ErrorResponse "Internal Server Error"
+// @Router /v1/importfrompimpmypackurl [post]
+func ImportFromPimpMyPackURL(c *gin.Context) {
+	var input ImportFromURLRequest
+
+	userID, err := security.ExtractTokenID(c)
+	if err != nil {
+		helper.LogAndSanitize(err, "import from pimpmypack url: extract token ID failed")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": helper.ErrMsgUnauthorized})
+		return
+	}
+
+	if err := c.ShouldBindJSON(&input); err != nil {
+		helper.LogAndSanitize(err, "import from pimpmypack url: bind json failed")
+		c.JSON(http.StatusBadRequest, gin.H{"error": helper.ErrMsgBadRequest})
+		return
+	}
+
+	sharingCode, err := validatePimpMyPackURL(input.URL)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	sharedPack, err := returnSharedPack(c.Request.Context(), sharingCode)
+	if err != nil {
+		if errors.Is(err, ErrPackNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "shared pack not found"})
+			return
+		}
+		helper.LogAndSanitize(err, "import from pimpmypack url: return shared pack failed")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	items := convertSharedPackToExternalPack(sharedPack)
+
+	packID, err := insertExternalPack(
+		c.Request.Context(), items, userID,
+		sharedPack.Pack.PackName, sharedPack.Pack.PackDescription,
+	)
+	if err != nil {
+		helper.LogAndSanitize(err, "import from pimpmypack url: insert external pack failed")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "PimpMyPack URL imported successfully",
 		"pack_id": packID,
 	})
 }

--- a/pkg/packs/lighterpack.go
+++ b/pkg/packs/lighterpack.go
@@ -68,7 +68,7 @@ func fetchLighterPackPage(ctx context.Context, rawURL string) ([]byte, error) {
 }
 
 // parseLighterPackHTML parses a LighterPack HTML page and extracts pack data.
-func parseLighterPackHTML(data []byte) (string, string, LighterPack, error) {
+func parseLighterPackHTML(data []byte) (string, string, ExternalPack, error) {
 	doc, err := xhtml.Parse(bytes.NewReader(data))
 	if err != nil {
 		return "", "", nil, fmt.Errorf("failed to parse HTML: %w", err)
@@ -95,7 +95,7 @@ func parseLighterPackHTML(data []byte) (string, string, LighterPack, error) {
 	}
 
 	// Extract items by category
-	var items LighterPack
+	var items ExternalPack
 	categoryNodes := findNodesByClass(doc, "li", "lpCategory")
 
 	for _, catNode := range categoryNodes {
@@ -122,8 +122,8 @@ func parseLighterPackHTML(data []byte) (string, string, LighterPack, error) {
 }
 
 // parseLighterPackItem extracts a single item from an li.lpItem node.
-func parseLighterPackItem(node *xhtml.Node, category string) LighterPackItem {
-	item := LighterPackItem{
+func parseLighterPackItem(node *xhtml.Node, category string) ExternalPackItem {
+	item := ExternalPackItem{
 		Category: category,
 		Qty:      1,
 		Currency: "EUR", // default
@@ -140,7 +140,7 @@ func parseLighterPackItem(node *xhtml.Node, category string) LighterPackItem {
 	return item
 }
 
-func extractItemName(node *xhtml.Node, item *LighterPackItem) {
+func extractItemName(node *xhtml.Node, item *ExternalPackItem) {
 	nameNodes := findNodesByClass(node, "span", "lpName")
 	if len(nameNodes) > 0 {
 		item.URL = extractItemURL(nameNodes[0])
@@ -148,14 +148,14 @@ func extractItemName(node *xhtml.Node, item *LighterPackItem) {
 	}
 }
 
-func extractItemDescription(node *xhtml.Node, item *LighterPackItem) {
+func extractItemDescription(node *xhtml.Node, item *ExternalPackItem) {
 	descNodes := findNodesByClass(node, "span", "lpDescription")
 	if len(descNodes) > 0 {
 		item.Desc = strings.TrimSpace(textContent(descNodes[0]))
 	}
 }
 
-func extractItemWeight(node *xhtml.Node, item *LighterPackItem) {
+func extractItemWeight(node *xhtml.Node, item *ExternalPackItem) {
 	mgNodes := findNodesByClass(node, "input", "lpMG")
 	if len(mgNodes) > 0 {
 		valStr := getAttr(mgNodes[0], "value")
@@ -165,7 +165,7 @@ func extractItemWeight(node *xhtml.Node, item *LighterPackItem) {
 	}
 }
 
-func extractItemPrice(node *xhtml.Node, item *LighterPackItem) {
+func extractItemPrice(node *xhtml.Node, item *ExternalPackItem) {
 	priceNodes := findNodesByClass(node, "span", "lpPriceCell")
 	for _, pn := range priceNodes {
 		if hasClass(pn, "lpNumber") {
@@ -180,7 +180,7 @@ func extractItemPrice(node *xhtml.Node, item *LighterPackItem) {
 	}
 }
 
-func extractItemQuantity(node *xhtml.Node, item *LighterPackItem) {
+func extractItemQuantity(node *xhtml.Node, item *ExternalPackItem) {
 	qtyNodes := findNodesByClass(node, "span", "lpQtyCell")
 	if len(qtyNodes) > 0 {
 		qtyText := strings.TrimSpace(textContent(qtyNodes[0]))

--- a/pkg/packs/packs_test.go
+++ b/pkg/packs/packs_test.go
@@ -941,7 +941,7 @@ item2,category2,description2,2,150,g,http://example2.com,20,,consumable`
 func verifyImportResponse(t *testing.T, responseBody []byte) {
 	t.Helper()
 
-	var response ImportLighterPackResponse
+	var response ImportExternalPackResponse
 	if err := json.Unmarshal(responseBody, &response); err != nil {
 		t.Fatalf("Failed to parse response JSON: %v", err)
 	}

--- a/pkg/packs/pimpmypack_import.go
+++ b/pkg/packs/pimpmypack_import.go
@@ -1,0 +1,42 @@
+package packs
+
+import (
+	"errors"
+	"regexp"
+)
+
+var pimpMyPackURLPattern = regexp.MustCompile(
+	`^https://app\.alki\.earth/(?:sharedlist|api/sharedlist)/([BILMPTaceghikmnprsty]{30})$`,
+)
+
+// validatePimpMyPackURL checks that the URL is a valid PimpMyPack sharing URL
+// and returns the sharing code.
+func validatePimpMyPackURL(rawURL string) (string, error) {
+	matches := pimpMyPackURLPattern.FindStringSubmatch(rawURL)
+	if matches == nil {
+		return "", errors.New("invalid PimpMyPack URL: must match https://app.alki.earth/sharedlist/<code>")
+	}
+	return matches[1], nil
+}
+
+// convertSharedPackToExternalPack converts a SharedPackResponse into an ExternalPack
+// for insertion via the shared insertExternalPack function.
+func convertSharedPackToExternalPack(resp *SharedPackResponse) *ExternalPack {
+	items := make(ExternalPack, 0, len(resp.Contents))
+	for _, c := range resp.Contents {
+		items = append(items, ExternalPackItem{
+			ItemName:   c.ItemName,
+			Category:   c.Category,
+			Desc:       c.ItemDescription,
+			Qty:        c.Quantity,
+			Weight:     c.Weight,
+			Unit:       "gram",
+			URL:        c.ItemURL,
+			Price:      c.Price,
+			Currency:   c.Currency,
+			Worn:       c.Worn,
+			Consumable: c.Consumable,
+		})
+	}
+	return &items
+}

--- a/pkg/packs/pimpmypack_import_test.go
+++ b/pkg/packs/pimpmypack_import_test.go
@@ -15,16 +15,16 @@ func TestValidatePimpMyPackURL(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name:     "valid sharedlist URL",
+			name:     "short code - 28 chars",
 			url:      "https://app.alki.earth/sharedlist/pimpMyPackIsBetterThanLighte",
 			wantCode: "pimpMyPackIsBetterThanLighte",
 			wantErr:  true, // only 28 chars
 		},
 		{
-			name:     "valid 30-char code",
+			name:     "short code - 27 chars",
 			url:      "https://app.alki.earth/sharedlist/pimpMyPackIsBetterThanLight",
 			wantCode: "pimpMyPackIsBetterThanLight",
-			wantErr:  true, // only 26 chars
+			wantErr:  true, // only 27 chars
 		},
 		{
 			name:     "wrong domain",

--- a/pkg/packs/pimpmypack_import_test.go
+++ b/pkg/packs/pimpmypack_import_test.go
@@ -1,0 +1,199 @@
+package packs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatePimpMyPackURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		wantCode string
+		wantErr  bool
+	}{
+		{
+			name:     "valid sharedlist URL",
+			url:      "https://app.alki.earth/sharedlist/pimpMyPackIsBetterThanLighte",
+			wantCode: "pimpMyPackIsBetterThanLighte",
+			wantErr:  true, // only 28 chars
+		},
+		{
+			name:     "valid 30-char code",
+			url:      "https://app.alki.earth/sharedlist/pimpMyPackIsBetterThanLight",
+			wantCode: "pimpMyPackIsBetterThanLight",
+			wantErr:  true, // only 26 chars
+		},
+		{
+			name:     "wrong domain",
+			url:      "https://evil.com/sharedlist/pimpMyPackIsBetterThanLighterPac",
+			wantCode: "",
+			wantErr:  true,
+		},
+		{
+			name:     "HTTP not HTTPS",
+			url:      "http://app.alki.earth/sharedlist/pimpMyPackIsBetterThanLighterPac",
+			wantCode: "",
+			wantErr:  true,
+		},
+		{
+			name:     "wrong path",
+			url:      "https://app.alki.earth/other/pimpMyPackIsBetterThanLighterPac",
+			wantCode: "",
+			wantErr:  true,
+		},
+		{
+			name:     "empty string",
+			url:      "",
+			wantCode: "",
+			wantErr:  true,
+		},
+		{
+			name:     "extra path segment",
+			url:      "https://app.alki.earth/sharedlist/pimpMyPackIsBetterThanLighterPac/extra",
+			wantCode: "",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid characters in code",
+			url:      "https://app.alki.earth/sharedlist/123456789012345678901234567890",
+			wantCode: "",
+			wantErr:  true,
+		},
+	}
+
+	// Valid 30-char code from the charset (unique chars: BILMPTaceghikmnprsty)
+	validCode := "pimpMyPackIsBetterThanLighterP"
+	validURL := "https://app.alki.earth/sharedlist/" + validCode
+	tests = append(tests, struct {
+		name     string
+		url      string
+		wantCode string
+		wantErr  bool
+	}{
+		name:     "valid sharedlist URL with 30-char code",
+		url:      validURL,
+		wantCode: validCode,
+		wantErr:  false,
+	})
+
+	// API variant
+	apiURL := "https://app.alki.earth/api/sharedlist/" + validCode
+	tests = append(tests, struct {
+		name     string
+		url      string
+		wantCode string
+		wantErr  bool
+	}{
+		name:     "valid API sharedlist URL",
+		url:      apiURL,
+		wantCode: validCode,
+		wantErr:  false,
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, err := validatePimpMyPackURL(tt.url)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Empty(t, code)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantCode, code)
+			}
+		})
+	}
+}
+
+func TestConvertSharedPackToExternalPack(t *testing.T) {
+	resp := &SharedPackResponse{
+		Pack: SharedPackInfo{
+			ID:              1,
+			PackName:        "Test Pack",
+			PackDescription: "A test pack",
+		},
+		Contents: PackContentWithItems{
+			{
+				ItemName:        "Tent",
+				Category:        "Shelter",
+				ItemDescription: "Lightweight tent",
+				Quantity:        1,
+				Weight:          1200,
+				ItemURL:         "https://example.com/tent",
+				Price:           35000,
+				Currency:        "EUR",
+				Worn:            false,
+				Consumable:      false,
+			},
+			{
+				ItemName:        "Rain Jacket",
+				Category:        "Clothing",
+				ItemDescription: "Waterproof",
+				Quantity:        1,
+				Weight:          250,
+				ItemURL:         "",
+				Price:           15000,
+				Currency:        "EUR",
+				Worn:            true,
+				Consumable:      false,
+			},
+			{
+				ItemName:        "Trail Mix",
+				Category:        "Food",
+				ItemDescription: "Snack",
+				Quantity:        3,
+				Weight:          100,
+				ItemURL:         "",
+				Price:           500,
+				Currency:        "USD",
+				Worn:            false,
+				Consumable:      true,
+			},
+		},
+	}
+
+	result := convertSharedPackToExternalPack(resp)
+	require.NotNil(t, result)
+	require.Len(t, *result, 3)
+
+	items := *result
+
+	// First item
+	assert.Equal(t, "Tent", items[0].ItemName)
+	assert.Equal(t, "Shelter", items[0].Category)
+	assert.Equal(t, "Lightweight tent", items[0].Desc)
+	assert.Equal(t, 1, items[0].Qty)
+	assert.Equal(t, 1200, items[0].Weight)
+	assert.Equal(t, "gram", items[0].Unit)
+	assert.Equal(t, "https://example.com/tent", items[0].URL)
+	assert.Equal(t, 35000, items[0].Price)
+	assert.Equal(t, "EUR", items[0].Currency)
+	assert.False(t, items[0].Worn)
+	assert.False(t, items[0].Consumable)
+
+	// Second item - worn
+	assert.Equal(t, "Rain Jacket", items[1].ItemName)
+	assert.True(t, items[1].Worn)
+	assert.False(t, items[1].Consumable)
+	assert.Equal(t, "gram", items[1].Unit)
+
+	// Third item - consumable
+	assert.Equal(t, "Trail Mix", items[2].ItemName)
+	assert.Equal(t, 3, items[2].Qty)
+	assert.False(t, items[2].Worn)
+	assert.True(t, items[2].Consumable)
+	assert.Equal(t, "USD", items[2].Currency)
+}
+
+func TestConvertSharedPackToExternalPack_Empty(t *testing.T) {
+	resp := &SharedPackResponse{
+		Pack:     SharedPackInfo{PackName: "Empty Pack"},
+		Contents: PackContentWithItems{},
+	}
+
+	result := convertSharedPackToExternalPack(resp)
+	require.NotNil(t, result)
+	assert.Empty(t, *result)
+}

--- a/pkg/packs/repository.go
+++ b/pkg/packs/repository.go
@@ -686,44 +686,44 @@ func deletePackContentByID(ctx context.Context, id uint) error {
 
 // readLineFromCSV takes a record from csv.NewReader and returns an ExternalPackItem
 func readLineFromCSV(record []string) (ExternalPackItem, error) {
-	var lighterPackItem ExternalPackItem
+	var item ExternalPackItem
 
-	lighterPackItem.ItemName = record[0]
-	lighterPackItem.Category = record[1]
-	lighterPackItem.Desc = record[2]
-	lighterPackItem.Unit = record[5]
-	lighterPackItem.URL = record[6]
+	item.ItemName = record[0]
+	item.Category = record[1]
+	item.Desc = record[2]
+	item.Unit = record[5]
+	item.URL = record[6]
 
 	qty, err := strconv.Atoi(record[3])
 	if err != nil {
-		return lighterPackItem, errors.New("invalid CSV format - failed to convert qty to number")
+		return item, errors.New("invalid CSV format - failed to convert qty to number")
 	}
 
-	lighterPackItem.Qty = qty
+	item.Qty = qty
 
 	weightRaw, err := strconv.ParseFloat(record[4], 64)
 	if err != nil {
-		return lighterPackItem, errors.New("invalid CSV format - failed to convert weight to number")
+		return item, errors.New("invalid CSV format - failed to convert weight to number")
 	}
 
-	lighterPackItem.Weight = int(math.Round(helper.ConvertToGrams(weightRaw, record[5])))
+	item.Weight = int(math.Round(helper.ConvertToGrams(weightRaw, record[5])))
 
 	price, err := strconv.Atoi(record[7])
 	if err != nil {
-		return lighterPackItem, errors.New("invalid CSV format - failed to convert price to number")
+		return item, errors.New("invalid CSV format - failed to convert price to number")
 	}
 
-	lighterPackItem.Price = price
+	item.Price = price
 
 	if record[8] == "Worn" {
-		lighterPackItem.Worn = true
+		item.Worn = true
 	}
 
 	if record[9] == "Consumable" {
-		lighterPackItem.Consumable = true
+		item.Consumable = true
 	}
 
-	return lighterPackItem, nil
+	return item, nil
 }
 
 func insertExternalPack(

--- a/pkg/packs/repository.go
+++ b/pkg/packs/repository.go
@@ -684,9 +684,9 @@ func deletePackContentByID(ctx context.Context, id uint) error {
 
 // Import/CSV
 
-// readLineFromCSV takes a record from csv.NewReader and returns a LighterPackItem
-func readLineFromCSV(record []string) (LighterPackItem, error) {
-	var lighterPackItem LighterPackItem
+// readLineFromCSV takes a record from csv.NewReader and returns an ExternalPackItem
+func readLineFromCSV(record []string) (ExternalPackItem, error) {
+	var lighterPackItem ExternalPackItem
 
 	lighterPackItem.ItemName = record[0]
 	lighterPackItem.Category = record[1]
@@ -726,8 +726,8 @@ func readLineFromCSV(record []string) (LighterPackItem, error) {
 	return lighterPackItem, nil
 }
 
-func insertLighterPack(
-	ctx context.Context, lp *LighterPack, userID uint, packName, packDescription string,
+func insertExternalPack(
+	ctx context.Context, lp *ExternalPack, userID uint, packName, packDescription string,
 ) (uint, error) {
 	if lp == nil || len(*lp) == 0 {
 		return 0, errors.New("payload is empty")

--- a/pkg/packs/types.go
+++ b/pkg/packs/types.go
@@ -146,8 +146,8 @@ type PackContentUpdateRequest struct {
 	Consumable bool `json:"consumable"`
 }
 
-// LighterPackItem represents an item imported from LighterPack format
-type LighterPackItem struct {
+// ExternalPackItem represents an item imported from an external source (LighterPack, PimpMyPack, etc.)
+type ExternalPackItem struct {
 	ItemName   string `json:"item_name"`
 	Category   string `json:"category"`
 	Desc       string `json:"desc"`
@@ -166,11 +166,11 @@ type ImportFromURLRequest struct {
 	URL string `json:"url" binding:"required"`
 }
 
-// LighterPack represents a collection of LighterPack items
-type LighterPack []LighterPackItem
+// ExternalPack represents a collection of external pack items
+type ExternalPack []ExternalPackItem
 
-// ImportLighterPackResponse represents the response when importing from LighterPack
-type ImportLighterPackResponse struct {
+// ImportExternalPackResponse represents the response when importing from an external source
+type ImportExternalPackResponse struct {
 	Message string `json:"message"`
 	PackID  uint   `json:"pack_id"`
 }

--- a/specs/007_lighterpack-url-import.md
+++ b/specs/007_lighterpack-url-import.md
@@ -1,6 +1,6 @@
 # LighterPack URL Import - Specification
 
-**Status**: Implemented
+**Status**: Merged
 **Author**: Claude Agent
 **Date**: 2026-03-05
 **GitHub Issue**: [#185](https://github.com/Angak0k/pimpmypack/issues/185)


### PR DESCRIPTION
## Summary

- Rename LighterPack-specific types (`LighterPackItem`, `LighterPack`, `insertLighterPack`) to generic names (`ExternalPackItem`, `ExternalPack`, `insertExternalPack`) shared across import sources
- Add `POST /api/v1/importfrompimpmypackurl` endpoint to import a pack from a PimpMyPack sharing URL (`app.alki.earth/sharedlist/<code>`)
- No external HTTP calls needed — sharing code is validated via regex and pack data is fetched directly from the database

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)