### PR TITLE
feat: add dedicated image processing for inventory items

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -30,3 +30,6 @@ MAIL_PORT=587
 MAIL_IDENTITY=noreply@pimpmypack.com                   # Sender email address (used as From and envelope sender)
 MAIL_USERNAME=jonh@doe.com                              # SMTP authentication login
 MAIL_PASSWORD=123456
+
+# Feature Flags
+FEATURE_ITEM_PICTURES_UPLOAD=true                  # Enable/disable inventory item picture uploads (default: true)

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -47,6 +47,7 @@ var (
 	ResendConfirmRateLimitWindowMinutes int
 	MailServerConfig                    MailServer
 	SeedOnStartup                       bool
+	FeatureItemPicturesUpload           bool
 )
 
 type Config struct {
@@ -66,6 +67,7 @@ type Config struct {
 	ResendConfirmRateLimitWindowMinutes int
 	MailServer                          MailServer
 	SeedOnStartup                       bool
+	FeatureItemPicturesUpload           bool
 }
 
 func EnvInit(envFilePath string) error {
@@ -94,6 +96,7 @@ func EnvInit(envFilePath string) error {
 	ResendConfirmRateLimitWindowMinutes = newConfig.ResendConfirmRateLimitWindowMinutes
 	MailServerConfig = newConfig.MailServer
 	SeedOnStartup = newConfig.SeedOnStartup
+	FeatureItemPicturesUpload = newConfig.FeatureItemPicturesUpload
 
 	return nil
 }
@@ -145,6 +148,7 @@ func newConfig() Config {
 		MailServer: MailServer{
 			MailPort: 587,
 		},
+		FeatureItemPicturesUpload: true,
 	}
 }
 
@@ -182,6 +186,7 @@ func setEnvVars(cfg *Config) {
 	cfg.MailServer.MailServer = os.Getenv("MAIL_SERVER")
 	cfg.MailServer.MailPort, _ = strconv.Atoi(ifEnvEmpty(os.Getenv("MAIL_PORT"), strconv.Itoa(cfg.MailServer.MailPort)))
 	cfg.SeedOnStartup = os.Getenv("SEED_ON_STARTUP") == "true"
+	cfg.FeatureItemPicturesUpload = os.Getenv("FEATURE_ITEM_PICTURES_UPLOAD") != "false"
 }
 
 func ifEnvEmpty(envVar, defaultValue string) string {

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -186,7 +186,9 @@ func setEnvVars(cfg *Config) {
 	cfg.MailServer.MailServer = os.Getenv("MAIL_SERVER")
 	cfg.MailServer.MailPort, _ = strconv.Atoi(ifEnvEmpty(os.Getenv("MAIL_PORT"), strconv.Itoa(cfg.MailServer.MailPort)))
 	cfg.SeedOnStartup = os.Getenv("SEED_ON_STARTUP") == "true"
-	cfg.FeatureItemPicturesUpload = os.Getenv("FEATURE_ITEM_PICTURES_UPLOAD") != "false"
+	if v, err := strconv.ParseBool(os.Getenv("FEATURE_ITEM_PICTURES_UPLOAD")); err == nil {
+		cfg.FeatureItemPicturesUpload = v
+	}
 }
 
 func ifEnvEmpty(envVar, defaultValue string) string {

--- a/pkg/images/handlers.go
+++ b/pkg/images/handlers.go
@@ -3,6 +3,7 @@ package images
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/Angak0k/pimpmypack/pkg/helper"
@@ -13,33 +14,32 @@ import (
 
 var storage ImageStorage = NewDBImageStorage()
 
-// processUploadedImage handles file validation and image processing
-func processUploadedImage(c *gin.Context) (*ProcessedImage, error) {
-	// Get file from form data
+// imageProcessorFunc is a function type for processing uploaded images from a reader
+type imageProcessorFunc = func(reader io.Reader) (*ProcessedImage, error)
+
+// processUploadedImageWith handles file validation and delegates processing to the given function
+func processUploadedImageWith(c *gin.Context, processFn imageProcessorFunc) (*ProcessedImage, error) {
 	file, err := c.FormFile("image")
 	if err != nil {
 		return nil, errors.New(ErrMsgNoImageProvided)
 	}
 
-	// Check file size (5MB limit)
 	if file.Size > MaxUploadSize {
 		return nil, fmt.Errorf("file size exceeds maximum allowed (%d bytes): %w", MaxUploadSize, ErrTooLarge)
 	}
 
-	// Open file
 	fileReader, err := file.Open()
 	if err != nil {
 		return nil, errors.New("failed to read uploaded file")
 	}
 	defer fileReader.Close()
 
-	// Process image
-	processed, err := ProcessImageFromReader(fileReader)
-	if err != nil {
-		return nil, err
-	}
+	return processFn(fileReader)
+}
 
-	return processed, nil
+// processUploadedImage handles file validation and image processing using default settings
+func processUploadedImage(c *gin.Context) (*ProcessedImage, error) {
+	return processUploadedImageWith(c, ProcessImageFromReader)
 }
 
 // UploadPackImage uploads or updates an image for a pack

--- a/pkg/images/handlers_inventory.go
+++ b/pkg/images/handlers_inventory.go
@@ -2,7 +2,6 @@ package images
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/Angak0k/pimpmypack/pkg/config"
@@ -30,6 +29,7 @@ var inventoryStorage InventoryImageStorage = NewDBInventoryImageStorage()
 // @Failure 404 {object} map[string]string "Item not found"
 // @Failure 413 {object} map[string]string "Payload too large"
 // @Failure 500 {object} map[string]string "Internal server error"
+// @Failure 503 {object} map[string]string "Feature disabled"
 // @Router /v1/myinventory/{id}/image [post]
 func UploadInventoryItemImage(c *gin.Context) {
 	if !config.FeatureItemPicturesUpload {
@@ -239,25 +239,5 @@ func DeleteInventoryItemImage(c *gin.Context) {
 
 // processUploadedInventoryItemImage handles file validation and image processing for inventory items
 func processUploadedInventoryItemImage(c *gin.Context) (*ProcessedImage, error) {
-	file, err := c.FormFile("image")
-	if err != nil {
-		return nil, errors.New(ErrMsgNoImageProvided)
-	}
-
-	if file.Size > MaxUploadSize {
-		return nil, fmt.Errorf("file size exceeds maximum allowed (%d bytes): %w", MaxUploadSize, ErrTooLarge)
-	}
-
-	fileReader, err := file.Open()
-	if err != nil {
-		return nil, errors.New("failed to read uploaded file")
-	}
-	defer fileReader.Close()
-
-	processed, err := ProcessInventoryItemImageFromReader(fileReader)
-	if err != nil {
-		return nil, err
-	}
-
-	return processed, nil
+	return processUploadedImageWith(c, ProcessInventoryItemImageFromReader)
 }

--- a/pkg/images/handlers_inventory.go
+++ b/pkg/images/handlers_inventory.go
@@ -2,8 +2,10 @@ package images
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
+	"github.com/Angak0k/pimpmypack/pkg/config"
 	"github.com/Angak0k/pimpmypack/pkg/helper"
 	"github.com/Angak0k/pimpmypack/pkg/inventories"
 	"github.com/Angak0k/pimpmypack/pkg/security"
@@ -30,6 +32,11 @@ var inventoryStorage InventoryImageStorage = NewDBInventoryImageStorage()
 // @Failure 500 {object} map[string]string "Internal server error"
 // @Router /v1/myinventory/{id}/image [post]
 func UploadInventoryItemImage(c *gin.Context) {
+	if !config.FeatureItemPicturesUpload {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Item picture upload is currently disabled"})
+		return
+	}
+
 	ctx := c.Request.Context()
 
 	userID, err := security.ExtractTokenID(c)
@@ -67,26 +74,21 @@ func UploadInventoryItemImage(c *gin.Context) {
 		return
 	}
 
-	processed, err := processUploadedImage(c)
+	processed, err := processUploadedInventoryItemImage(c)
 	if err != nil {
-		if errors.Is(err, ErrInvalidFormat) {
+		switch {
+		case errors.Is(err, ErrInvalidFormat):
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid image format. Only JPEG, PNG, and WebP are supported"})
-			return
-		}
-		if errors.Is(err, ErrTooLarge) {
+		case errors.Is(err, ErrTooLarge):
 			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "File size exceeds maximum allowed"})
-			return
-		}
-		if errors.Is(err, ErrCorrupted) {
+		case errors.Is(err, ErrCorrupted):
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Corrupted or invalid image file"})
-			return
-		}
-		if err.Error() == ErrMsgNoImageProvided {
+		case err.Error() == ErrMsgNoImageProvided:
 			c.JSON(http.StatusBadRequest, gin.H{"error": "No image file provided"})
-			return
+		default:
+			helper.LogAndSanitize(err, "upload inventory image: process image failed")
+			c.JSON(http.StatusBadRequest, gin.H{"error": helper.ErrMsgBadRequest})
 		}
-		helper.LogAndSanitize(err, "upload inventory image: process image failed")
-		c.JSON(http.StatusBadRequest, gin.H{"error": helper.ErrMsgBadRequest})
 		return
 	}
 
@@ -233,4 +235,29 @@ func DeleteInventoryItemImage(c *gin.Context) {
 		"message": "Image deleted successfully",
 		"item_id": itemID,
 	})
+}
+
+// processUploadedInventoryItemImage handles file validation and image processing for inventory items
+func processUploadedInventoryItemImage(c *gin.Context) (*ProcessedImage, error) {
+	file, err := c.FormFile("image")
+	if err != nil {
+		return nil, errors.New(ErrMsgNoImageProvided)
+	}
+
+	if file.Size > MaxUploadSize {
+		return nil, fmt.Errorf("file size exceeds maximum allowed (%d bytes): %w", MaxUploadSize, ErrTooLarge)
+	}
+
+	fileReader, err := file.Open()
+	if err != nil {
+		return nil, errors.New("failed to read uploaded file")
+	}
+	defer fileReader.Close()
+
+	processed, err := ProcessInventoryItemImageFromReader(fileReader)
+	if err != nil {
+		return nil, err
+	}
+
+	return processed, nil
 }

--- a/pkg/images/processor.go
+++ b/pkg/images/processor.go
@@ -112,9 +112,11 @@ func ResizeImage(img image.Image) image.Image {
 	return ResizeImageWithMax(img, MaxDimension)
 }
 
-// EncodeToJPEGWithQuality encodes an image to JPEG format with the given quality (0-100)
-// This also effectively strips EXIF data as we're re-encoding from scratch
+// EncodeToJPEGWithQuality encodes an image to JPEG format with the given quality (1-100)
+// Values outside the range are clamped. This also effectively strips EXIF data.
 func EncodeToJPEGWithQuality(img image.Image, quality int) ([]byte, error) {
+	quality = max(1, min(100, quality))
+
 	var buf bytes.Buffer
 
 	opts := &jpeg.Options{Quality: quality}

--- a/pkg/images/processor.go
+++ b/pkg/images/processor.go
@@ -20,8 +20,12 @@ const (
 	MaxDimension = 1920
 	// MaxProfilePicDimension is the maximum width or height for profile pictures
 	MaxProfilePicDimension = 512
+	// MaxInventoryItemDimension is the maximum width or height for inventory item pictures
+	MaxInventoryItemDimension = 400
 	// JPEGQuality is the quality setting for JPEG encoding (0-100)
 	JPEGQuality = 85
+	// InventoryItemJPEGQuality is the quality setting for inventory item images (0-100)
+	InventoryItemJPEGQuality = 70
 	// MimeTypeJPEG is the MIME type for JPEG images
 	MimeTypeJPEG = "image/jpeg"
 	// MimeTypePNG is the MIME type for PNG images
@@ -108,18 +112,23 @@ func ResizeImage(img image.Image) image.Image {
 	return ResizeImageWithMax(img, MaxDimension)
 }
 
-// EncodeToJPEG encodes an image to JPEG format with specified quality
+// EncodeToJPEGWithQuality encodes an image to JPEG format with the given quality (0-100)
 // This also effectively strips EXIF data as we're re-encoding from scratch
-func EncodeToJPEG(img image.Image) ([]byte, error) {
+func EncodeToJPEGWithQuality(img image.Image, quality int) ([]byte, error) {
 	var buf bytes.Buffer
 
-	opts := &jpeg.Options{Quality: JPEGQuality}
+	opts := &jpeg.Options{Quality: quality}
 	err := jpeg.Encode(&buf, img, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode JPEG: %w", err)
 	}
 
 	return buf.Bytes(), nil
+}
+
+// EncodeToJPEG encodes an image to JPEG format with default quality (JPEGQuality)
+func EncodeToJPEG(img image.Image) ([]byte, error) {
+	return EncodeToJPEGWithQuality(img, JPEGQuality)
 }
 
 // ProcessImage validates and processes an uploaded image
@@ -234,4 +243,57 @@ func ProcessProfileImageFromReader(reader io.Reader) (*ProcessedImage, error) {
 	}
 
 	return ProcessProfileImage(data)
+}
+
+// ProcessInventoryItemImage validates and processes an uploaded inventory item picture
+// Uses MaxInventoryItemDimension (400px) and InventoryItemJPEGQuality (70%)
+func ProcessInventoryItemImage(data []byte) (*ProcessedImage, error) {
+	if len(data) > MaxUploadSize {
+		return nil, fmt.Errorf("%w: upload size %d exceeds %d bytes",
+			ErrTooLarge, len(data), MaxUploadSize)
+	}
+
+	_, err := ValidateImageFormat(data)
+	if err != nil {
+		return nil, err
+	}
+
+	img, err := DecodeImage(data)
+	if err != nil {
+		return nil, err
+	}
+
+	img = ResizeImageWithMax(img, MaxInventoryItemDimension)
+
+	processedData, err := EncodeToJPEGWithQuality(img, InventoryItemJPEGQuality)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(processedData) > MaxProcessedSize {
+		return nil, fmt.Errorf("%w: processed size %d exceeds %d bytes",
+			ErrTooLarge, len(processedData), MaxProcessedSize)
+	}
+
+	bounds := img.Bounds()
+
+	return &ProcessedImage{
+		Data: processedData,
+		Metadata: ImageMetadata{
+			MimeType: MimeTypeJPEG,
+			FileSize: len(processedData),
+			Width:    bounds.Dx(),
+			Height:   bounds.Dy(),
+		},
+	}, nil
+}
+
+// ProcessInventoryItemImageFromReader processes an inventory item image from an io.Reader
+func ProcessInventoryItemImageFromReader(reader io.Reader) (*ProcessedImage, error) {
+	data, err := io.ReadAll(io.LimitReader(reader, MaxUploadSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read image data: %w", err)
+	}
+
+	return ProcessInventoryItemImage(data)
 }

--- a/pkg/images/processor_test.go
+++ b/pkg/images/processor_test.go
@@ -402,7 +402,12 @@ func TestProcessImageFromReader(t *testing.T) {
 }
 
 func TestEncodeToJPEGWithQuality(t *testing.T) {
-	img := image.NewRGBA(image.Rect(0, 0, 200, 200))
+	// Use a gradient image to ensure quality difference is measurable
+	data := createTestJPEG(200, 200)
+	img, err := DecodeImage(data)
+	if err != nil {
+		t.Fatalf("Failed to decode test image: %v", err)
+	}
 
 	// Encode at high quality
 	highQ, err := EncodeToJPEGWithQuality(img, 95)

--- a/pkg/images/processor_test.go
+++ b/pkg/images/processor_test.go
@@ -400,3 +400,74 @@ func TestProcessImageFromReader(t *testing.T) {
 		t.Errorf("Expected height 600, got %d", result.Metadata.Height)
 	}
 }
+
+func TestEncodeToJPEGWithQuality(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 200, 200))
+
+	// Encode at high quality
+	highQ, err := EncodeToJPEGWithQuality(img, 95)
+	if err != nil {
+		t.Fatalf("Failed to encode at quality 95: %v", err)
+	}
+
+	// Encode at low quality
+	lowQ, err := EncodeToJPEGWithQuality(img, 30)
+	if err != nil {
+		t.Fatalf("Failed to encode at quality 30: %v", err)
+	}
+
+	// Lower quality should produce smaller file
+	if len(lowQ) >= len(highQ) {
+		t.Errorf("Expected lower quality to produce smaller file: high=%d, low=%d", len(highQ), len(lowQ))
+	}
+
+	// Both should be valid JPEG
+	for _, data := range [][]byte{highQ, lowQ} {
+		mimeType, err := ValidateImageFormat(data)
+		if err != nil {
+			t.Fatalf("Encoded data is not a valid image: %v", err)
+		}
+		if mimeType != "image/jpeg" {
+			t.Errorf("Expected image/jpeg, got %s", mimeType)
+		}
+	}
+}
+
+func TestProcessInventoryItemImage_ResizesLargeImage(t *testing.T) {
+	data := createTestJPEG(800, 600)
+
+	result, err := ProcessInventoryItemImage(data)
+	if err != nil {
+		t.Fatalf("Failed to process inventory item image: %v", err)
+	}
+
+	// 800x600 exceeds MaxInventoryItemDimension (400), should be resized
+	if result.Metadata.Width > MaxInventoryItemDimension || result.Metadata.Height > MaxInventoryItemDimension {
+		t.Errorf("Image not resized properly: %dx%d (max %d)",
+			result.Metadata.Width, result.Metadata.Height, MaxInventoryItemDimension)
+	}
+
+	// Largest dimension should be MaxInventoryItemDimension
+	if result.Metadata.Width != MaxInventoryItemDimension && result.Metadata.Height != MaxInventoryItemDimension {
+		t.Errorf("Neither dimension is MaxInventoryItemDimension: %dx%d",
+			result.Metadata.Width, result.Metadata.Height)
+	}
+
+	if result.Metadata.MimeType != "image/jpeg" {
+		t.Errorf("Expected mime type image/jpeg, got %s", result.Metadata.MimeType)
+	}
+}
+
+func TestProcessInventoryItemImage_SmallImageUnchangedDimensions(t *testing.T) {
+	data := createTestJPEG(200, 150)
+
+	result, err := ProcessInventoryItemImage(data)
+	if err != nil {
+		t.Fatalf("Failed to process inventory item image: %v", err)
+	}
+
+	// 200x150 is within MaxInventoryItemDimension, dimensions should be preserved
+	if result.Metadata.Width != 200 || result.Metadata.Height != 150 {
+		t.Errorf("Expected 200x150, got %dx%d", result.Metadata.Width, result.Metadata.Height)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #203

- **Smaller image dimensions & lower quality**: Inventory item pictures are now processed at max 400x400px with 70% JPEG quality (instead of pack image defaults of 1920px / 85%), reducing storage and bandwidth for item thumbnails
- **Feature flag**: Added `FEATURE_ITEM_PICTURES_UPLOAD` env var (default: `true`) to disable upload operations (POST) at runtime while keeping GET/DELETE available. Returns 503 when disabled.
- **Parameterized JPEG encoding**: Added `EncodeToJPEGWithQuality` to support different quality levels; existing `EncodeToJPEG` delegates to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)