### PR TITLE
feat: add public user profile endpoint

### DIFF
--- a/api-doc/docs.go
+++ b/api-doc/docs.go
@@ -333,6 +333,47 @@ const docTemplate = `{
                 }
             }
         },
+        "/user/{username}": {
+            "get": {
+                "description": "Returns public profile information and shared packs for a user.\nReturns 404 for non-existent users or users without a public profile (anti-enumeration).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Profiles"
+                ],
+                "summary": "Get public user profile",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/profiles.PublicProfile"
+                        }
+                    },
+                    "404": {
+                        "description": "Profile not found",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/accounts/{id}/image": {
             "get": {
                 "description": "Get the profile image for a user account",
@@ -1201,6 +1242,15 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Feature disabled",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -2449,6 +2499,9 @@ const docTemplate = `{
                 "instagram_url": {
                     "type": "string"
                 },
+                "is_profile_public": {
+                    "type": "boolean"
+                },
                 "lastname": {
                     "type": "string"
                 },
@@ -2497,6 +2550,9 @@ const docTemplate = `{
                 },
                 "instagram_url": {
                     "type": "string"
+                },
+                "is_profile_public": {
+                    "type": "boolean"
                 },
                 "lastname": {
                     "type": "string"
@@ -2985,6 +3041,76 @@ const docTemplate = `{
                 },
                 "pack": {
                     "$ref": "#/definitions/packs.SharedPackInfo"
+                }
+            }
+        },
+        "profiles.PublicProfile": {
+            "type": "object",
+            "properties": {
+                "firstname": {
+                    "type": "string"
+                },
+                "has_profile_image": {
+                    "type": "boolean"
+                },
+                "image_position_x": {
+                    "type": "integer"
+                },
+                "image_position_y": {
+                    "type": "integer"
+                },
+                "instagram_url": {
+                    "type": "string"
+                },
+                "shared_packs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/profiles.SharedPackSummary"
+                    }
+                },
+                "username": {
+                    "type": "string"
+                },
+                "youtube_url": {
+                    "type": "string"
+                }
+            }
+        },
+        "profiles.SharedPackSummary": {
+            "type": "object",
+            "properties": {
+                "adventure": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "has_image": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "pack_description": {
+                    "type": "string"
+                },
+                "pack_items_count": {
+                    "type": "integer"
+                },
+                "pack_name": {
+                    "type": "string"
+                },
+                "pack_weight": {
+                    "type": "integer"
+                },
+                "season": {
+                    "type": "string"
+                },
+                "sharing_code": {
+                    "type": "string"
+                },
+                "trail": {
+                    "type": "string"
                 }
             }
         },

--- a/api-doc/docs.go
+++ b/api-doc/docs.go
@@ -374,6 +374,53 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/accounts/{id}/banner": {
+            "get": {
+                "description": "Get the banner/hero image for a user account",
+                "produces": [
+                    "image/jpeg"
+                ],
+                "tags": [
+                    "Account Images"
+                ],
+                "summary": "Get banner image",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Account ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid account ID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "No banner image found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/accounts/{id}/image": {
             "get": {
                 "description": "Get the profile image for a user account",
@@ -683,6 +730,122 @@ const docTemplate = `{
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/myaccount/banner": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Upload or update the banner/hero image for the currently logged-in user",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Account Images"
+                ],
+                "summary": "Upload or update banner image",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "Image file (JPEG, PNG, or WebP, max 5MB)",
+                        "name": "image",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Banner image uploaded successfully",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request or image",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "Payload too large",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Delete the banner/hero image for the currently logged-in user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Account Images"
+                ],
+                "summary": "Delete banner image",
+                "responses": {
+                    "200": {
+                        "description": "Banner image deleted successfully",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     }
                 }
@@ -2475,6 +2638,9 @@ const docTemplate = `{
         "accounts.Account": {
             "type": "object",
             "properties": {
+                "banner_position_y": {
+                    "type": "integer"
+                },
                 "created_at": {
                     "type": "string"
                 },
@@ -2483,6 +2649,9 @@ const docTemplate = `{
                 },
                 "firstname": {
                     "type": "string"
+                },
+                "has_banner_image": {
+                    "type": "boolean"
                 },
                 "has_profile_image": {
                     "type": "boolean"
@@ -2536,6 +2705,9 @@ const docTemplate = `{
                 "lastname"
             ],
             "properties": {
+                "banner_position_y": {
+                    "type": "integer"
+                },
                 "email": {
                     "type": "string"
                 },
@@ -3047,8 +3219,14 @@ const docTemplate = `{
         "profiles.PublicProfile": {
             "type": "object",
             "properties": {
+                "banner_position_y": {
+                    "type": "integer"
+                },
                 "firstname": {
                     "type": "string"
+                },
+                "has_banner_image": {
+                    "type": "boolean"
                 },
                 "has_profile_image": {
                     "type": "boolean"

--- a/api-doc/swagger.json
+++ b/api-doc/swagger.json
@@ -371,6 +371,53 @@
                 }
             }
         },
+        "/v1/accounts/{id}/banner": {
+            "get": {
+                "description": "Get the banner/hero image for a user account",
+                "produces": [
+                    "image/jpeg"
+                ],
+                "tags": [
+                    "Account Images"
+                ],
+                "summary": "Get banner image",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Account ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid account ID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "No banner image found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/accounts/{id}/image": {
             "get": {
                 "description": "Get the profile image for a user account",
@@ -680,6 +727,122 @@
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/myaccount/banner": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Upload or update the banner/hero image for the currently logged-in user",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Account Images"
+                ],
+                "summary": "Upload or update banner image",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "Image file (JPEG, PNG, or WebP, max 5MB)",
+                        "name": "image",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Banner image uploaded successfully",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request or image",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "Payload too large",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Delete the banner/hero image for the currently logged-in user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Account Images"
+                ],
+                "summary": "Delete banner image",
+                "responses": {
+                    "200": {
+                        "description": "Banner image deleted successfully",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     }
                 }
@@ -2472,6 +2635,9 @@
         "accounts.Account": {
             "type": "object",
             "properties": {
+                "banner_position_y": {
+                    "type": "integer"
+                },
                 "created_at": {
                     "type": "string"
                 },
@@ -2480,6 +2646,9 @@
                 },
                 "firstname": {
                     "type": "string"
+                },
+                "has_banner_image": {
+                    "type": "boolean"
                 },
                 "has_profile_image": {
                     "type": "boolean"
@@ -2533,6 +2702,9 @@
                 "lastname"
             ],
             "properties": {
+                "banner_position_y": {
+                    "type": "integer"
+                },
                 "email": {
                     "type": "string"
                 },
@@ -3044,8 +3216,14 @@
         "profiles.PublicProfile": {
             "type": "object",
             "properties": {
+                "banner_position_y": {
+                    "type": "integer"
+                },
                 "firstname": {
                     "type": "string"
+                },
+                "has_banner_image": {
+                    "type": "boolean"
                 },
                 "has_profile_image": {
                     "type": "boolean"

--- a/api-doc/swagger.json
+++ b/api-doc/swagger.json
@@ -330,6 +330,47 @@
                 }
             }
         },
+        "/user/{username}": {
+            "get": {
+                "description": "Returns public profile information and shared packs for a user.\nReturns 404 for non-existent users or users without a public profile (anti-enumeration).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Profiles"
+                ],
+                "summary": "Get public user profile",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/profiles.PublicProfile"
+                        }
+                    },
+                    "404": {
+                        "description": "Profile not found",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/accounts/{id}/image": {
             "get": {
                 "description": "Get the profile image for a user account",
@@ -1198,6 +1239,15 @@
                     },
                     "500": {
                         "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Feature disabled",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -2446,6 +2496,9 @@
                 "instagram_url": {
                     "type": "string"
                 },
+                "is_profile_public": {
+                    "type": "boolean"
+                },
                 "lastname": {
                     "type": "string"
                 },
@@ -2494,6 +2547,9 @@
                 },
                 "instagram_url": {
                     "type": "string"
+                },
+                "is_profile_public": {
+                    "type": "boolean"
                 },
                 "lastname": {
                     "type": "string"
@@ -2982,6 +3038,76 @@
                 },
                 "pack": {
                     "$ref": "#/definitions/packs.SharedPackInfo"
+                }
+            }
+        },
+        "profiles.PublicProfile": {
+            "type": "object",
+            "properties": {
+                "firstname": {
+                    "type": "string"
+                },
+                "has_profile_image": {
+                    "type": "boolean"
+                },
+                "image_position_x": {
+                    "type": "integer"
+                },
+                "image_position_y": {
+                    "type": "integer"
+                },
+                "instagram_url": {
+                    "type": "string"
+                },
+                "shared_packs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/profiles.SharedPackSummary"
+                    }
+                },
+                "username": {
+                    "type": "string"
+                },
+                "youtube_url": {
+                    "type": "string"
+                }
+            }
+        },
+        "profiles.SharedPackSummary": {
+            "type": "object",
+            "properties": {
+                "adventure": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "has_image": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "pack_description": {
+                    "type": "string"
+                },
+                "pack_items_count": {
+                    "type": "integer"
+                },
+                "pack_name": {
+                    "type": "string"
+                },
+                "pack_weight": {
+                    "type": "integer"
+                },
+                "season": {
+                    "type": "string"
+                },
+                "sharing_code": {
+                    "type": "string"
+                },
+                "trail": {
+                    "type": "string"
                 }
             }
         },

--- a/api-doc/swagger.yaml
+++ b/api-doc/swagger.yaml
@@ -2,12 +2,16 @@ basePath: /api
 definitions:
   accounts.Account:
     properties:
+      banner_position_y:
+        type: integer
       created_at:
         type: string
       email:
         type: string
       firstname:
         type: string
+      has_banner_image:
+        type: boolean
       has_profile_image:
         type: boolean
       id:
@@ -39,6 +43,8 @@ definitions:
     type: object
   accounts.AccountUpdateInput:
     properties:
+      banner_position_y:
+        type: integer
       email:
         type: string
       firstname:
@@ -380,8 +386,12 @@ definitions:
     type: object
   profiles.PublicProfile:
     properties:
+      banner_position_y:
+        type: integer
       firstname:
         type: string
+      has_banner_image:
+        type: boolean
       has_profile_image:
         type: boolean
       image_position_x:
@@ -702,6 +712,37 @@ paths:
       summary: Get public user profile
       tags:
       - Profiles
+  /v1/accounts/{id}/banner:
+    get:
+      description: Get the banner/hero image for a user account
+      parameters:
+      - description: Account ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - image/jpeg
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: file
+        "400":
+          description: Invalid account ID
+          schema:
+            type: string
+        "404":
+          description: No banner image found
+          schema:
+            type: string
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      summary: Get banner image
+      tags:
+      - Account Images
   /v1/accounts/{id}/image:
     get:
       description: Get the profile image for a user account
@@ -903,6 +944,82 @@ paths:
       summary: Update account info
       tags:
       - Accounts
+  /v1/myaccount/banner:
+    delete:
+      description: Delete the banner/hero image for the currently logged-in user
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Banner image deleted successfully
+          schema:
+            additionalProperties: true
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - Bearer: []
+      summary: Delete banner image
+      tags:
+      - Account Images
+    post:
+      consumes:
+      - multipart/form-data
+      description: Upload or update the banner/hero image for the currently logged-in
+        user
+      parameters:
+      - description: Image file (JPEG, PNG, or WebP, max 5MB)
+        in: formData
+        name: image
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Banner image uploaded successfully
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Invalid request or image
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "413":
+          description: Payload too large
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - Bearer: []
+      summary: Upload or update banner image
+      tags:
+      - Account Images
   /v1/myaccount/image:
     delete:
       description: Delete the profile image for the currently logged-in user

--- a/api-doc/swagger.yaml
+++ b/api-doc/swagger.yaml
@@ -18,6 +18,8 @@ definitions:
         type: integer
       instagram_url:
         type: string
+      is_profile_public:
+        type: boolean
       lastname:
         type: string
       preferred_currency:
@@ -47,6 +49,8 @@ definitions:
         type: integer
       instagram_url:
         type: string
+      is_profile_public:
+        type: boolean
       lastname:
         type: string
       preferred_currency:
@@ -374,6 +378,52 @@ definitions:
       pack:
         $ref: '#/definitions/packs.SharedPackInfo'
     type: object
+  profiles.PublicProfile:
+    properties:
+      firstname:
+        type: string
+      has_profile_image:
+        type: boolean
+      image_position_x:
+        type: integer
+      image_position_y:
+        type: integer
+      instagram_url:
+        type: string
+      shared_packs:
+        items:
+          $ref: '#/definitions/profiles.SharedPackSummary'
+        type: array
+      username:
+        type: string
+      youtube_url:
+        type: string
+    type: object
+  profiles.SharedPackSummary:
+    properties:
+      adventure:
+        type: string
+      created_at:
+        type: string
+      has_image:
+        type: boolean
+      id:
+        type: integer
+      pack_description:
+        type: string
+      pack_items_count:
+        type: integer
+      pack_name:
+        type: string
+      pack_weight:
+        type: integer
+      season:
+        type: string
+      sharing_code:
+        type: string
+      trail:
+        type: string
+    type: object
   security.RefreshResponse:
     properties:
       access_token:
@@ -623,6 +673,35 @@ paths:
       summary: Get shared pack with metadata
       tags:
       - Public
+  /user/{username}:
+    get:
+      description: |-
+        Returns public profile information and shared packs for a user.
+        Returns 404 for non-existent users or users without a public profile (anti-enumeration).
+      parameters:
+      - description: Username
+        in: path
+        name: username
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/profiles.PublicProfile'
+        "404":
+          description: Profile not found
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+      summary: Get public user profile
+      tags:
+      - Profiles
   /v1/accounts/{id}/image:
     get:
       description: Get the profile image for a user account
@@ -1235,6 +1314,12 @@ paths:
             type: object
         "500":
           description: Internal server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "503":
+          description: Feature disabled
           schema:
             additionalProperties:
               type: string

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Angak0k/pimpmypack/pkg/images"
 	"github.com/Angak0k/pimpmypack/pkg/inventories"
 	"github.com/Angak0k/pimpmypack/pkg/packs"
+	"github.com/Angak0k/pimpmypack/pkg/profiles"
 	"github.com/Angak0k/pimpmypack/pkg/security"
 	"github.com/gin-gonic/gin"
 	swaggerFiles "github.com/swaggo/files"
@@ -124,6 +125,7 @@ func setupPublicRoutes(router *gin.Engine) {
 		),
 		accounts.ResendConfirmEmail)
 	public.GET("/sharedlist/:sharing_code", packs.SharedList)
+	public.GET("/user/:username", profiles.GetPublicProfile)
 	public.GET("/v1/packs/:id/image", images.GetPackImage)
 	public.GET("/v1/accounts/:id/image", images.GetProfileImage)
 }

--- a/main.go
+++ b/main.go
@@ -128,6 +128,7 @@ func setupPublicRoutes(router *gin.Engine) {
 	public.GET("/user/:username", profiles.GetPublicProfile)
 	public.GET("/v1/packs/:id/image", images.GetPackImage)
 	public.GET("/v1/accounts/:id/image", images.GetProfileImage)
+	public.GET("/v1/accounts/:id/banner", images.GetBannerImage)
 }
 
 func setupProtectedRoutes(router *gin.Engine) {
@@ -162,6 +163,8 @@ func setupProtectedRoutes(router *gin.Engine) {
 	protected.DELETE("/mypack/:id/image", images.DeletePackImage)
 	protected.POST("/myaccount/image", images.UploadMyProfileImage)
 	protected.DELETE("/myaccount/image", images.DeleteMyProfileImage)
+	protected.POST("/myaccount/banner", images.UploadMyBannerImage)
+	protected.DELETE("/myaccount/banner", images.DeleteMyBannerImage)
 	protected.POST("/myinventory/:id/image", images.UploadInventoryItemImage)
 	protected.GET("/myinventory/:id/image", images.GetInventoryItemImage)
 	protected.DELETE("/myinventory/:id/image", images.DeleteInventoryItemImage)

--- a/pkg/accounts/accounts.go
+++ b/pkg/accounts/accounts.go
@@ -344,9 +344,12 @@ func returnAccounts(ctx context.Context) (*Accounts, error) {
 		    a.preferred_currency, a.preferred_unit_system, a.youtube_url, a.instagram_url,
 		    CASE WHEN ai.account_id IS NOT NULL THEN true ELSE false END AS has_profile_image,
 		    a.image_position_x, a.image_position_y, a.is_profile_public,
+		    CASE WHEN abi.account_id IS NOT NULL THEN true ELSE false END AS has_banner_image,
+		    a.banner_position_y,
 		    a.created_at, a.updated_at
 		FROM account a
-		LEFT JOIN account_images ai ON a.id = ai.account_id;`)
+		LEFT JOIN account_images ai ON a.id = ai.account_id
+		LEFT JOIN account_banner_images abi ON a.id = abi.account_id;`)
 	if err != nil {
 		return nil, err
 	}
@@ -370,6 +373,8 @@ func returnAccounts(ctx context.Context) (*Accounts, error) {
 			&account.ImagePositionX,
 			&account.ImagePositionY,
 			&account.IsProfilePublic,
+			&account.HasBannerImage,
+			&account.BannerPositionY,
 			&account.CreatedAt,
 			&account.UpdatedAt)
 		if err != nil {
@@ -393,9 +398,12 @@ func findAccountByID(ctx context.Context, id uint) (*Account, error) {
 		    a.preferred_currency, a.preferred_unit_system, a.youtube_url, a.instagram_url,
 		    CASE WHEN ai.account_id IS NOT NULL THEN true ELSE false END AS has_profile_image,
 		    a.image_position_x, a.image_position_y, a.is_profile_public,
+		    CASE WHEN abi.account_id IS NOT NULL THEN true ELSE false END AS has_banner_image,
+		    a.banner_position_y,
 		    a.created_at, a.updated_at
 		FROM account a
 		LEFT JOIN account_images ai ON a.id = ai.account_id
+		LEFT JOIN account_banner_images abi ON a.id = abi.account_id
 		WHERE a.id = $1;`,
 		id)
 	err := row.Scan(
@@ -414,6 +422,8 @@ func findAccountByID(ctx context.Context, id uint) (*Account, error) {
 		&account.ImagePositionX,
 		&account.ImagePositionY,
 		&account.IsProfilePublic,
+		&account.HasBannerImage,
+		&account.BannerPositionY,
 		&account.CreatedAt,
 		&account.UpdatedAt)
 
@@ -462,8 +472,8 @@ func updateAccountByID(ctx context.Context, id uint, a *Account) error {
 	statement, err := database.DB().PrepareContext(ctx,
 		`UPDATE account SET email=$1, firstname=$2, lastname=$3, status=$4, role=$5, preferred_currency=$6,
 		    preferred_unit_system=$7, youtube_url=$8, instagram_url=$9, image_position_x=$10,
-		    image_position_y=$11, is_profile_public=$12, updated_at=$13
-		WHERE id=$14 RETURNING username;`)
+		    image_position_y=$11, is_profile_public=$12, banner_position_y=$13, updated_at=$14
+		WHERE id=$15 RETURNING username;`)
 	if err != nil {
 		return err
 	}
@@ -472,7 +482,7 @@ func updateAccountByID(ctx context.Context, id uint, a *Account) error {
 
 	err = statement.QueryRowContext(ctx, a.Email, a.Firstname, a.Lastname, a.Status, a.Role, a.PreferredCurrency,
 		a.PreferredUnitSystem, a.YoutubeURL, a.InstagramURL, a.ImagePositionX, a.ImagePositionY,
-		a.IsProfilePublic, a.UpdatedAt, a.ID).Scan(&a.Username)
+		a.IsProfilePublic, a.BannerPositionY, a.UpdatedAt, a.ID).Scan(&a.Username)
 	if err != nil {
 		return err
 	}
@@ -484,7 +494,8 @@ func isValidationError(err error) bool {
 	msg := err.Error()
 	return msg == "invalid email format" ||
 		msg == "image_position_x must be between 0 and 100" ||
-		msg == "image_position_y must be between 0 and 100"
+		msg == "image_position_y must be between 0 and 100" ||
+		msg == "banner_position_y must be between 0 and 100"
 }
 
 // normalizeEmptyStringPtr converts empty string pointers to nil for clean DB storage
@@ -519,6 +530,9 @@ func updateMyAccount(ctx context.Context, userID uint, input *AccountUpdateInput
 	if input.ImagePositionY != nil && (*input.ImagePositionY < 0 || *input.ImagePositionY > 100) {
 		return nil, errors.New("image_position_y must be between 0 and 100")
 	}
+	if input.BannerPositionY != nil && (*input.BannerPositionY < 0 || *input.BannerPositionY > 100) {
+		return nil, errors.New("banner_position_y must be between 0 and 100")
+	}
 
 	now := time.Now().Truncate(time.Second)
 
@@ -531,11 +545,13 @@ func updateMyAccount(ctx context.Context, userID uint, input *AccountUpdateInput
 		     image_position_x=COALESCE($8, image_position_x),
 		     image_position_y=COALESCE($9, image_position_y),
 		     is_profile_public=COALESCE($10, is_profile_public),
-		     updated_at=$11
-		 WHERE id=$12
+		     banner_position_y=COALESCE($11, banner_position_y),
+		     updated_at=$12
+		 WHERE id=$13
 		 RETURNING id, username, email, firstname, lastname, role, status,
 		           preferred_currency, preferred_unit_system, youtube_url, instagram_url,
 		           image_position_x, image_position_y, is_profile_public,
+		           banner_position_y,
 		           created_at, updated_at;`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare statement: %w", err)
@@ -554,6 +570,7 @@ func updateMyAccount(ctx context.Context, userID uint, input *AccountUpdateInput
 		input.ImagePositionX,
 		input.ImagePositionY,
 		input.IsProfilePublic,
+		input.BannerPositionY,
 		now,
 		userID,
 	).Scan(
@@ -571,6 +588,7 @@ func updateMyAccount(ctx context.Context, userID uint, input *AccountUpdateInput
 		&account.ImagePositionX,
 		&account.ImagePositionY,
 		&account.IsProfilePublic,
+		&account.BannerPositionY,
 		&account.CreatedAt,
 		&account.UpdatedAt,
 	)
@@ -582,16 +600,19 @@ func updateMyAccount(ctx context.Context, userID uint, input *AccountUpdateInput
 		return nil, fmt.Errorf("failed to update account: %w", err)
 	}
 
-	// Compute has_profile_image separately
-	var hasProfileImage bool
+	// Compute has_profile_image and has_banner_image separately
+	var hasProfileImage, hasBannerImage bool
 	err = database.DB().QueryRowContext(ctx,
-		`SELECT EXISTS(SELECT 1 FROM account_images WHERE account_id = $1)`,
+		`SELECT
+		    EXISTS(SELECT 1 FROM account_images WHERE account_id = $1),
+		    EXISTS(SELECT 1 FROM account_banner_images WHERE account_id = $1)`,
 		userID,
-	).Scan(&hasProfileImage)
+	).Scan(&hasProfileImage, &hasBannerImage)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check profile image: %w", err)
+		return nil, fmt.Errorf("failed to check images: %w", err)
 	}
 	account.HasProfileImage = hasProfileImage
+	account.HasBannerImage = hasBannerImage
 
 	return &account, nil
 }

--- a/pkg/accounts/accounts.go
+++ b/pkg/accounts/accounts.go
@@ -462,8 +462,8 @@ func updateAccountByID(ctx context.Context, id uint, a *Account) error {
 	statement, err := database.DB().PrepareContext(ctx,
 		`UPDATE account SET email=$1, firstname=$2, lastname=$3, status=$4, role=$5, preferred_currency=$6,
 		    preferred_unit_system=$7, youtube_url=$8, instagram_url=$9, image_position_x=$10,
-		    image_position_y=$11, updated_at=$12
-		WHERE id=$13 RETURNING username;`)
+		    image_position_y=$11, is_profile_public=$12, updated_at=$13
+		WHERE id=$14 RETURNING username;`)
 	if err != nil {
 		return err
 	}
@@ -472,7 +472,7 @@ func updateAccountByID(ctx context.Context, id uint, a *Account) error {
 
 	err = statement.QueryRowContext(ctx, a.Email, a.Firstname, a.Lastname, a.Status, a.Role, a.PreferredCurrency,
 		a.PreferredUnitSystem, a.YoutubeURL, a.InstagramURL, a.ImagePositionX, a.ImagePositionY,
-		a.UpdatedAt, a.ID).Scan(&a.Username)
+		a.IsProfilePublic, a.UpdatedAt, a.ID).Scan(&a.Username)
 	if err != nil {
 		return err
 	}

--- a/pkg/accounts/accounts.go
+++ b/pkg/accounts/accounts.go
@@ -343,7 +343,7 @@ func returnAccounts(ctx context.Context) (*Accounts, error) {
 		`SELECT a.id, a.username, a.email, a.firstname, a.lastname, a.role, a.status,
 		    a.preferred_currency, a.preferred_unit_system, a.youtube_url, a.instagram_url,
 		    CASE WHEN ai.account_id IS NOT NULL THEN true ELSE false END AS has_profile_image,
-		    a.image_position_x, a.image_position_y,
+		    a.image_position_x, a.image_position_y, a.is_profile_public,
 		    a.created_at, a.updated_at
 		FROM account a
 		LEFT JOIN account_images ai ON a.id = ai.account_id;`)
@@ -369,6 +369,7 @@ func returnAccounts(ctx context.Context) (*Accounts, error) {
 			&account.HasProfileImage,
 			&account.ImagePositionX,
 			&account.ImagePositionY,
+			&account.IsProfilePublic,
 			&account.CreatedAt,
 			&account.UpdatedAt)
 		if err != nil {
@@ -391,7 +392,7 @@ func findAccountByID(ctx context.Context, id uint) (*Account, error) {
 		`SELECT a.id, a.username, a.email, a.firstname, a.lastname, a.role, a.status,
 		    a.preferred_currency, a.preferred_unit_system, a.youtube_url, a.instagram_url,
 		    CASE WHEN ai.account_id IS NOT NULL THEN true ELSE false END AS has_profile_image,
-		    a.image_position_x, a.image_position_y,
+		    a.image_position_x, a.image_position_y, a.is_profile_public,
 		    a.created_at, a.updated_at
 		FROM account a
 		LEFT JOIN account_images ai ON a.id = ai.account_id
@@ -412,6 +413,7 @@ func findAccountByID(ctx context.Context, id uint) (*Account, error) {
 		&account.HasProfileImage,
 		&account.ImagePositionX,
 		&account.ImagePositionY,
+		&account.IsProfilePublic,
 		&account.CreatedAt,
 		&account.UpdatedAt)
 
@@ -521,18 +523,19 @@ func updateMyAccount(ctx context.Context, userID uint, input *AccountUpdateInput
 	now := time.Now().Truncate(time.Second)
 
 	// Update ONLY safe fields - explicitly excludes role, status, username
-	// COALESCE keeps existing image_position values when client omits them (nil)
+	// COALESCE keeps existing values when client omits them (nil)
 	statement, err := database.DB().PrepareContext(ctx,
 		`UPDATE account
 		 SET email=$1, firstname=$2, lastname=$3, preferred_currency=$4,
 		     preferred_unit_system=$5, youtube_url=$6, instagram_url=$7,
 		     image_position_x=COALESCE($8, image_position_x),
 		     image_position_y=COALESCE($9, image_position_y),
-		     updated_at=$10
-		 WHERE id=$11
+		     is_profile_public=COALESCE($10, is_profile_public),
+		     updated_at=$11
+		 WHERE id=$12
 		 RETURNING id, username, email, firstname, lastname, role, status,
 		           preferred_currency, preferred_unit_system, youtube_url, instagram_url,
-		           image_position_x, image_position_y,
+		           image_position_x, image_position_y, is_profile_public,
 		           created_at, updated_at;`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare statement: %w", err)
@@ -550,6 +553,7 @@ func updateMyAccount(ctx context.Context, userID uint, input *AccountUpdateInput
 		input.InstagramURL,
 		input.ImagePositionX,
 		input.ImagePositionY,
+		input.IsProfilePublic,
 		now,
 		userID,
 	).Scan(
@@ -566,6 +570,7 @@ func updateMyAccount(ctx context.Context, userID uint, input *AccountUpdateInput
 		&account.InstagramURL,
 		&account.ImagePositionX,
 		&account.ImagePositionY,
+		&account.IsProfilePublic,
 		&account.CreatedAt,
 		&account.UpdatedAt,
 	)

--- a/pkg/accounts/accounts_test.go
+++ b/pkg/accounts/accounts_test.go
@@ -1164,6 +1164,111 @@ func testOmittedImagePositionPreserved(t *testing.T, router *gin.Engine, token s
 	}
 }
 
+func TestPutMyAccountIsProfilePublic(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	router.PUT("/v1/myaccount", PutMyAccount)
+	router.GET("/v1/myaccount", GetMyAccount)
+
+	testUser := users[0]
+	token, err := security.GenerateToken(testUser.ID)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	t.Run("Default is_profile_public is false", func(t *testing.T) {
+		testDefaultProfilePublic(t, router, token)
+	})
+	t.Run("Toggle is_profile_public to true", func(t *testing.T) {
+		testSetProfilePublic(t, router, token, testUser, true)
+	})
+	t.Run("Omitting is_profile_public preserves current value", func(t *testing.T) {
+		testOmittedProfilePublicPreserved(t, router, token, testUser)
+	})
+	t.Run("Toggle is_profile_public back to false", func(t *testing.T) {
+		testSetProfilePublic(t, router, token, testUser, false)
+	})
+}
+
+func testDefaultProfilePublic(t *testing.T, router *gin.Engine, token string) {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, "/v1/myaccount", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200 but got %d: %s", w.Code, w.Body.String())
+	}
+
+	var account Account
+	if err := json.Unmarshal(w.Body.Bytes(), &account); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+	if account.IsProfilePublic {
+		t.Error("Expected is_profile_public to be false by default")
+	}
+}
+
+func testSetProfilePublic(
+	t *testing.T, router *gin.Engine, token string, user User, value bool,
+) {
+	t.Helper()
+	input := AccountUpdateInput{
+		Email:           user.Email,
+		Firstname:       user.Firstname,
+		Lastname:        user.Lastname,
+		IsProfilePublic: &value,
+	}
+	jsonData, _ := json.Marshal(input)
+	req, _ := http.NewRequest(http.MethodPut, "/v1/myaccount", bytes.NewBuffer(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200 but got %d: %s", w.Code, w.Body.String())
+	}
+
+	var account Account
+	if err := json.Unmarshal(w.Body.Bytes(), &account); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+	if account.IsProfilePublic != value {
+		t.Errorf("Expected is_profile_public to be %v but got %v", value, account.IsProfilePublic)
+	}
+}
+
+func testOmittedProfilePublicPreserved(
+	t *testing.T, router *gin.Engine, token string, user User,
+) {
+	t.Helper()
+	input := AccountUpdateInput{
+		Email:     user.Email,
+		Firstname: user.Firstname,
+		Lastname:  user.Lastname,
+	}
+	jsonData, _ := json.Marshal(input)
+	req, _ := http.NewRequest(http.MethodPut, "/v1/myaccount", bytes.NewBuffer(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200 but got %d: %s", w.Code, w.Body.String())
+	}
+
+	var account Account
+	if err := json.Unmarshal(w.Body.Bytes(), &account); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+	if !account.IsProfilePublic {
+		t.Error("Expected is_profile_public to remain true when omitted")
+	}
+}
+
 func testImagePositionOutOfRange(t *testing.T, router *gin.Engine, token string, user User) {
 	t.Helper()
 	posX := 150

--- a/pkg/accounts/types.go
+++ b/pkg/accounts/types.go
@@ -18,6 +18,7 @@ type Account struct {
 	HasProfileImage     bool      `json:"has_profile_image"`
 	ImagePositionX      int       `json:"image_position_x"`
 	ImagePositionY      int       `json:"image_position_y"`
+	IsProfilePublic     bool      `json:"is_profile_public"`
 	CreatedAt           time.Time `json:"created_at"`
 	UpdatedAt           time.Time `json:"updated_at"`
 }
@@ -82,6 +83,7 @@ type AccountUpdateInput struct {
 	InstagramURL        *string `json:"instagram_url"`
 	ImagePositionX      *int    `json:"image_position_x"`
 	ImagePositionY      *int    `json:"image_position_y"`
+	IsProfilePublic     *bool   `json:"is_profile_public"`
 }
 
 // ResendConfirmEmailInput represents the data required to resend a confirmation email

--- a/pkg/accounts/types.go
+++ b/pkg/accounts/types.go
@@ -19,6 +19,8 @@ type Account struct {
 	ImagePositionX      int       `json:"image_position_x"`
 	ImagePositionY      int       `json:"image_position_y"`
 	IsProfilePublic     bool      `json:"is_profile_public"`
+	HasBannerImage      bool      `json:"has_banner_image"`
+	BannerPositionY     int       `json:"banner_position_y"`
 	CreatedAt           time.Time `json:"created_at"`
 	UpdatedAt           time.Time `json:"updated_at"`
 }
@@ -84,6 +86,7 @@ type AccountUpdateInput struct {
 	ImagePositionX      *int    `json:"image_position_x"`
 	ImagePositionY      *int    `json:"image_position_y"`
 	IsProfilePublic     *bool   `json:"is_profile_public"`
+	BannerPositionY     *int    `json:"banner_position_y"`
 }
 
 // ResendConfirmEmailInput represents the data required to resend a confirmation email

--- a/pkg/database/migration/migration_scripts/000021_account_is_profile_public.down.sql
+++ b/pkg/database/migration/migration_scripts/000021_account_is_profile_public.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE account DROP COLUMN is_profile_public;

--- a/pkg/database/migration/migration_scripts/000021_account_is_profile_public.up.sql
+++ b/pkg/database/migration/migration_scripts/000021_account_is_profile_public.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE account ADD COLUMN is_profile_public BOOLEAN NOT NULL DEFAULT false;

--- a/pkg/database/migration/migration_scripts/000022_account_banner_images.down.sql
+++ b/pkg/database/migration/migration_scripts/000022_account_banner_images.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE account DROP COLUMN banner_position_y;
+DROP TABLE IF EXISTS account_banner_images;

--- a/pkg/database/migration/migration_scripts/000022_account_banner_images.up.sql
+++ b/pkg/database/migration/migration_scripts/000022_account_banner_images.up.sql
@@ -9,4 +9,4 @@ CREATE TABLE account_banner_images (
     updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
-ALTER TABLE account ADD COLUMN banner_position_y INTEGER NOT NULL DEFAULT 50;
+ALTER TABLE account ADD COLUMN banner_position_y INTEGER NOT NULL DEFAULT 50 CHECK (banner_position_y BETWEEN 0 AND 100);

--- a/pkg/database/migration/migration_scripts/000022_account_banner_images.up.sql
+++ b/pkg/database/migration/migration_scripts/000022_account_banner_images.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE account_banner_images (
+    account_id INTEGER PRIMARY KEY REFERENCES account(id) ON DELETE CASCADE,
+    image_data BYTEA NOT NULL,
+    mime_type VARCHAR(50) NOT NULL DEFAULT 'image/jpeg',
+    file_size INTEGER NOT NULL,
+    width INTEGER NOT NULL,
+    height INTEGER NOT NULL,
+    uploaded_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE account ADD COLUMN banner_position_y INTEGER NOT NULL DEFAULT 50;

--- a/pkg/images/handlers_account.go
+++ b/pkg/images/handlers_account.go
@@ -1,8 +1,8 @@
 package images
 
 import (
+	"context"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/Angak0k/pimpmypack/pkg/helper"
@@ -12,29 +12,74 @@ import (
 
 var accountStorage AccountImageStorage = NewDBAccountImageStorage()
 
-// processUploadedProfileImage handles file validation and profile image processing
-func processUploadedProfileImage(c *gin.Context) (*ProcessedImage, error) {
-	file, err := c.FormFile("image")
+// handleImageProcessingError sends the appropriate HTTP error response for image processing errors
+func handleImageProcessingError(c *gin.Context, err error, context string) {
+	if errors.Is(err, ErrInvalidFormat) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid image format. Only JPEG, PNG, and WebP are supported",
+		})
+		return
+	}
+	if errors.Is(err, ErrTooLarge) {
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{
+			"error": "File size exceeds maximum allowed",
+		})
+		return
+	}
+	if errors.Is(err, ErrCorrupted) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Corrupted or invalid image file"})
+		return
+	}
+	if err.Error() == ErrMsgNoImageProvided {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "No image file provided"})
+		return
+	}
+	helper.LogAndSanitize(err, context+": process image failed")
+	c.JSON(http.StatusBadRequest, gin.H{"error": helper.ErrMsgBadRequest})
+}
+
+// imageSaver abstracts the Save method shared by storage interfaces
+type imageSaver interface {
+	Save(ctx context.Context, id uint, data []byte, metadata ImageMetadata) error
+}
+
+// uploadUserImage handles the common upload flow: extract token, process, save, respond
+func uploadUserImage(
+	c *gin.Context,
+	store imageSaver,
+	processor imageProcessorFunc,
+	logPrefix string,
+	successMsg string,
+) {
+	ctx := c.Request.Context()
+
+	userID, err := security.ExtractTokenID(c)
 	if err != nil {
-		return nil, errors.New(ErrMsgNoImageProvided)
+		helper.LogAndSanitize(err, logPrefix+": extract token ID failed")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": helper.ErrMsgUnauthorized})
+		return
 	}
 
-	if file.Size > MaxUploadSize {
-		return nil, fmt.Errorf("%w: file size exceeds maximum allowed (%d bytes)", ErrTooLarge, MaxUploadSize)
-	}
-
-	fileReader, err := file.Open()
+	processed, err := processUploadedImageWith(c, processor)
 	if err != nil {
-		return nil, errors.New("failed to read uploaded file")
+		handleImageProcessingError(c, err, logPrefix)
+		return
 	}
-	defer fileReader.Close()
 
-	processed, err := ProcessProfileImageFromReader(fileReader)
+	err = store.Save(ctx, userID, processed.Data, processed.Metadata)
 	if err != nil {
-		return nil, err
+		helper.LogAndSanitize(err, logPrefix+": save image failed")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save image"})
+		return
 	}
 
-	return processed, nil
+	c.JSON(http.StatusOK, gin.H{
+		"message":   successMsg,
+		"mime_type": processed.Metadata.MimeType,
+		"file_size": processed.Metadata.FileSize,
+		"width":     processed.Metadata.Width,
+		"height":    processed.Metadata.Height,
+	})
 }
 
 // UploadMyProfileImage uploads or updates the profile image for the current user
@@ -52,52 +97,8 @@ func processUploadedProfileImage(c *gin.Context) (*ProcessedImage, error) {
 // @Failure 500 {object} map[string]string "Internal server error"
 // @Router /v1/myaccount/image [post]
 func UploadMyProfileImage(c *gin.Context) {
-	ctx := c.Request.Context()
-
-	userID, err := security.ExtractTokenID(c)
-	if err != nil {
-		helper.LogAndSanitize(err, "upload profile image: extract token ID failed")
-		c.JSON(http.StatusUnauthorized, gin.H{"error": helper.ErrMsgUnauthorized})
-		return
-	}
-
-	processed, err := processUploadedProfileImage(c)
-	if err != nil {
-		if errors.Is(err, ErrInvalidFormat) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid image format. Only JPEG, PNG, and WebP are supported"})
-			return
-		}
-		if errors.Is(err, ErrTooLarge) {
-			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "File size exceeds maximum allowed"})
-			return
-		}
-		if errors.Is(err, ErrCorrupted) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Corrupted or invalid image file"})
-			return
-		}
-		if err.Error() == ErrMsgNoImageProvided {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "No image file provided"})
-			return
-		}
-		helper.LogAndSanitize(err, "upload profile image: process image failed")
-		c.JSON(http.StatusBadRequest, gin.H{"error": helper.ErrMsgBadRequest})
-		return
-	}
-
-	err = accountStorage.Save(ctx, userID, processed.Data, processed.Metadata)
-	if err != nil {
-		helper.LogAndSanitize(err, "upload profile image: save image failed")
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save image"})
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"message":   "Profile image uploaded successfully",
-		"mime_type": processed.Metadata.MimeType,
-		"file_size": processed.Metadata.FileSize,
-		"width":     processed.Metadata.Width,
-		"height":    processed.Metadata.Height,
-	})
+	uploadUserImage(c, accountStorage, ProcessProfileImageFromReader,
+		"upload profile image", "Profile image uploaded successfully")
 }
 
 // DeleteMyProfileImage deletes the profile image for the current user

--- a/pkg/images/handlers_banner.go
+++ b/pkg/images/handlers_banner.go
@@ -1,0 +1,97 @@
+package images
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/Angak0k/pimpmypack/pkg/helper"
+	"github.com/Angak0k/pimpmypack/pkg/security"
+	"github.com/gin-gonic/gin"
+)
+
+var bannerStorage BannerImageStorage = NewDBBannerImageStorage()
+
+// UploadMyBannerImage uploads or updates the banner image for the current user
+// @Summary Upload or update banner image
+// @Description Upload or update the banner/hero image for the currently logged-in user
+// @Security Bearer
+// @Tags Account Images
+// @Accept multipart/form-data
+// @Produce json
+// @Param image formData file true "Image file (JPEG, PNG, or WebP, max 5MB)"
+// @Success 200 {object} map[string]interface{} "Banner image uploaded successfully"
+// @Failure 400 {object} map[string]string "Invalid request or image"
+// @Failure 401 {object} map[string]string "Unauthorized"
+// @Failure 413 {object} map[string]string "Payload too large"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /v1/myaccount/banner [post]
+func UploadMyBannerImage(c *gin.Context) {
+	uploadUserImage(c, bannerStorage, ProcessBannerImageFromReader,
+		"upload banner image", "Banner image uploaded successfully")
+}
+
+// DeleteMyBannerImage deletes the banner image for the current user
+// @Summary Delete banner image
+// @Description Delete the banner/hero image for the currently logged-in user
+// @Security Bearer
+// @Tags Account Images
+// @Produce json
+// @Success 200 {object} map[string]interface{} "Banner image deleted successfully"
+// @Failure 401 {object} map[string]string "Unauthorized"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /v1/myaccount/banner [delete]
+func DeleteMyBannerImage(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	userID, err := security.ExtractTokenID(c)
+	if err != nil {
+		helper.LogAndSanitize(err, "delete banner image: extract token ID failed")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": helper.ErrMsgUnauthorized})
+		return
+	}
+
+	err = bannerStorage.Delete(ctx, userID)
+	if err != nil {
+		helper.LogAndSanitize(err, "delete banner image: delete image failed")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete image"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Banner image deleted successfully",
+	})
+}
+
+// GetBannerImage retrieves the banner image for a given account
+// @Summary Get banner image
+// @Description Get the banner/hero image for a user account
+// @Tags Account Images
+// @Produce image/jpeg
+// @Param id path int true "Account ID"
+// @Success 200 {file} image/jpeg "Banner image"
+// @Failure 400 {string} string "Invalid account ID"
+// @Failure 404 {string} string "No banner image found"
+// @Failure 500 {string} string "Internal server error"
+// @Router /v1/accounts/{id}/banner [get]
+func GetBannerImage(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	accountID, err := helper.StringToUint(c.Param("id"))
+	if err != nil {
+		c.String(http.StatusBadRequest, "Invalid account ID format")
+		return
+	}
+
+	img, err := bannerStorage.Get(ctx, accountID)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			c.String(http.StatusNotFound, "No banner image found")
+			return
+		}
+		c.String(http.StatusInternalServerError, "Failed to retrieve image")
+		return
+	}
+
+	c.Header("Cache-Control", "public, max-age=86400")
+	c.Data(http.StatusOK, img.Metadata.MimeType, img.Data)
+}

--- a/pkg/images/processor.go
+++ b/pkg/images/processor.go
@@ -26,6 +26,10 @@ const (
 	JPEGQuality = 85
 	// InventoryItemJPEGQuality is the quality setting for inventory item images (0-100)
 	InventoryItemJPEGQuality = 70
+	// MaxBannerWidth is the maximum width for banner images
+	MaxBannerWidth = 1920
+	// MaxBannerHeight is the maximum height for banner images
+	MaxBannerHeight = 600
 	// MimeTypeJPEG is the MIME type for JPEG images
 	MimeTypeJPEG = "image/jpeg"
 	// MimeTypePNG is the MIME type for PNG images
@@ -298,4 +302,80 @@ func ProcessInventoryItemImageFromReader(reader io.Reader) (*ProcessedImage, err
 	}
 
 	return ProcessInventoryItemImage(data)
+}
+
+// ResizeBannerImage resizes an image to fit within MaxBannerWidth x MaxBannerHeight
+func ResizeBannerImage(img image.Image) image.Image {
+	bounds := img.Bounds()
+	width := bounds.Dx()
+	height := bounds.Dy()
+
+	if width <= MaxBannerWidth && height <= MaxBannerHeight {
+		return img
+	}
+
+	// Scale down to fit within both width and height constraints
+	scaleW := float64(MaxBannerWidth) / float64(width)
+	scaleH := float64(MaxBannerHeight) / float64(height)
+	scale := min(scaleW, scaleH)
+
+	newWidth := max(1, int(float64(width)*scale))
+	newHeight := max(1, int(float64(height)*scale))
+
+	dst := image.NewRGBA(image.Rect(0, 0, newWidth, newHeight))
+	draw.CatmullRom.Scale(dst, dst.Rect, img, bounds, draw.Over, nil)
+
+	return dst
+}
+
+// ProcessBannerImage validates and processes an uploaded banner image
+func ProcessBannerImage(data []byte) (*ProcessedImage, error) {
+	if len(data) > MaxUploadSize {
+		return nil, fmt.Errorf("%w: upload size %d exceeds %d bytes",
+			ErrTooLarge, len(data), MaxUploadSize)
+	}
+
+	_, err := ValidateImageFormat(data)
+	if err != nil {
+		return nil, err
+	}
+
+	img, err := DecodeImage(data)
+	if err != nil {
+		return nil, err
+	}
+
+	img = ResizeBannerImage(img)
+
+	processedData, err := EncodeToJPEG(img)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(processedData) > MaxProcessedSize {
+		return nil, fmt.Errorf("%w: processed size %d exceeds %d bytes",
+			ErrTooLarge, len(processedData), MaxProcessedSize)
+	}
+
+	bounds := img.Bounds()
+
+	return &ProcessedImage{
+		Data: processedData,
+		Metadata: ImageMetadata{
+			MimeType: MimeTypeJPEG,
+			FileSize: len(processedData),
+			Width:    bounds.Dx(),
+			Height:   bounds.Dy(),
+		},
+	}, nil
+}
+
+// ProcessBannerImageFromReader processes a banner image from an io.Reader
+func ProcessBannerImageFromReader(reader io.Reader) (*ProcessedImage, error) {
+	data, err := io.ReadAll(io.LimitReader(reader, MaxUploadSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read image data: %w", err)
+	}
+
+	return ProcessBannerImage(data)
 }

--- a/pkg/images/storage_db.go
+++ b/pkg/images/storage_db.go
@@ -119,3 +119,8 @@ func NewDBAccountImageStorage() *DBStorage {
 func NewDBInventoryImageStorage() *DBStorage {
 	return &DBStorage{store: dbImageStore{table: "inventory_images", idColumn: "item_id"}}
 }
+
+// NewDBBannerImageStorage creates a new database banner image storage instance
+func NewDBBannerImageStorage() *DBStorage {
+	return &DBStorage{store: dbImageStore{table: "account_banner_images", idColumn: "account_id"}}
+}

--- a/pkg/images/types.go
+++ b/pkg/images/types.go
@@ -76,6 +76,23 @@ type AccountImageStorage interface {
 	Exists(ctx context.Context, accountID uint) (bool, error)
 }
 
+// BannerImageStorage defines the interface for account banner image storage operations
+type BannerImageStorage interface {
+	// Save stores a banner image for an account
+	Save(ctx context.Context, accountID uint, data []byte, metadata ImageMetadata) error
+
+	// Get retrieves a banner image for an account
+	// Returns ErrNotFound if the image doesn't exist
+	Get(ctx context.Context, accountID uint) (*Image, error)
+
+	// Delete removes a banner image for an account
+	// Returns nil if the image doesn't exist (idempotent)
+	Delete(ctx context.Context, accountID uint) error
+
+	// Exists checks if a banner image exists for an account
+	Exists(ctx context.Context, accountID uint) (bool, error)
+}
+
 // InventoryImageStorage defines the interface for inventory item image storage operations
 type InventoryImageStorage interface {
 	// Save stores an image for an inventory item

--- a/pkg/profiles/handlers.go
+++ b/pkg/profiles/handlers.go
@@ -1,0 +1,46 @@
+package profiles
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/Angak0k/pimpmypack/pkg/helper"
+	"github.com/gin-gonic/gin"
+)
+
+// GetPublicProfile returns the public profile and shared packs for a username
+// @Summary Get public user profile
+// @Description Returns public profile information and shared packs for a user.
+// @Description Returns 404 for non-existent users or users without a public profile (anti-enumeration).
+// @Tags Profiles
+// @Produce json
+// @Param username path string true "Username"
+// @Success 200 {object} PublicProfile
+// @Failure 404 {object} apitypes.ErrorResponse "Profile not found"
+// @Failure 500 {object} apitypes.ErrorResponse "Internal Server Error"
+// @Router /user/{username} [get]
+func GetPublicProfile(c *gin.Context) {
+	username := c.Param("username")
+
+	profile, err := returnPublicProfileByUsername(c.Request.Context(), username)
+	if err != nil {
+		if errors.Is(err, ErrProfileNotFound) {
+			c.IndentedJSON(http.StatusNotFound, gin.H{"error": "Profile not found"})
+			return
+		}
+		helper.LogAndSanitize(err, "get public profile: fetch profile failed")
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	sharedPacks, err := returnSharedPacksByUsername(c.Request.Context(), username)
+	if err != nil {
+		helper.LogAndSanitize(err, "get public profile: fetch shared packs failed")
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	profile.SharedPacks = sharedPacks
+
+	c.IndentedJSON(http.StatusOK, profile)
+}

--- a/pkg/profiles/profiles_test.go
+++ b/pkg/profiles/profiles_test.go
@@ -1,0 +1,325 @@
+package profiles
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Angak0k/pimpmypack/pkg/config"
+	"github.com/Angak0k/pimpmypack/pkg/database"
+	"github.com/Angak0k/pimpmypack/pkg/security"
+	"github.com/gin-gonic/gin"
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+// test data IDs populated during setup
+var (
+	publicUserID    uint
+	privateUserID   uint
+	publicUsername  string
+	privateUsername string
+	sharedPackID    uint
+	privatePackID   uint
+)
+
+func TestMain(m *testing.M) {
+	err := config.EnvInit("../../.env")
+	if err != nil {
+		log.Fatalf("Error loading .env file: %v", err)
+	}
+
+	err = database.Initialization()
+	if err != nil {
+		log.Fatalf("Error connecting database: %v", err)
+	}
+
+	err = database.Migrate()
+	if err != nil {
+		log.Fatalf("Error migrating database: %v", err)
+	}
+
+	println("Loading profiles test dataset...")
+	err = loadingProfileDataset()
+	if err != nil {
+		log.Fatalf("Error loading dataset: %v", err)
+	}
+
+	ret := m.Run()
+
+	println("Cleaning up profiles test data...")
+	err = cleanupProfileDataset()
+	if err != nil {
+		log.Printf("Warning: Error cleaning up dataset: %v", err)
+	}
+
+	os.Exit(ret)
+}
+
+func loadingProfileDataset() error {
+	ctx := context.Background()
+	now := time.Now().Truncate(time.Second)
+
+	publicUsername = "pub-" + random.UniqueId()
+	privateUsername = "priv-" + random.UniqueId()
+
+	// Create public user (is_profile_public = true)
+	err := database.DB().QueryRowContext(ctx,
+		`INSERT INTO account (username, email, firstname, lastname, role, status,
+			is_profile_public, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9) RETURNING id;`,
+		publicUsername, publicUsername+"@test.com", "Public", "User",
+		"standard", "active", true, now, now,
+	).Scan(&publicUserID)
+	if err != nil {
+		return fmt.Errorf("failed to insert public user: %w", err)
+	}
+
+	hashedPassword, err := security.HashPassword("password")
+	if err != nil {
+		return fmt.Errorf("failed to hash password: %w", err)
+	}
+	var pwID int
+	err = database.DB().QueryRowContext(ctx,
+		`INSERT INTO password (user_id, password, updated_at) VALUES ($1,$2,$3) RETURNING id;`,
+		publicUserID, hashedPassword, now,
+	).Scan(&pwID)
+	if err != nil {
+		return fmt.Errorf("failed to insert password for public user: %w", err)
+	}
+
+	// Create private user (is_profile_public = false, default)
+	err = database.DB().QueryRowContext(ctx,
+		`INSERT INTO account (username, email, firstname, lastname, role, status,
+			created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING id;`,
+		privateUsername, privateUsername+"@test.com", "Private", "User",
+		"standard", "active", now, now,
+	).Scan(&privateUserID)
+	if err != nil {
+		return fmt.Errorf("failed to insert private user: %w", err)
+	}
+
+	err = database.DB().QueryRowContext(ctx,
+		`INSERT INTO password (user_id, password, updated_at) VALUES ($1,$2,$3) RETURNING id;`,
+		privateUserID, hashedPassword, now,
+	).Scan(&pwID)
+	if err != nil {
+		return fmt.Errorf("failed to insert password for private user: %w", err)
+	}
+
+	// Create inventory item for public user
+	var itemID uint
+	err = database.DB().QueryRowContext(ctx,
+		`INSERT INTO inventory (user_id, item_name, category, description,
+			weight, url, price, currency, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) RETURNING id;`,
+		publicUserID, "Backpack", "Gear", "Test backpack", 1000, "https://example.com", 100, "USD", now, now,
+	).Scan(&itemID)
+	if err != nil {
+		return fmt.Errorf("failed to insert inventory item: %w", err)
+	}
+
+	// Create shared pack for public user
+	sharingCode := "profile-test-" + random.UniqueId()
+	err = database.DB().QueryRowContext(ctx,
+		`INSERT INTO pack (user_id, pack_name, pack_description, sharing_code, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6) RETURNING id;`,
+		publicUserID, "Shared Pack", "A shared pack", sharingCode, now, now,
+	).Scan(&sharedPackID)
+	if err != nil {
+		return fmt.Errorf("failed to insert shared pack: %w", err)
+	}
+
+	// Add item to shared pack
+	var pcID uint
+	err = database.DB().QueryRowContext(ctx,
+		`INSERT INTO pack_content (pack_id, item_id, quantity, worn, consumable, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING id;`,
+		sharedPackID, itemID, 1, false, false, now, now,
+	).Scan(&pcID)
+	if err != nil {
+		return fmt.Errorf("failed to insert pack content: %w", err)
+	}
+
+	// Create private pack (no sharing_code) for public user
+	err = database.DB().QueryRowContext(ctx,
+		`INSERT INTO pack (user_id, pack_name, pack_description, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5) RETURNING id;`,
+		publicUserID, "Private Pack", "A private pack", now, now,
+	).Scan(&privatePackID)
+	if err != nil {
+		return fmt.Errorf("failed to insert private pack: %w", err)
+	}
+
+	return nil
+}
+
+func cleanupProfileDataset() error {
+	ctx := context.Background()
+
+	for _, id := range []uint{publicUserID, privateUserID} {
+		if id != 0 {
+			_, err := database.DB().ExecContext(ctx, "DELETE FROM account WHERE id = $1", id)
+			if err != nil {
+				return fmt.Errorf("failed to delete user %d: %w", id, err)
+			}
+		}
+	}
+	return nil
+}
+
+func TestGetPublicProfile_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	router.GET("/user/:username", GetPublicProfile)
+
+	req, err := http.NewRequest(http.MethodGet, "/user/"+publicUsername, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var profile PublicProfile
+	if err := json.Unmarshal(w.Body.Bytes(), &profile); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	if profile.Username != publicUsername {
+		t.Errorf("Expected username %s, got %s", publicUsername, profile.Username)
+	}
+
+	if profile.Firstname != "Public" {
+		t.Errorf("Expected firstname 'Public', got %s", profile.Firstname)
+	}
+
+	// Should have exactly 1 shared pack (private pack excluded)
+	if len(profile.SharedPacks) != 1 {
+		t.Fatalf("Expected 1 shared pack, got %d", len(profile.SharedPacks))
+	}
+
+	if profile.SharedPacks[0].PackName != "Shared Pack" {
+		t.Errorf("Expected pack name 'Shared Pack', got %s", profile.SharedPacks[0].PackName)
+	}
+
+	if profile.SharedPacks[0].PackItemsCount != 1 {
+		t.Errorf("Expected 1 item in pack, got %d", profile.SharedPacks[0].PackItemsCount)
+	}
+
+	if profile.SharedPacks[0].PackWeight != 1000 {
+		t.Errorf("Expected pack weight 1000, got %d", profile.SharedPacks[0].PackWeight)
+	}
+}
+
+func TestGetPublicProfile_NonExistentUser(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	router.GET("/user/:username", GetPublicProfile)
+
+	req, err := http.NewRequest(http.MethodGet, "/user/nonexistent-user-xyz", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status %d, got %d", http.StatusNotFound, w.Code)
+	}
+}
+
+func TestGetPublicProfile_PrivateUser(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	router.GET("/user/:username", GetPublicProfile)
+
+	req, err := http.NewRequest(http.MethodGet, "/user/"+privateUsername, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Should return 404 (anti-enumeration: same as non-existent user)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status %d for private user, got %d", http.StatusNotFound, w.Code)
+	}
+}
+
+func TestGetPublicProfile_NoSharedPacks(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().Truncate(time.Second)
+
+	// Create a public user with no shared packs
+	username := "nopacks-" + random.UniqueId()
+	var userID uint
+	err := database.DB().QueryRowContext(ctx,
+		`INSERT INTO account (username, email, firstname, lastname, role, status,
+			is_profile_public, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9) RETURNING id;`,
+		username, username+"@test.com", "NoPack", "User",
+		"standard", "active", true, now, now,
+	).Scan(&userID)
+	if err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+
+	hashedPassword, err := security.HashPassword("password")
+	if err != nil {
+		t.Fatalf("Failed to hash password: %v", err)
+	}
+	var pwID int
+	err = database.DB().QueryRowContext(ctx,
+		`INSERT INTO password (user_id, password, updated_at) VALUES ($1,$2,$3) RETURNING id;`,
+		userID, hashedPassword, now,
+	).Scan(&pwID)
+	if err != nil {
+		t.Fatalf("Failed to insert password: %v", err)
+	}
+
+	defer func() {
+		_, _ = database.DB().ExecContext(ctx, "DELETE FROM account WHERE id = $1", userID)
+	}()
+
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	router.GET("/user/:username", GetPublicProfile)
+
+	req, err := http.NewRequest(http.MethodGet, "/user/"+username, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var profile PublicProfile
+	if err := json.Unmarshal(w.Body.Bytes(), &profile); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	// Should return empty array, not null
+	if profile.SharedPacks == nil {
+		t.Error("Expected empty array for shared_packs, got nil")
+	}
+	if len(profile.SharedPacks) != 0 {
+		t.Errorf("Expected 0 shared packs, got %d", len(profile.SharedPacks))
+	}
+}

--- a/pkg/profiles/repository.go
+++ b/pkg/profiles/repository.go
@@ -1,0 +1,107 @@
+package profiles
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/Angak0k/pimpmypack/pkg/database"
+)
+
+// ErrProfileNotFound is returned when a public profile is not found
+// (user doesn't exist, is not active, or has not enabled public profile)
+var ErrProfileNotFound = errors.New("public profile not found")
+
+// returnPublicProfileByUsername fetches the public profile for a user.
+// Returns ErrProfileNotFound if the user doesn't exist, is not active,
+// or has is_profile_public = false (anti-enumeration: same error for all cases).
+func returnPublicProfileByUsername(ctx context.Context, username string) (*PublicProfile, error) {
+	var profile PublicProfile
+
+	err := database.DB().QueryRowContext(ctx,
+		`SELECT a.username, a.firstname, a.youtube_url, a.instagram_url,
+		    CASE WHEN ai.account_id IS NOT NULL THEN true ELSE false END AS has_profile_image,
+		    a.image_position_x, a.image_position_y
+		FROM account a
+		LEFT JOIN account_images ai ON a.id = ai.account_id
+		WHERE a.username = $1 AND a.status = 'active' AND a.is_profile_public = true;`,
+		username,
+	).Scan(
+		&profile.Username,
+		&profile.Firstname,
+		&profile.YoutubeURL,
+		&profile.InstagramURL,
+		&profile.HasProfileImage,
+		&profile.ImagePositionX,
+		&profile.ImagePositionY,
+	)
+
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrProfileNotFound
+		}
+		return nil, fmt.Errorf("failed to fetch public profile: %w", err)
+	}
+
+	return &profile, nil
+}
+
+// returnSharedPacksByUsername fetches all shared packs for a given username.
+// Only returns packs with a non-NULL sharing_code.
+func returnSharedPacksByUsername(ctx context.Context, username string) ([]SharedPackSummary, error) {
+	rows, err := database.DB().QueryContext(ctx, `
+		SELECT p.id, p.pack_name, p.pack_description,
+		    CASE WHEN pi.pack_id IS NOT NULL THEN true ELSE false END AS has_image,
+		    COALESCE(SUM(i.weight * pc.quantity), 0) AS pack_weight,
+		    COALESCE(SUM(pc.quantity), 0) AS pack_items_count,
+		    p.sharing_code, p.season, p.trail, p.adventure, p.created_at
+		FROM pack p
+		JOIN account a ON p.user_id = a.id
+		LEFT JOIN pack_content pc ON p.id = pc.pack_id
+		LEFT JOIN inventory i ON pc.item_id = i.id
+		LEFT JOIN pack_images pi ON p.id = pi.pack_id
+		WHERE a.username = $1 AND p.sharing_code IS NOT NULL
+		GROUP BY p.id, p.pack_name, p.pack_description, p.sharing_code,
+		         pi.pack_id, p.season, p.trail, p.adventure, p.created_at
+		ORDER BY p.created_at DESC;`,
+		username,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch shared packs: %w", err)
+	}
+	defer rows.Close()
+
+	var packs []SharedPackSummary
+	for rows.Next() {
+		var pack SharedPackSummary
+		err := rows.Scan(
+			&pack.ID,
+			&pack.PackName,
+			&pack.PackDescription,
+			&pack.HasImage,
+			&pack.PackWeight,
+			&pack.PackItemsCount,
+			&pack.SharingCode,
+			&pack.Season,
+			&pack.Trail,
+			&pack.Adventure,
+			&pack.CreatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan shared pack: %w", err)
+		}
+		packs = append(packs, pack)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows iteration error: %w", err)
+	}
+
+	// Return empty slice instead of nil for consistent JSON output
+	if packs == nil {
+		packs = []SharedPackSummary{}
+	}
+
+	return packs, nil
+}

--- a/pkg/profiles/repository.go
+++ b/pkg/profiles/repository.go
@@ -61,7 +61,10 @@ func returnSharedPacksByUsername(ctx context.Context, username string) ([]Shared
 		LEFT JOIN pack_content pc ON p.id = pc.pack_id
 		LEFT JOIN inventory i ON pc.item_id = i.id
 		LEFT JOIN pack_images pi ON p.id = pi.pack_id
-		WHERE a.username = $1 AND p.sharing_code IS NOT NULL
+		WHERE a.username = $1
+		  AND a.status = 'active'
+		  AND a.is_profile_public = true
+		  AND p.sharing_code IS NOT NULL
 		GROUP BY p.id, p.pack_name, p.pack_description, p.sharing_code,
 		         pi.pack_id, p.season, p.trail, p.adventure, p.created_at
 		ORDER BY p.created_at DESC;`,

--- a/pkg/profiles/repository.go
+++ b/pkg/profiles/repository.go
@@ -22,9 +22,12 @@ func returnPublicProfileByUsername(ctx context.Context, username string) (*Publi
 	err := database.DB().QueryRowContext(ctx,
 		`SELECT a.username, a.firstname, a.youtube_url, a.instagram_url,
 		    CASE WHEN ai.account_id IS NOT NULL THEN true ELSE false END AS has_profile_image,
-		    a.image_position_x, a.image_position_y
+		    a.image_position_x, a.image_position_y,
+		    CASE WHEN abi.account_id IS NOT NULL THEN true ELSE false END AS has_banner_image,
+		    a.banner_position_y
 		FROM account a
 		LEFT JOIN account_images ai ON a.id = ai.account_id
+		LEFT JOIN account_banner_images abi ON a.id = abi.account_id
 		WHERE a.username = $1 AND a.status = 'active' AND a.is_profile_public = true;`,
 		username,
 	).Scan(
@@ -35,6 +38,8 @@ func returnPublicProfileByUsername(ctx context.Context, username string) (*Publi
 		&profile.HasProfileImage,
 		&profile.ImagePositionX,
 		&profile.ImagePositionY,
+		&profile.HasBannerImage,
+		&profile.BannerPositionY,
 	)
 
 	if err != nil {

--- a/pkg/profiles/repository.go
+++ b/pkg/profiles/repository.go
@@ -20,7 +20,7 @@ func returnPublicProfileByUsername(ctx context.Context, username string) (*Publi
 	var profile PublicProfile
 
 	err := database.DB().QueryRowContext(ctx,
-		`SELECT a.username, a.firstname, a.youtube_url, a.instagram_url,
+		`SELECT a.id, a.username, a.firstname, a.youtube_url, a.instagram_url,
 		    CASE WHEN ai.account_id IS NOT NULL THEN true ELSE false END AS has_profile_image,
 		    a.image_position_x, a.image_position_y,
 		    CASE WHEN abi.account_id IS NOT NULL THEN true ELSE false END AS has_banner_image,
@@ -31,6 +31,7 @@ func returnPublicProfileByUsername(ctx context.Context, username string) (*Publi
 		WHERE a.username = $1 AND a.status = 'active' AND a.is_profile_public = true;`,
 		username,
 	).Scan(
+		&profile.AccountID,
 		&profile.Username,
 		&profile.Firstname,
 		&profile.YoutubeURL,

--- a/pkg/profiles/types.go
+++ b/pkg/profiles/types.go
@@ -9,6 +9,8 @@ type PublicProfile struct {
 	HasProfileImage bool                `json:"has_profile_image"`
 	ImagePositionX  int                 `json:"image_position_x"`
 	ImagePositionY  int                 `json:"image_position_y"`
+	HasBannerImage  bool                `json:"has_banner_image"`
+	BannerPositionY int                 `json:"banner_position_y"`
 	YoutubeURL      *string             `json:"youtube_url,omitempty"`
 	InstagramURL    *string             `json:"instagram_url,omitempty"`
 	SharedPacks     []SharedPackSummary `json:"shared_packs"`

--- a/pkg/profiles/types.go
+++ b/pkg/profiles/types.go
@@ -4,6 +4,7 @@ import "time"
 
 // PublicProfile represents the public-facing user profile
 type PublicProfile struct {
+	AccountID       uint                `json:"account_id"`
 	Username        string              `json:"username"`
 	Firstname       string              `json:"firstname"`
 	HasProfileImage bool                `json:"has_profile_image"`

--- a/pkg/profiles/types.go
+++ b/pkg/profiles/types.go
@@ -1,0 +1,30 @@
+package profiles
+
+import "time"
+
+// PublicProfile represents the public-facing user profile
+type PublicProfile struct {
+	Username        string              `json:"username"`
+	Firstname       string              `json:"firstname"`
+	HasProfileImage bool                `json:"has_profile_image"`
+	ImagePositionX  int                 `json:"image_position_x"`
+	ImagePositionY  int                 `json:"image_position_y"`
+	YoutubeURL      *string             `json:"youtube_url,omitempty"`
+	InstagramURL    *string             `json:"instagram_url,omitempty"`
+	SharedPacks     []SharedPackSummary `json:"shared_packs"`
+}
+
+// SharedPackSummary represents a shared pack in a public profile
+type SharedPackSummary struct {
+	ID              uint      `json:"id"`
+	PackName        string    `json:"pack_name"`
+	PackDescription string    `json:"pack_description"`
+	HasImage        bool      `json:"has_image"`
+	PackWeight      int       `json:"pack_weight"`
+	PackItemsCount  int       `json:"pack_items_count"`
+	SharingCode     string    `json:"sharing_code"`
+	Season          *string   `json:"season,omitempty"`
+	Trail           *string   `json:"trail,omitempty"`
+	Adventure       *string   `json:"adventure,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+}


### PR DESCRIPTION
## Summary

Add public user profile page and banner/hero image support for the upcoming PackWizard-style profile feature.

### Public Profile Endpoint
- Add `GET /api/user/:username` public endpoint returning user profile and shared packs
- Add `is_profile_public` boolean field to accounts (opt-in, default false)
- Anti-enumeration: non-existent and non-public users both return 404
- Only packs with a `sharing_code` appear in the profile response
- New `pkg/profiles` package with handler, repository, types, and tests

### Banner/Hero Image
- Add `POST/DELETE /api/v1/myaccount/banner` for upload/delete (JWT required)
- Add `GET /api/v1/accounts/:id/banner` public endpoint to serve banner images
- New `account_banner_images` table (same BYTEA pattern as other images)
- Banner images resized to max 1920x600, converted to JPEG @ quality 85
- Add `banner_position_y` field (0-100) on accounts for vertical crop positioning
- Refactor image upload handlers to eliminate code duplication

### Account Changes
- Add `is_profile_public`, `has_banner_image`, `banner_position_y` to Account model
- All fields use COALESCE pattern for optional updates (omit = preserve current value)
- Validation: `banner_position_y` must be between 0 and 100

Relates to #188 (frontend work still needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)