### PR TITLE
refactor: wire rate limiter window config and dynamic retry_after

### DIFF
--- a/main.go
+++ b/main.go
@@ -111,17 +111,21 @@ func setupPublicRoutes(router *gin.Engine) {
 	public.POST("/register", accounts.Register)
 	public.POST("/login", accounts.Login)
 	public.POST("/auth/refresh",
-		security.RefreshRateLimiter(
+		security.NewEndpointRateLimiter(
+			"/auth/refresh",
 			config.RefreshRateLimitRequests,
 			config.RefreshRateLimitRequests,
+			config.RefreshRateLimitWindowMinutes,
 		),
 		security.RefreshTokenHandler)
 	public.GET("/confirmemail", accounts.ConfirmEmail)
 	public.POST("/forgotpassword", accounts.ForgotPassword)
 	public.POST("/resend-confirmemail",
-		security.ResendConfirmRateLimiter(
+		security.NewEndpointRateLimiter(
+			"/resend-confirmemail",
 			config.ResendConfirmRateLimitRequests,
 			config.ResendConfirmRateLimitRequests,
+			config.ResendConfirmRateLimitWindowMinutes,
 		),
 		accounts.ResendConfirmEmail)
 	public.GET("/sharedlist/:sharing_code", packs.SharedList)

--- a/pkg/security/rate_limiter.go
+++ b/pkg/security/rate_limiter.go
@@ -11,17 +11,20 @@ import (
 
 // IPRateLimiter manages rate limiters per IP address
 type IPRateLimiter struct {
-	limiters sync.Map // map[string]*rate.Limiter
-	rate     rate.Limit
-	burst    int
+	limiters      sync.Map // map[string]*rate.Limiter
+	rate          rate.Limit
+	burst         int
+	windowMinutes int
 }
 
 // NewIPRateLimiter creates a new IP-based rate limiter
-func NewIPRateLimiter(requestsPerMinute, burstSize int) *IPRateLimiter {
-	r := rate.Every(time.Minute / time.Duration(requestsPerMinute))
+func NewIPRateLimiter(requestsPerWindow, burstSize, windowMinutes int) *IPRateLimiter {
+	window := time.Duration(windowMinutes) * time.Minute
+	r := rate.Every(window / time.Duration(requestsPerWindow))
 	return &IPRateLimiter{
-		rate:  r,
-		burst: burstSize,
+		rate:          r,
+		burst:         burstSize,
+		windowMinutes: windowMinutes,
 	}
 }
 
@@ -40,39 +43,23 @@ func (rl *IPRateLimiter) GetLimiter(ip string) *rate.Limiter {
 	return rateLimiter
 }
 
-// RefreshRateLimiter creates a rate limiting middleware for /auth/refresh endpoint
-func RefreshRateLimiter(requestsPerMinute, burstSize int) gin.HandlerFunc {
-	limiter := NewIPRateLimiter(requestsPerMinute, burstSize)
-
-	return func(c *gin.Context) {
-		clientIP := c.ClientIP()
-
-		if !limiter.GetLimiter(clientIP).Allow() {
-			AuditRateLimitExceeded(c, "/auth/refresh")
-			c.JSON(http.StatusTooManyRequests, gin.H{
-				"error":       "Rate limit exceeded",
-				"retry_after": 60,
-			})
-			c.Abort()
-			return
-		}
-
-		c.Next()
-	}
+// RetryAfterSeconds returns the retry_after value in seconds based on the configured window
+func (rl *IPRateLimiter) RetryAfterSeconds() int {
+	return rl.windowMinutes * 60
 }
 
-// ResendConfirmRateLimiter creates a rate limiting middleware for /resend-confirmemail endpoint
-func ResendConfirmRateLimiter(requestsPerMinute, burstSize int) gin.HandlerFunc {
-	limiter := NewIPRateLimiter(requestsPerMinute, burstSize)
+// NewEndpointRateLimiter creates a rate limiting middleware for any endpoint
+func NewEndpointRateLimiter(endpoint string, requestsPerWindow, burstSize, windowMinutes int) gin.HandlerFunc {
+	limiter := NewIPRateLimiter(requestsPerWindow, burstSize, windowMinutes)
 
 	return func(c *gin.Context) {
 		clientIP := c.ClientIP()
 
 		if !limiter.GetLimiter(clientIP).Allow() {
-			AuditRateLimitExceeded(c, "/resend-confirmemail")
+			AuditRateLimitExceeded(c, endpoint)
 			c.JSON(http.StatusTooManyRequests, gin.H{
 				"error":       "Rate limit exceeded",
-				"retry_after": 60,
+				"retry_after": limiter.RetryAfterSeconds(),
 			})
 			c.Abort()
 			return

--- a/pkg/security/rate_limiter.go
+++ b/pkg/security/rate_limiter.go
@@ -19,8 +19,18 @@ type IPRateLimiter struct {
 
 // NewIPRateLimiter creates a new IP-based rate limiter
 func NewIPRateLimiter(requestsPerWindow, burstSize, windowMinutes int) *IPRateLimiter {
+	if windowMinutes <= 0 {
+		windowMinutes = 1
+	}
+	if requestsPerWindow <= 0 {
+		requestsPerWindow = 1
+	}
+	if burstSize < 1 {
+		burstSize = 1
+	}
+
 	window := time.Duration(windowMinutes) * time.Minute
-	r := rate.Every(window / time.Duration(requestsPerWindow))
+	r := rate.Limit(float64(requestsPerWindow) / window.Seconds())
 	return &IPRateLimiter{
 		rate:          r,
 		burst:         burstSize,

--- a/pkg/security/rate_limiter_test.go
+++ b/pkg/security/rate_limiter_test.go
@@ -1,6 +1,7 @@
 package security
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -8,14 +9,15 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestRefreshRateLimiter_AllowsUnderLimit(t *testing.T) {
+func TestNewEndpointRateLimiter_AllowsUnderLimit(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 
-	// Rate limiter: 10 requests per minute
-	router.POST("/test", RefreshRateLimiter(10, 10), func(c *gin.Context) {
+	// Rate limiter: 10 requests per 1-minute window
+	router.POST("/test", NewEndpointRateLimiter("/test", 10, 10, 1), func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"message": "success"})
 	})
 
@@ -29,12 +31,12 @@ func TestRefreshRateLimiter_AllowsUnderLimit(t *testing.T) {
 	}
 }
 
-func TestRefreshRateLimiter_BlocksOverLimit(t *testing.T) {
+func TestNewEndpointRateLimiter_BlocksOverLimit(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 
-	// Rate limiter: 10 requests per minute
-	router.POST("/test", RefreshRateLimiter(10, 10), func(c *gin.Context) {
+	// Rate limiter: 10 requests per 1-minute window
+	router.POST("/test", NewEndpointRateLimiter("/test", 10, 10, 1), func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"message": "success"})
 	})
 
@@ -57,12 +59,12 @@ func TestRefreshRateLimiter_BlocksOverLimit(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "retry_after")
 }
 
-func TestRefreshRateLimiter_DifferentIPsIndependent(t *testing.T) {
+func TestNewEndpointRateLimiter_DifferentIPsIndependent(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 
-	// Rate limiter: 5 requests per minute
-	router.POST("/test", RefreshRateLimiter(5, 5), func(c *gin.Context) {
+	// Rate limiter: 5 requests per 1-minute window
+	router.POST("/test", NewEndpointRateLimiter("/test", 5, 5, 1), func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"message": "success"})
 	})
 
@@ -93,12 +95,12 @@ func TestRefreshRateLimiter_DifferentIPsIndependent(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w2.Code, "Request from different IP should succeed")
 }
 
-func TestRefreshRateLimiter_ResetAfterWindow(t *testing.T) {
+func TestNewEndpointRateLimiter_ResetAfterWindow(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 
-	// Rate limiter: 2 requests per 100ms for faster test
-	router.POST("/test", RefreshRateLimiter(1200, 2), func(c *gin.Context) {
+	// Rate limiter: 1200 requests per 1-minute window (= 2 per 100ms burst)
+	router.POST("/test", NewEndpointRateLimiter("/test", 1200, 2, 1), func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"message": "success"})
 	})
 
@@ -129,12 +131,12 @@ func TestRefreshRateLimiter_ResetAfterWindow(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w2.Code, "Request after window should succeed")
 }
 
-func TestResendConfirmRateLimiter_AllowsUnderLimit(t *testing.T) {
+func TestNewEndpointRateLimiter_ResendConfirm_AllowsUnderLimit(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 
-	// Rate limiter: 1 request per minute
-	router.POST("/test", ResendConfirmRateLimiter(1, 1), func(c *gin.Context) {
+	// Rate limiter: 1 request per 1-minute window
+	router.POST("/test", NewEndpointRateLimiter("/resend-confirmemail", 1, 1, 1), func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"message": "success"})
 	})
 
@@ -146,12 +148,12 @@ func TestResendConfirmRateLimiter_AllowsUnderLimit(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code, "First request should succeed")
 }
 
-func TestResendConfirmRateLimiter_BlocksOverLimit(t *testing.T) {
+func TestNewEndpointRateLimiter_ResendConfirm_BlocksOverLimit(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 
-	// Rate limiter: 1 request per minute
-	router.POST("/test", ResendConfirmRateLimiter(1, 1), func(c *gin.Context) {
+	// Rate limiter: 1 request per 1-minute window
+	router.POST("/test", NewEndpointRateLimiter("/resend-confirmemail", 1, 1, 1), func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"message": "success"})
 	})
 
@@ -172,8 +174,62 @@ func TestResendConfirmRateLimiter_BlocksOverLimit(t *testing.T) {
 	assert.Contains(t, w2.Body.String(), "retry_after")
 }
 
+func TestNewEndpointRateLimiter_DynamicRetryAfter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	// Rate limiter: 1 request per 5-minute window → retry_after should be 300
+	router.POST("/test", NewEndpointRateLimiter("/test", 1, 1, 5), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "success"})
+	})
+
+	// First request succeeds
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Second request should be rate limited with retry_after = 300
+	req2 := httptest.NewRequest(http.MethodPost, "/test", nil)
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req2)
+
+	assert.Equal(t, http.StatusTooManyRequests, w2.Code)
+
+	var body map[string]json.Number
+	err := json.NewDecoder(w2.Body).Decode(&body)
+	require.NoError(t, err)
+	retryAfter, err := body["retry_after"].Int64()
+	require.NoError(t, err)
+	assert.Equal(t, int64(300), retryAfter)
+}
+
+func TestNewEndpointRateLimiter_WindowMinutesAffectsRate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// 2 requests per 2-minute window → 1 req/min refill rate
+	router := gin.New()
+	router.POST("/test", NewEndpointRateLimiter("/test", 2, 2, 2), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "success"})
+	})
+
+	// Use burst of 2
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/test", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	}
+
+	// 3rd should be blocked
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+}
+
 func TestIPRateLimiter_GetLimiter(t *testing.T) {
-	limiter := NewIPRateLimiter(10, 10)
+	limiter := NewIPRateLimiter(10, 10, 1)
 
 	// Get limiter for IP 1
 	limiter1 := limiter.GetLimiter("192.168.1.1")
@@ -187,4 +243,12 @@ func TestIPRateLimiter_GetLimiter(t *testing.T) {
 	limiter2 := limiter.GetLimiter("192.168.1.2")
 	assert.NotNil(t, limiter2)
 	assert.NotSame(t, limiter1, limiter2, "Different IPs should return different limiter instances")
+}
+
+func TestIPRateLimiter_RetryAfterSeconds(t *testing.T) {
+	limiter := NewIPRateLimiter(10, 10, 5)
+	assert.Equal(t, 300, limiter.RetryAfterSeconds())
+
+	limiter2 := NewIPRateLimiter(10, 10, 1)
+	assert.Equal(t, 60, limiter2.RetryAfterSeconds())
 }

--- a/pkg/security/rate_limiter_test.go
+++ b/pkg/security/rate_limiter_test.go
@@ -196,36 +196,43 @@ func TestNewEndpointRateLimiter_DynamicRetryAfter(t *testing.T) {
 
 	assert.Equal(t, http.StatusTooManyRequests, w2.Code)
 
-	var body map[string]json.Number
+	var body struct {
+		RetryAfter int `json:"retry_after"`
+	}
 	err := json.NewDecoder(w2.Body).Decode(&body)
 	require.NoError(t, err)
-	retryAfter, err := body["retry_after"].Int64()
-	require.NoError(t, err)
-	assert.Equal(t, int64(300), retryAfter)
+	assert.Equal(t, 300, body.RetryAfter)
 }
 
 func TestNewEndpointRateLimiter_WindowMinutesAffectsRate(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	// 2 requests per 2-minute window → 1 req/min refill rate
+	// 6000 requests per 1-minute window → 1 token every 10ms, burst of 1
 	router := gin.New()
-	router.POST("/test", NewEndpointRateLimiter("/test", 2, 2, 2), func(c *gin.Context) {
+	router.POST("/test", NewEndpointRateLimiter("/test", 6000, 1, 1), func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"message": "success"})
 	})
 
-	// Use burst of 2
-	for i := 0; i < 2; i++ {
-		req := httptest.NewRequest(http.MethodPost, "/test", nil)
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-		assert.Equal(t, http.StatusOK, w.Code)
-	}
+	// First request uses the burst token
+	req1 := httptest.NewRequest(http.MethodPost, "/test", nil)
+	w1 := httptest.NewRecorder()
+	router.ServeHTTP(w1, req1)
+	assert.Equal(t, http.StatusOK, w1.Code)
 
-	// 3rd should be blocked
-	req := httptest.NewRequest(http.MethodPost, "/test", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	// Immediate second request should be rate limited (no time for refill)
+	req2 := httptest.NewRequest(http.MethodPost, "/test", nil)
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req2)
+	assert.Equal(t, http.StatusTooManyRequests, w2.Code)
+
+	// Wait long enough for at least one token to be refilled
+	time.Sleep(20 * time.Millisecond)
+
+	// Request after sleep should succeed due to refill
+	req3 := httptest.NewRequest(http.MethodPost, "/test", nil)
+	w3 := httptest.NewRecorder()
+	router.ServeHTTP(w3, req3)
+	assert.Equal(t, http.StatusOK, w3.Code)
 }
 
 func TestIPRateLimiter_GetLimiter(t *testing.T) {


### PR DESCRIPTION
## Summary

- Wire `WindowMinutes` config into `NewIPRateLimiter` so the token bucket refill rate uses the configured window instead of hardcoding 1 minute
- Compute `retry_after` dynamically from the actual rate limiter window configuration instead of hardcoding `60`
- Replace `RefreshRateLimiter` and `ResendConfirmRateLimiter` with a single generic `NewEndpointRateLimiter(endpoint, requestsPerWindow, burstSize, windowMinutes)` factory, eliminating near-identical code

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)