### PR TITLE
fix: import URL parsing for PimpMyPack and LighterPack

### DIFF
--- a/pkg/packs/lighterpack.go
+++ b/pkg/packs/lighterpack.go
@@ -84,11 +84,11 @@ func parseLighterPackHTML(data []byte) (string, string, ExternalPack, error) {
 		}
 	}
 
-	// Extract pack description from span.lpListDescription
+	// Extract pack description from div#lpListDescription
 	packDescription := packName
-	descNodes := findNodesByClass(doc, "span", "lpListDescription")
-	if len(descNodes) > 0 {
-		desc := strings.TrimSpace(textContent(descNodes[0]))
+	descNode := findNodeByID(doc, "lpListDescription")
+	if descNode != nil {
+		desc := strings.TrimSpace(textContent(descNode))
 		if desc != "" {
 			packDescription = desc
 		}
@@ -279,6 +279,29 @@ func textContent(node *xhtml.Node) string {
 		sb.WriteString(textContent(child))
 	}
 	return sb.String()
+}
+
+// findNodeByID finds the first descendant element with the given id attribute.
+func findNodeByID(node *xhtml.Node, id string) *xhtml.Node {
+	if node == nil {
+		return nil
+	}
+	var result *xhtml.Node
+	var walk func(*xhtml.Node)
+	walk = func(n *xhtml.Node) {
+		if result != nil {
+			return
+		}
+		if n.Type == xhtml.ElementNode && getAttr(n, "id") == id {
+			result = n
+			return
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(node)
+	return result
 }
 
 // findNodesByClass finds all descendant elements matching the given tag and class.

--- a/pkg/packs/pimpmypack_import.go
+++ b/pkg/packs/pimpmypack_import.go
@@ -39,7 +39,10 @@ func validatePimpMyPackURL(rawURL string) (string, error) {
 		}
 	}
 
-	return "", errors.New("invalid PimpMyPack URL: must match https://app.alki.earth/sharedlist/<code> or https://app.alki.earth/public-pack.html?code=<code>")
+	return "", errors.New(
+		"invalid PimpMyPack URL: must match https://app.alki.earth/sharedlist/<code>" +
+			" or https://app.alki.earth/public-pack.html?code=<code>",
+	)
 }
 
 // convertSharedPackToExternalPack converts a SharedPackResponse into an ExternalPack

--- a/pkg/packs/pimpmypack_import.go
+++ b/pkg/packs/pimpmypack_import.go
@@ -2,21 +2,44 @@ package packs
 
 import (
 	"errors"
+	"net/url"
 	"regexp"
 )
 
-var pimpMyPackURLPattern = regexp.MustCompile(
-	`^https://app\.alki\.earth/(?:sharedlist|api/sharedlist)/([BILMPTaceghikmnprsty]{30})$`,
+var pimpMyPackPathPattern = regexp.MustCompile(
+	`^/(?:sharedlist|api/sharedlist)/([BILMPTaceghikmnprsty]{30})$`,
+)
+
+var pimpMyPackCodePattern = regexp.MustCompile(
+	`^[BILMPTaceghikmnprsty]{30}$`,
 )
 
 // validatePimpMyPackURL checks that the URL is a valid PimpMyPack sharing URL
 // and returns the sharing code.
+// Supported formats:
+//   - https://app.alki.earth/sharedlist/<code>
+//   - https://app.alki.earth/api/sharedlist/<code>
+//   - https://app.alki.earth/public-pack.html?code=<code>
 func validatePimpMyPackURL(rawURL string) (string, error) {
-	matches := pimpMyPackURLPattern.FindStringSubmatch(rawURL)
-	if matches == nil {
-		return "", errors.New("invalid PimpMyPack URL: must match https://app.alki.earth/sharedlist/<code>")
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Scheme != "https" || parsed.Host != "app.alki.earth" {
+		return "", errors.New("invalid PimpMyPack URL: must be from https://app.alki.earth")
 	}
-	return matches[1], nil
+
+	// Try path-based format: /sharedlist/<code> or /api/sharedlist/<code>
+	if matches := pimpMyPackPathPattern.FindStringSubmatch(parsed.Path); matches != nil {
+		return matches[1], nil
+	}
+
+	// Try query-based format: /public-pack.html?code=<code>
+	if parsed.Path == "/public-pack.html" {
+		code := parsed.Query().Get("code")
+		if pimpMyPackCodePattern.MatchString(code) {
+			return code, nil
+		}
+	}
+
+	return "", errors.New("invalid PimpMyPack URL: must match https://app.alki.earth/sharedlist/<code> or https://app.alki.earth/public-pack.html?code=<code>")
 }
 
 // convertSharedPackToExternalPack converts a SharedPackResponse into an ExternalPack

--- a/pkg/packs/pimpmypack_import_test.go
+++ b/pkg/packs/pimpmypack_import_test.go
@@ -93,6 +93,44 @@ func TestValidatePimpMyPackURL(t *testing.T) {
 		wantErr:  false,
 	})
 
+	// public-pack.html?code= variant
+	publicPackURL := "https://app.alki.earth/public-pack.html?code=" + validCode
+	tests = append(tests, struct {
+		name     string
+		url      string
+		wantCode string
+		wantErr  bool
+	}{
+		name:     "valid public-pack.html URL",
+		url:      publicPackURL,
+		wantCode: validCode,
+		wantErr:  false,
+	})
+
+	// public-pack.html with invalid code
+	tests = append(tests, struct {
+		name     string
+		url      string
+		wantCode string
+		wantErr  bool
+	}{
+		name:    "public-pack.html with invalid code",
+		url:     "https://app.alki.earth/public-pack.html?code=123invalid",
+		wantErr: true,
+	})
+
+	// public-pack.html without code param
+	tests = append(tests, struct {
+		name     string
+		url      string
+		wantCode string
+		wantErr  bool
+	}{
+		name:    "public-pack.html without code param",
+		url:     "https://app.alki.earth/public-pack.html",
+		wantErr: true,
+	})
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			code, err := validatePimpMyPackURL(tt.url)

--- a/pkg/packs/testdata/lighterpack_eur.html
+++ b/pkg/packs/testdata/lighterpack_eur.html
@@ -4,7 +4,7 @@
 <body>
 <div id="lpApp">
   <h1 class="lpListName">Mon sac GR20</h1>
-  <span class="lpListDescription">Liste pour le GR20</span>
+  <div id="lpListDescription"><p>Liste pour le GR20</p></div>
   <ul class="lpCategories">
     <li class="lpCategory">
       <h2 class="lpCategoryName">Abri</h2>

--- a/pkg/packs/testdata/lighterpack_sample.html
+++ b/pkg/packs/testdata/lighterpack_sample.html
@@ -4,7 +4,7 @@
 <body>
 <div id="lpApp">
   <h1 class="lpListName">My Thru-Hike Gear</h1>
-  <span class="lpListDescription">PCT 2026 gear list</span>
+  <div id="lpListDescription"><p>PCT 2026 gear list</p></div>
   <ul class="lpCategories">
     <li class="lpCategory">
       <h2 class="lpCategoryName">Shelter</h2>


### PR DESCRIPTION
## Summary
- **PimpMyPack import**: Support the `public-pack.html?code=<code>` URL format in addition to the existing `/sharedlist/<code>` and `/api/sharedlist/<code>` formats
- **LighterPack import**: Fix pack description extraction — the parser was looking for `<span class="lpListDescription">` but the actual HTML uses `<div id="lpListDescription">`, causing the description to always fall back to the pack name

🤖 Generated with [Claude Code](https://claude.com/claude-code)