### PR TITLE
fix: banner image crop-to-fill for sharp display at all sizes

### DIFF
--- a/pkg/images/processor.go
+++ b/pkg/images/processor.go
@@ -313,23 +313,33 @@ func ResizeBannerImage(img image.Image) image.Image {
 	origW := bounds.Dx()
 	origH := bounds.Dy()
 
-	// Scale to cover the entire target area
-	scaleW := float64(MaxBannerWidth) / float64(origW)
-	scaleH := float64(MaxBannerHeight) / float64(origH)
-	scale := math.Max(scaleW, scaleH)
+	if origW == MaxBannerWidth && origH == MaxBannerHeight {
+		return img
+	}
 
-	scaledW := max(MaxBannerWidth, int(math.Round(float64(origW)*scale)))
-	scaledH := max(MaxBannerHeight, int(math.Round(float64(origH)*scale)))
+	// Compute the source crop rectangle matching the target aspect ratio,
+	// then scale directly to the target size. This avoids allocating a
+	// potentially huge intermediate image for extreme aspect ratios.
+	targetAspect := float64(MaxBannerWidth) / float64(MaxBannerHeight)
+	sourceAspect := float64(origW) / float64(origH)
 
-	scaled := image.NewRGBA(image.Rect(0, 0, scaledW, scaledH))
-	draw.CatmullRom.Scale(scaled, scaled.Bounds(), img, bounds, draw.Over, nil)
-
-	// Center-crop to exact target dimensions
-	cropX := (scaledW - MaxBannerWidth) / 2
-	cropY := (scaledH - MaxBannerHeight) / 2
+	var cropRect image.Rectangle
+	if sourceAspect > targetAspect {
+		// Source is wider than target — crop sides
+		cropH := origH
+		cropW := int(math.Round(float64(cropH) * targetAspect))
+		cropX := (origW - cropW) / 2
+		cropRect = image.Rect(bounds.Min.X+cropX, bounds.Min.Y, bounds.Min.X+cropX+cropW, bounds.Min.Y+cropH)
+	} else {
+		// Source is taller than target — crop top/bottom
+		cropW := origW
+		cropH := int(math.Round(float64(cropW) / targetAspect))
+		cropY := (origH - cropH) / 2
+		cropRect = image.Rect(bounds.Min.X, bounds.Min.Y+cropY, bounds.Min.X+cropW, bounds.Min.Y+cropY+cropH)
+	}
 
 	dst := image.NewRGBA(image.Rect(0, 0, MaxBannerWidth, MaxBannerHeight))
-	draw.Draw(dst, dst.Bounds(), scaled, image.Pt(cropX, cropY), draw.Src)
+	draw.CatmullRom.Scale(dst, dst.Bounds(), img, cropRect, draw.Over, nil)
 
 	return dst
 }

--- a/pkg/images/processor.go
+++ b/pkg/images/processor.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"image/jpeg"
 	"io"
+	"math"
 
 	"golang.org/x/image/draw"
 	_ "golang.org/x/image/webp" // Register WebP decoder
@@ -26,6 +27,8 @@ const (
 	JPEGQuality = 85
 	// InventoryItemJPEGQuality is the quality setting for inventory item images (0-100)
 	InventoryItemJPEGQuality = 70
+	// BannerJPEGQuality is the quality setting for banner images (0-100)
+	BannerJPEGQuality = 95
 	// MaxBannerWidth is the maximum width for banner images
 	MaxBannerWidth = 1920
 	// MaxBannerHeight is the maximum height for banner images
@@ -304,26 +307,29 @@ func ProcessInventoryItemImageFromReader(reader io.Reader) (*ProcessedImage, err
 	return ProcessInventoryItemImage(data)
 }
 
-// ResizeBannerImage resizes an image to fit within MaxBannerWidth x MaxBannerHeight
+// ResizeBannerImage scales and center-crops an image to exactly MaxBannerWidth x MaxBannerHeight
 func ResizeBannerImage(img image.Image) image.Image {
 	bounds := img.Bounds()
-	width := bounds.Dx()
-	height := bounds.Dy()
+	origW := bounds.Dx()
+	origH := bounds.Dy()
 
-	if width <= MaxBannerWidth && height <= MaxBannerHeight {
-		return img
-	}
+	// Scale to cover the entire target area
+	scaleW := float64(MaxBannerWidth) / float64(origW)
+	scaleH := float64(MaxBannerHeight) / float64(origH)
+	scale := math.Max(scaleW, scaleH)
 
-	// Scale down to fit within both width and height constraints
-	scaleW := float64(MaxBannerWidth) / float64(width)
-	scaleH := float64(MaxBannerHeight) / float64(height)
-	scale := min(scaleW, scaleH)
+	scaledW := max(MaxBannerWidth, int(math.Round(float64(origW)*scale)))
+	scaledH := max(MaxBannerHeight, int(math.Round(float64(origH)*scale)))
 
-	newWidth := max(1, int(float64(width)*scale))
-	newHeight := max(1, int(float64(height)*scale))
+	scaled := image.NewRGBA(image.Rect(0, 0, scaledW, scaledH))
+	draw.CatmullRom.Scale(scaled, scaled.Bounds(), img, bounds, draw.Over, nil)
 
-	dst := image.NewRGBA(image.Rect(0, 0, newWidth, newHeight))
-	draw.CatmullRom.Scale(dst, dst.Rect, img, bounds, draw.Over, nil)
+	// Center-crop to exact target dimensions
+	cropX := (scaledW - MaxBannerWidth) / 2
+	cropY := (scaledH - MaxBannerHeight) / 2
+
+	dst := image.NewRGBA(image.Rect(0, 0, MaxBannerWidth, MaxBannerHeight))
+	draw.Draw(dst, dst.Bounds(), scaled, image.Pt(cropX, cropY), draw.Src)
 
 	return dst
 }
@@ -347,7 +353,7 @@ func ProcessBannerImage(data []byte) (*ProcessedImage, error) {
 
 	img = ResizeBannerImage(img)
 
-	processedData, err := EncodeToJPEG(img)
+	processedData, err := EncodeToJPEGWithQuality(img, BannerJPEGQuality)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/images/processor_test.go
+++ b/pkg/images/processor_test.go
@@ -477,47 +477,56 @@ func TestProcessInventoryItemImage_SmallImageUnchangedDimensions(t *testing.T) {
 	}
 }
 
-func TestResizeBannerImage_4x3Source(t *testing.T) {
-	img := image.NewRGBA(image.Rect(0, 0, 2048, 1536))
-	result := ResizeBannerImage(img)
-	bounds := result.Bounds()
-	if bounds.Dx() != MaxBannerWidth || bounds.Dy() != MaxBannerHeight {
-		t.Errorf("Expected %dx%d, got %dx%d", MaxBannerWidth, MaxBannerHeight, bounds.Dx(), bounds.Dy())
+func TestResizeBannerImage(t *testing.T) {
+	tests := []struct {
+		name   string
+		width  int
+		height int
+	}{
+		{"4x3 source", 2048, 1536},
+		{"16x9 source", 1920, 1080},
+		{"wide panoramic", 3840, 600},
+		{"small image", 800, 400},
+		{"exact target size", MaxBannerWidth, MaxBannerHeight},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			img := image.NewRGBA(image.Rect(0, 0, tt.width, tt.height))
+			result := ResizeBannerImage(img)
+			bounds := result.Bounds()
+			if bounds.Dx() != MaxBannerWidth || bounds.Dy() != MaxBannerHeight {
+				t.Errorf("Expected %dx%d, got %dx%d", MaxBannerWidth, MaxBannerHeight, bounds.Dx(), bounds.Dy())
+			}
+		})
 	}
 }
 
-func TestResizeBannerImage_16x9Source(t *testing.T) {
-	img := image.NewRGBA(image.Rect(0, 0, 1920, 1080))
-	result := ResizeBannerImage(img)
-	bounds := result.Bounds()
-	if bounds.Dx() != MaxBannerWidth || bounds.Dy() != MaxBannerHeight {
-		t.Errorf("Expected %dx%d, got %dx%d", MaxBannerWidth, MaxBannerHeight, bounds.Dx(), bounds.Dy())
+func TestProcessBannerImage(t *testing.T) {
+	tests := []struct {
+		name   string
+		width  int
+		height int
+	}{
+		{"4x3 source", 2048, 1536},
+		{"16x9 source", 1920, 1080},
+		{"small image", 800, 400},
 	}
-}
 
-func TestResizeBannerImage_WidePanoramic(t *testing.T) {
-	img := image.NewRGBA(image.Rect(0, 0, 3840, 600))
-	result := ResizeBannerImage(img)
-	bounds := result.Bounds()
-	if bounds.Dx() != MaxBannerWidth || bounds.Dy() != MaxBannerHeight {
-		t.Errorf("Expected %dx%d, got %dx%d", MaxBannerWidth, MaxBannerHeight, bounds.Dx(), bounds.Dy())
-	}
-}
-
-func TestResizeBannerImage_SmallImage(t *testing.T) {
-	img := image.NewRGBA(image.Rect(0, 0, 800, 400))
-	result := ResizeBannerImage(img)
-	bounds := result.Bounds()
-	if bounds.Dx() != MaxBannerWidth || bounds.Dy() != MaxBannerHeight {
-		t.Errorf("Expected %dx%d, got %dx%d", MaxBannerWidth, MaxBannerHeight, bounds.Dx(), bounds.Dy())
-	}
-}
-
-func TestResizeBannerImage_ExactTargetSize(t *testing.T) {
-	img := image.NewRGBA(image.Rect(0, 0, MaxBannerWidth, MaxBannerHeight))
-	result := ResizeBannerImage(img)
-	bounds := result.Bounds()
-	if bounds.Dx() != MaxBannerWidth || bounds.Dy() != MaxBannerHeight {
-		t.Errorf("Expected %dx%d, got %dx%d", MaxBannerWidth, MaxBannerHeight, bounds.Dx(), bounds.Dy())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := createTestJPEG(tt.width, tt.height)
+			result, err := ProcessBannerImage(data)
+			if err != nil {
+				t.Fatalf("Failed to process banner image: %v", err)
+			}
+			if result.Metadata.Width != MaxBannerWidth || result.Metadata.Height != MaxBannerHeight {
+				t.Errorf("Expected %dx%d, got %dx%d",
+					MaxBannerWidth, MaxBannerHeight, result.Metadata.Width, result.Metadata.Height)
+			}
+			if result.Metadata.MimeType != MimeTypeJPEG {
+				t.Errorf("Expected %s, got %s", MimeTypeJPEG, result.Metadata.MimeType)
+			}
+		})
 	}
 }

--- a/pkg/images/processor_test.go
+++ b/pkg/images/processor_test.go
@@ -476,3 +476,48 @@ func TestProcessInventoryItemImage_SmallImageUnchangedDimensions(t *testing.T) {
 		t.Errorf("Expected 200x150, got %dx%d", result.Metadata.Width, result.Metadata.Height)
 	}
 }
+
+func TestResizeBannerImage_4x3Source(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 2048, 1536))
+	result := ResizeBannerImage(img)
+	bounds := result.Bounds()
+	if bounds.Dx() != MaxBannerWidth || bounds.Dy() != MaxBannerHeight {
+		t.Errorf("Expected %dx%d, got %dx%d", MaxBannerWidth, MaxBannerHeight, bounds.Dx(), bounds.Dy())
+	}
+}
+
+func TestResizeBannerImage_16x9Source(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 1920, 1080))
+	result := ResizeBannerImage(img)
+	bounds := result.Bounds()
+	if bounds.Dx() != MaxBannerWidth || bounds.Dy() != MaxBannerHeight {
+		t.Errorf("Expected %dx%d, got %dx%d", MaxBannerWidth, MaxBannerHeight, bounds.Dx(), bounds.Dy())
+	}
+}
+
+func TestResizeBannerImage_WidePanoramic(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 3840, 600))
+	result := ResizeBannerImage(img)
+	bounds := result.Bounds()
+	if bounds.Dx() != MaxBannerWidth || bounds.Dy() != MaxBannerHeight {
+		t.Errorf("Expected %dx%d, got %dx%d", MaxBannerWidth, MaxBannerHeight, bounds.Dx(), bounds.Dy())
+	}
+}
+
+func TestResizeBannerImage_SmallImage(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 800, 400))
+	result := ResizeBannerImage(img)
+	bounds := result.Bounds()
+	if bounds.Dx() != MaxBannerWidth || bounds.Dy() != MaxBannerHeight {
+		t.Errorf("Expected %dx%d, got %dx%d", MaxBannerWidth, MaxBannerHeight, bounds.Dx(), bounds.Dy())
+	}
+}
+
+func TestResizeBannerImage_ExactTargetSize(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, MaxBannerWidth, MaxBannerHeight))
+	result := ResizeBannerImage(img)
+	bounds := result.Bounds()
+	if bounds.Dx() != MaxBannerWidth || bounds.Dy() != MaxBannerHeight {
+		t.Errorf("Expected %dx%d, got %dx%d", MaxBannerWidth, MaxBannerHeight, bounds.Dx(), bounds.Dy())
+	}
+}


### PR DESCRIPTION
## Summary

- Change `ResizeBannerImage` from fit-within to crop-to-fill strategy — banners are now always exactly 1920x600 regardless of source aspect ratio
- Add `BannerJPEGQuality = 95` constant and use it for banner encoding instead of the default 85
- The old fit-within approach produced undersized banners (e.g. 800x600 from a 4:3 source), causing the frontend to upscale ~1.4x and blur the image

| Source aspect ratio | Old (fit-within) | New (crop-to-fill) |
|---|---|---|
| 4:3 (2048x1536) | 800x600 | 1920x600 |
| 16:9 (1920x1080) | 1067x600 | 1920x600 |
| Small (800x400) | 800x400 | 1920x600 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)