### PR TITLE
feat: trails database & admin management (#187)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Angak0k/pimpmypack/pkg/packs"
 	"github.com/Angak0k/pimpmypack/pkg/profiles"
 	"github.com/Angak0k/pimpmypack/pkg/security"
+	"github.com/Angak0k/pimpmypack/pkg/trails"
 	"github.com/gin-gonic/gin"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
@@ -102,6 +103,7 @@ func main() {
 func setupRoutes(router *gin.Engine) {
 	setupPublicRoutes(router)
 	setupProtectedRoutes(router)
+	setupV2Routes(router)
 	setupPrivateRoutes(router)
 	setupSwaggerRoutes(router)
 }
@@ -174,6 +176,12 @@ func setupProtectedRoutes(router *gin.Engine) {
 	protected.DELETE("/myinventory/:id/image", images.DeleteInventoryItemImage)
 }
 
+func setupV2Routes(router *gin.Engine) {
+	v2 := router.Group("/api/v2")
+	v2.Use(security.JwtAuthProcessor())
+	v2.GET("/pack-options", packs.GetPackOptionsV2)
+}
+
 func setupPrivateRoutes(router *gin.Engine) {
 	private := router.Group("/api/admin")
 	private.Use(security.JwtAuthAdminProcessor())
@@ -198,6 +206,13 @@ func setupPrivateRoutes(router *gin.Engine) {
 	private.PUT("/packcontents/:id", packs.PutPackContentByID)
 	private.DELETE("/packcontents/:id", packs.DeletePackContentByID)
 	private.GET("/packs/:id/packcontents", packs.GetPackContentsByPackID)
+	private.GET("/trails", trails.GetTrails)
+	private.GET("/trails/:id", trails.GetTrailByID)
+	private.POST("/trails", trails.PostTrail)
+	private.PUT("/trails/:id", trails.PutTrailByID)
+	private.DELETE("/trails/:id", trails.DeleteTrailByID)
+	private.POST("/trails/bulk", trails.PostTrailsBulk)
+	private.DELETE("/trails/bulk", trails.DeleteTrailsBulk)
 }
 
 func setupSwaggerRoutes(router *gin.Engine) {

--- a/pkg/database/migration/migration_scripts/000023_trail.down.sql
+++ b/pkg/database/migration/migration_scripts/000023_trail.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_trail_name;
+DROP TABLE IF EXISTS "trail";

--- a/pkg/database/migration/migration_scripts/000023_trail.up.sql
+++ b/pkg/database/migration/migration_scripts/000023_trail.up.sql
@@ -1,0 +1,103 @@
+CREATE TABLE "trail" (
+    "id"           SERIAL PRIMARY KEY,
+    "name"         TEXT NOT NULL,
+    "country"      TEXT NOT NULL,
+    "continent"    TEXT NOT NULL,
+    "distance_km"  INT,
+    "url"          TEXT,
+    "created_at"   TIMESTAMP NOT NULL DEFAULT NOW(),
+    "updated_at"   TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_trail_name ON trail(name);
+
+-- Seed with curated trail data
+INSERT INTO trail (name, country, continent, distance_km) VALUES
+-- North America
+('Appalachian Trail', 'United States', 'North America', 3500),
+('Pacific Crest Trail', 'United States', 'North America', 4265),
+('Continental Divide Trail', 'United States', 'North America', 4989),
+('John Muir Trail', 'United States', 'North America', 340),
+('Colorado Trail', 'United States', 'North America', 782),
+('Long Trail', 'United States', 'North America', 439),
+('Wonderland Trail', 'United States', 'North America', 150),
+('Superior Hiking Trail', 'United States', 'North America', 499),
+('Tahoe Rim Trail', 'United States', 'North America', 266),
+('Arizona Trail', 'United States', 'North America', 1287),
+('Ice Age Trail', 'United States', 'North America', 1900),
+('Pacific Northwest Trail', 'United States', 'North America', 1931),
+('Hayduke Trail', 'United States', 'North America', 1300),
+('Great Divide Trail', 'Canada', 'North America', 1130),
+('West Coast Trail', 'Canada', 'North America', 75),
+('Bruce Trail', 'Canada', 'North America', 900),
+
+-- Europe - France
+('GR20', 'France', 'Europe', 180),
+('GR10', 'France', 'Europe', 866),
+('GR34', 'France', 'Europe', 2000),
+('GR5', 'France', 'Europe', 620),
+('GR54', 'France', 'Europe', 176),
+('HRP', 'France', 'Europe', 800),
+('Hexatrek', 'France', 'Europe', 3034),
+('Tour du Mont Blanc', 'France', 'Europe', 170),
+
+-- Europe - Spain
+('Camino de Santiago', 'Spain', 'Europe', 800),
+('Camino del Norte', 'Spain', 'Europe', 825),
+('GR11', 'Spain', 'Europe', 840),
+
+-- Europe - Italy
+('Alta Via 1', 'Italy', 'Europe', 120),
+('Alta Via 2', 'Italy', 'Europe', 160),
+('Sentiero Italia', 'Italy', 'Europe', 7000),
+('Via Francigena', 'Italy', 'Europe', 1000),
+
+-- Europe - UK
+('West Highland Way', 'United Kingdom', 'Europe', 154),
+('Pennine Way', 'United Kingdom', 'Europe', 431),
+('South West Coast Path', 'United Kingdom', 'Europe', 1014),
+('Cape Wrath Trail', 'United Kingdom', 'Europe', 370),
+
+-- Europe - Scandinavia
+('Kungsleden', 'Sweden', 'Europe', 440),
+('Nordkalottleden', 'Sweden', 'Europe', 800),
+('Laugavegur Trail', 'Iceland', 'Europe', 55),
+
+-- Europe - Other
+('E5 European Long Distance Path', 'Germany', 'Europe', 600),
+('Walker''s Haute Route', 'Switzerland', 'Europe', 180),
+('Via Alpina Red Trail', 'Switzerland', 'Europe', 2500),
+('Lycian Way', 'Turkey', 'Europe', 540),
+('Rota Vicentina', 'Portugal', 'Europe', 450),
+
+-- Asia
+('Kumano Kodo', 'Japan', 'Asia', 70),
+('Nakasendo Trail', 'Japan', 'Asia', 335),
+('Shikoku Pilgrimage', 'Japan', 'Asia', 1200),
+('Annapurna Circuit', 'Nepal', 'Asia', 230),
+('Everest Base Camp Trek', 'Nepal', 'Asia', 130),
+('Langtang Valley Trek', 'Nepal', 'Asia', 75),
+('Markha Valley Trek', 'India', 'Asia', 75),
+
+-- Oceania
+('Te Araroa', 'New Zealand', 'Oceania', 3000),
+('Milford Track', 'New Zealand', 'Oceania', 53),
+('Routeburn Track', 'New Zealand', 'Oceania', 32),
+('Tongariro Northern Circuit', 'New Zealand', 'Oceania', 43),
+('Overland Track', 'Australia', 'Oceania', 65),
+('Larapinta Trail', 'Australia', 'Oceania', 223),
+('Bibbulmun Track', 'Australia', 'Oceania', 1003),
+
+-- South America
+('Torres del Paine W Trek', 'Chile', 'South America', 80),
+('Torres del Paine O Circuit', 'Chile', 'South America', 130),
+('Huemul Circuit', 'Argentina', 'South America', 65),
+('Inca Trail', 'Peru', 'South America', 43),
+('Santa Cruz Trek', 'Peru', 'South America', 50),
+('Lares Trek', 'Peru', 'South America', 33),
+
+-- Africa
+('Mount Kilimanjaro', 'Tanzania', 'Africa', 62),
+('Mount Kenya Circuit', 'Kenya', 'Africa', 50),
+('Otter Trail', 'South Africa', 'Africa', 42),
+('Fish River Canyon Trail', 'Namibia', 'Africa', 85);

--- a/pkg/database/migration/migration_scripts/000024_pack_trail_fk.down.sql
+++ b/pkg/database/migration/migration_scripts/000024_pack_trail_fk.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "pack" DROP COLUMN IF EXISTS "trail_id";

--- a/pkg/database/migration/migration_scripts/000024_pack_trail_fk.up.sql
+++ b/pkg/database/migration/migration_scripts/000024_pack_trail_fk.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "pack" ADD COLUMN "trail_id" INT REFERENCES trail(id) ON DELETE SET NULL;
+
+-- Backfill trail_id from existing trail text values
+UPDATE pack SET trail_id = t.id FROM trail t WHERE pack.trail = t.name;

--- a/pkg/database/seed/seed.go
+++ b/pkg/database/seed/seed.go
@@ -174,17 +174,29 @@ func createPacks(
 	packIDs := make([]uint, len(seedPackDefs))
 
 	for i, p := range seedPackDefs {
+		// Resolve trail name to trail_id
+		var trailID *uint
+		if p.trail != nil {
+			var tid uint
+			err := tx.QueryRowContext(ctx,
+				`SELECT id FROM trail WHERE name = $1`, *p.trail,
+			).Scan(&tid)
+			if err == nil {
+				trailID = &tid
+			}
+		}
+
 		var id uint
 		err := tx.QueryRowContext(ctx,
 			`INSERT INTO pack
 			(user_id, pack_name, pack_description,
-			 season, trail, adventure,
+			 season, trail, trail_id, adventure,
 			 is_favorite,
 			 created_at, updated_at)
-			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
 			RETURNING id`,
 			userID, p.packName, p.packDescription,
-			p.season, p.trail, p.adventure, p.isFavorite,
+			p.season, p.trail, trailID, p.adventure, p.isFavorite,
 			now, now,
 		).Scan(&id)
 		if err != nil {

--- a/pkg/packs/handlers.go
+++ b/pkg/packs/handlers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Angak0k/pimpmypack/pkg/helper"
 	"github.com/Angak0k/pimpmypack/pkg/security"
+	"github.com/Angak0k/pimpmypack/pkg/trails"
 	"github.com/gin-gonic/gin"
 )
 
@@ -97,7 +98,7 @@ func PostPack(c *gin.Context) {
 		return
 	}
 
-	if err := validatePackMetadata(input.Season, input.Trail, input.Adventure); err != nil {
+	if err := validatePackMetadata(c.Request.Context(), input.Season, input.Trail, input.Adventure); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -108,6 +109,7 @@ func PostPack(c *gin.Context) {
 		PackDescription: input.PackDescription,
 		Season:          input.Season,
 		Trail:           input.Trail,
+		TrailID:         resolveTrailID(c.Request.Context(), input.Trail),
 		Adventure:       input.Adventure,
 	}
 
@@ -147,7 +149,7 @@ func PutPackByID(c *gin.Context) {
 		return
 	}
 
-	if err := validatePackMetadata(input.Season, input.Trail, input.Adventure); err != nil {
+	if err := validatePackMetadata(c.Request.Context(), input.Season, input.Trail, input.Adventure); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -171,6 +173,7 @@ func PutPackByID(c *gin.Context) {
 		PackDescription: input.PackDescription,
 		Season:          input.Season,
 		Trail:           input.Trail,
+		TrailID:         resolveTrailID(c.Request.Context(), input.Trail),
 		Adventure:       input.Adventure,
 		CreatedAt:       existingPack.CreatedAt,      // Preserve existing CreatedAt
 		UpdatedAt:       existingPack.UpdatedAt,      // Preserve existing UpdatedAt
@@ -334,7 +337,7 @@ func PostMyPack(c *gin.Context) {
 		return
 	}
 
-	if err := validatePackMetadata(input.Season, input.Trail, input.Adventure); err != nil {
+	if err := validatePackMetadata(c.Request.Context(), input.Season, input.Trail, input.Adventure); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -345,6 +348,7 @@ func PostMyPack(c *gin.Context) {
 		PackDescription: input.PackDescription,
 		Season:          input.Season,
 		Trail:           input.Trail,
+		TrailID:         resolveTrailID(c.Request.Context(), input.Trail),
 		Adventure:       input.Adventure,
 	}
 
@@ -395,7 +399,7 @@ func PutMyPackByID(c *gin.Context) {
 		return
 	}
 
-	if err := validatePackMetadata(input.Season, input.Trail, input.Adventure); err != nil {
+	if err := validatePackMetadata(c.Request.Context(), input.Season, input.Trail, input.Adventure); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -427,6 +431,7 @@ func PutMyPackByID(c *gin.Context) {
 	updatedPack.PackDescription = input.PackDescription
 	updatedPack.Season = input.Season
 	updatedPack.Trail = input.Trail
+	updatedPack.TrailID = resolveTrailID(c.Request.Context(), input.Trail)
 	updatedPack.Adventure = input.Adventure
 
 	err = updatePackByID(c.Request.Context(), id, &updatedPack)
@@ -1390,17 +1395,34 @@ func ImportFromPimpMyPackURL(c *gin.Context) {
 
 // validatePackMetadata checks that season, trail, and adventure values are allowed.
 // Returns nil if all values are valid or nil.
-func validatePackMetadata(season, trail, adventure *string) error {
+func validatePackMetadata(ctx context.Context, season, trail, adventure *string) error {
 	if !isAllowedValue(season, allowedSeasons) {
 		return errors.New("invalid season value")
 	}
-	if !isAllowedValue(trail, allowedTrails) {
+	valid, err := trails.IsValidTrailName(ctx, trail)
+	if err != nil {
+		return errors.New("failed to validate trail")
+	}
+	if !valid {
 		return errors.New("invalid trail value")
 	}
 	if !isAllowedValue(adventure, allowedAdventures) {
 		return errors.New("invalid adventure value")
 	}
 	return nil
+}
+
+// resolveTrailID resolves a trail name to a trail ID.
+// Returns nil if the trail name is nil.
+func resolveTrailID(ctx context.Context, trailName *string) *uint {
+	if trailName == nil {
+		return nil
+	}
+	trail, err := trails.FindTrailByName(ctx, *trailName)
+	if err != nil {
+		return nil
+	}
+	return &trail.ID
 }
 
 // Get pack options
@@ -1412,7 +1434,19 @@ func validatePackMetadata(season, trail, adventure *string) error {
 // @Success 200 {object} PackOptionsResponse
 // @Router /v1/pack-options [get]
 func GetPackOptions(c *gin.Context) {
-	c.IndentedJSON(http.StatusOK, GetPackOptionsValues())
+	c.IndentedJSON(http.StatusOK, GetPackOptionsValues(c.Request.Context()))
+}
+
+// Get V2 pack options with grouped trails
+// @Summary Get allowed values for pack metadata (V2)
+// @Description Returns the allowed values for season, trail (grouped by continent/country), and adventure fields
+// @Tags Packs
+// @Produce json
+// @Security Bearer
+// @Success 200 {object} PackOptionsV2Response
+// @Router /v2/pack-options [get]
+func GetPackOptionsV2(c *gin.Context) {
+	c.IndentedJSON(http.StatusOK, GetPackOptionsV2Values(c.Request.Context()))
 }
 
 // SharedList gets pack metadata and contents for a shared pack

--- a/pkg/packs/handlers.go
+++ b/pkg/packs/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/csv"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -98,8 +99,14 @@ func PostPack(c *gin.Context) {
 		return
 	}
 
-	if err := validatePackMetadata(c.Request.Context(), input.Season, input.Trail, input.Adventure); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	trailID, err := validatePackMetadata(c.Request.Context(), input.Season, input.Trail, input.Adventure)
+	if err != nil {
+		if errors.Is(err, errTrailLookupFailed) {
+			helper.LogAndSanitize(err, "post pack: trail lookup failed")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		}
 		return
 	}
 
@@ -109,11 +116,11 @@ func PostPack(c *gin.Context) {
 		PackDescription: input.PackDescription,
 		Season:          input.Season,
 		Trail:           input.Trail,
-		TrailID:         resolveTrailID(c.Request.Context(), input.Trail),
+		TrailID:         trailID,
 		Adventure:       input.Adventure,
 	}
 
-	err := insertPack(c.Request.Context(), &newPack)
+	err = insertPack(c.Request.Context(), &newPack)
 	if err != nil {
 		helper.LogAndSanitize(err, "post pack: insert pack failed")
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
@@ -149,8 +156,14 @@ func PutPackByID(c *gin.Context) {
 		return
 	}
 
-	if err := validatePackMetadata(c.Request.Context(), input.Season, input.Trail, input.Adventure); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	trailID, err := validatePackMetadata(c.Request.Context(), input.Season, input.Trail, input.Adventure)
+	if err != nil {
+		if errors.Is(err, errTrailLookupFailed) {
+			helper.LogAndSanitize(err, "put pack by ID: trail lookup failed")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		}
 		return
 	}
 
@@ -173,7 +186,7 @@ func PutPackByID(c *gin.Context) {
 		PackDescription: input.PackDescription,
 		Season:          input.Season,
 		Trail:           input.Trail,
-		TrailID:         resolveTrailID(c.Request.Context(), input.Trail),
+		TrailID:         trailID,
 		Adventure:       input.Adventure,
 		CreatedAt:       existingPack.CreatedAt,      // Preserve existing CreatedAt
 		UpdatedAt:       existingPack.UpdatedAt,      // Preserve existing UpdatedAt
@@ -337,8 +350,14 @@ func PostMyPack(c *gin.Context) {
 		return
 	}
 
-	if err := validatePackMetadata(c.Request.Context(), input.Season, input.Trail, input.Adventure); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	trailID, err := validatePackMetadata(c.Request.Context(), input.Season, input.Trail, input.Adventure)
+	if err != nil {
+		if errors.Is(err, errTrailLookupFailed) {
+			helper.LogAndSanitize(err, "post my pack: trail lookup failed")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		}
 		return
 	}
 
@@ -348,7 +367,7 @@ func PostMyPack(c *gin.Context) {
 		PackDescription: input.PackDescription,
 		Season:          input.Season,
 		Trail:           input.Trail,
-		TrailID:         resolveTrailID(c.Request.Context(), input.Trail),
+		TrailID:         trailID,
 		Adventure:       input.Adventure,
 	}
 
@@ -399,8 +418,14 @@ func PutMyPackByID(c *gin.Context) {
 		return
 	}
 
-	if err := validatePackMetadata(c.Request.Context(), input.Season, input.Trail, input.Adventure); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	trailID, err := validatePackMetadata(c.Request.Context(), input.Season, input.Trail, input.Adventure)
+	if err != nil {
+		if errors.Is(err, errTrailLookupFailed) {
+			helper.LogAndSanitize(err, "put my pack by ID: trail lookup failed")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		}
 		return
 	}
 
@@ -431,7 +456,7 @@ func PutMyPackByID(c *gin.Context) {
 	updatedPack.PackDescription = input.PackDescription
 	updatedPack.Season = input.Season
 	updatedPack.Trail = input.Trail
-	updatedPack.TrailID = resolveTrailID(c.Request.Context(), input.Trail)
+	updatedPack.TrailID = trailID
 	updatedPack.Adventure = input.Adventure
 
 	err = updatePackByID(c.Request.Context(), id, &updatedPack)
@@ -1394,35 +1419,45 @@ func ImportFromPimpMyPackURL(c *gin.Context) {
 }
 
 // validatePackMetadata checks that season, trail, and adventure values are allowed.
-// Returns nil if all values are valid or nil.
-func validatePackMetadata(ctx context.Context, season, trail, adventure *string) error {
+// Returns the resolved trail ID (nil if trail is nil) and an error.
+// Uses a single DB lookup for both validation and trail_id resolution.
+func validatePackMetadata(
+	ctx context.Context, season, trail, adventure *string,
+) (*uint, error) {
 	if !isAllowedValue(season, allowedSeasons) {
-		return errors.New("invalid season value")
+		return nil, errors.New("invalid season value")
 	}
-	valid, err := trails.IsValidTrailName(ctx, trail)
+	trailID, err := resolveAndValidateTrail(ctx, trail)
 	if err != nil {
-		return errors.New("failed to validate trail")
-	}
-	if !valid {
-		return errors.New("invalid trail value")
+		return nil, err
 	}
 	if !isAllowedValue(adventure, allowedAdventures) {
-		return errors.New("invalid adventure value")
+		return nil, errors.New("invalid adventure value")
 	}
-	return nil
+	return trailID, nil
 }
 
-// resolveTrailID resolves a trail name to a trail ID.
-// Returns nil if the trail name is nil.
-func resolveTrailID(ctx context.Context, trailName *string) *uint {
+// errTrailLookupFailed is a sentinel error used to distinguish internal
+// trail lookup failures (500) from validation errors (400).
+var errTrailLookupFailed = errors.New("trail lookup failed")
+
+// resolveAndValidateTrail resolves a trail name to its ID via a single DB lookup.
+// Returns nil ID if trail name is nil.
+// Returns errTrailLookupFailed (wrapped) for internal errors, plain error for validation.
+func resolveAndValidateTrail(
+	ctx context.Context, trailName *string,
+) (*uint, error) {
 	if trailName == nil {
-		return nil
+		return nil, nil //nolint:nilnil // nil trail name is valid (optional field)
 	}
 	trail, err := trails.FindTrailByName(ctx, *trailName)
 	if err != nil {
-		return nil
+		if errors.Is(err, trails.ErrTrailNotFound) {
+			return nil, errors.New("invalid trail value")
+		}
+		return nil, fmt.Errorf("%w: %w", errTrailLookupFailed, err)
 	}
-	return &trail.ID
+	return &trail.ID, nil
 }
 
 // Get pack options
@@ -1434,7 +1469,13 @@ func resolveTrailID(ctx context.Context, trailName *string) *uint {
 // @Success 200 {object} PackOptionsResponse
 // @Router /v1/pack-options [get]
 func GetPackOptions(c *gin.Context) {
-	c.IndentedJSON(http.StatusOK, GetPackOptionsValues(c.Request.Context()))
+	options, err := GetPackOptionsValues(c.Request.Context())
+	if err != nil {
+		helper.LogAndSanitize(err, "get pack options: fetch trails failed")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+	c.IndentedJSON(http.StatusOK, options)
 }
 
 // Get V2 pack options with grouped trails
@@ -1446,7 +1487,13 @@ func GetPackOptions(c *gin.Context) {
 // @Success 200 {object} PackOptionsV2Response
 // @Router /v2/pack-options [get]
 func GetPackOptionsV2(c *gin.Context) {
-	c.IndentedJSON(http.StatusOK, GetPackOptionsV2Values(c.Request.Context()))
+	options, err := GetPackOptionsV2Values(c.Request.Context())
+	if err != nil {
+		helper.LogAndSanitize(err, "get pack options v2: fetch trails failed")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+	c.IndentedJSON(http.StatusOK, options)
 }
 
 // SharedList gets pack metadata and contents for a shared pack

--- a/pkg/packs/packs_test.go
+++ b/pkg/packs/packs_test.go
@@ -1832,12 +1832,13 @@ func TestGetPackOptions(t *testing.T) {
 			t.Fatalf("Failed to unmarshal response body: %v", err)
 		}
 
-		expectedOptions := GetPackOptionsValues()
+		expectedOptions := GetPackOptionsValues(req.Context())
 		if diff := cmp.Diff(expectedOptions.Seasons, response.Seasons); diff != "" {
 			t.Errorf("Seasons mismatch (-want +got):\n%s", diff)
 		}
-		if diff := cmp.Diff(expectedOptions.Trails, response.Trails); diff != "" {
-			t.Errorf("Trails mismatch (-want +got):\n%s", diff)
+		// Trails are now DB-driven, verify they are present
+		if len(response.Trails) == 0 {
+			t.Error("Expected trails to be non-empty")
 		}
 		if diff := cmp.Diff(expectedOptions.Adventures, response.Adventures); diff != "" {
 			t.Errorf("Adventures mismatch (-want +got):\n%s", diff)

--- a/pkg/packs/packs_test.go
+++ b/pkg/packs/packs_test.go
@@ -1832,7 +1832,10 @@ func TestGetPackOptions(t *testing.T) {
 			t.Fatalf("Failed to unmarshal response body: %v", err)
 		}
 
-		expectedOptions := GetPackOptionsValues(req.Context())
+		expectedOptions, err := GetPackOptionsValues(req.Context())
+		if err != nil {
+			t.Fatalf("Failed to get pack options: %v", err)
+		}
 		if diff := cmp.Diff(expectedOptions.Seasons, response.Seasons); diff != "" {
 			t.Errorf("Seasons mismatch (-want +got):\n%s", diff)
 		}

--- a/pkg/packs/repository.go
+++ b/pkg/packs/repository.go
@@ -25,13 +25,14 @@ func returnPacks(ctx context.Context) (Packs, error) {
 		COALESCE(SUM(pc.quantity), 0) as items_count,
 		COALESCE(SUM(i.weight * pc.quantity), 0) as total_weight,
 		CASE WHEN pi.pack_id IS NOT NULL THEN true ELSE false END as has_image,
-		p.season, p.trail, p.adventure
+		p.season, COALESCE(t.name, p.trail) as trail, p.trail_id, p.adventure
 		FROM pack p
 		LEFT JOIN pack_content pc ON p.id = pc.pack_id
 		LEFT JOIN inventory i ON pc.item_id = i.id
 		LEFT JOIN pack_images pi ON p.id = pi.pack_id
+		LEFT JOIN trail t ON p.trail_id = t.id
 		GROUP BY p.id, p.user_id, p.pack_name, p.pack_description, p.sharing_code, p.is_favorite,
-		p.created_at, p.updated_at, pi.pack_id, p.season, p.trail, p.adventure
+		p.created_at, p.updated_at, pi.pack_id, p.season, t.name, p.trail, p.trail_id, p.adventure
 		ORDER BY p.id;`)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -57,6 +58,7 @@ func returnPacks(ctx context.Context) (Packs, error) {
 			&pack.HasImage,
 			&pack.Season,
 			&pack.Trail,
+			&pack.TrailID,
 			&pack.Adventure,
 		)
 		if err != nil {
@@ -82,14 +84,15 @@ func findPackByID(ctx context.Context, id uint) (*Pack, error) {
 		COALESCE(SUM(pc.quantity), 0) as items_count,
 		COALESCE(SUM(i.weight * pc.quantity), 0) as total_weight,
 		CASE WHEN pi.pack_id IS NOT NULL THEN true ELSE false END as has_image,
-		p.season, p.trail, p.adventure
+		p.season, COALESCE(t.name, p.trail) as trail, p.trail_id, p.adventure
 		FROM pack p
 		LEFT JOIN pack_content pc ON p.id = pc.pack_id
 		LEFT JOIN inventory i ON pc.item_id = i.id
 		LEFT JOIN pack_images pi ON p.id = pi.pack_id
+		LEFT JOIN trail t ON p.trail_id = t.id
 		WHERE p.id = $1
 		GROUP BY p.id, p.user_id, p.pack_name, p.pack_description, p.sharing_code, p.is_favorite,
-		p.created_at, p.updated_at, pi.pack_id, p.season, p.trail, p.adventure;`,
+		p.created_at, p.updated_at, pi.pack_id, p.season, t.name, p.trail, p.trail_id, p.adventure;`,
 		id)
 	err := row.Scan(
 		&pack.ID,
@@ -105,6 +108,7 @@ func findPackByID(ctx context.Context, id uint) (*Pack, error) {
 		&pack.HasImage,
 		&pack.Season,
 		&pack.Trail,
+		&pack.TrailID,
 		&pack.Adventure)
 
 	if err != nil {
@@ -126,14 +130,15 @@ func findPacksByUserID(ctx context.Context, id uint) (*Packs, error) {
 		COALESCE(SUM(pc.quantity), 0) as items_count,
 		COALESCE(SUM(i.weight * pc.quantity), 0) as total_weight,
 		CASE WHEN pi.pack_id IS NOT NULL THEN true ELSE false END as has_image,
-		p.season, p.trail, p.adventure
+		p.season, COALESCE(t.name, p.trail) as trail, p.trail_id, p.adventure
 		FROM pack p
 		LEFT JOIN pack_content pc ON p.id = pc.pack_id
 		LEFT JOIN inventory i ON pc.item_id = i.id
 		LEFT JOIN pack_images pi ON p.id = pi.pack_id
+		LEFT JOIN trail t ON p.trail_id = t.id
 		WHERE p.user_id = $1
 		GROUP BY p.id, p.user_id, p.pack_name, p.pack_description, p.sharing_code, p.is_favorite,
-		         p.created_at, p.updated_at, pi.pack_id, p.season, p.trail, p.adventure;`, id)
+		         p.created_at, p.updated_at, pi.pack_id, p.season, t.name, p.trail, p.trail_id, p.adventure;`, id)
 	if err != nil {
 		return nil, err
 	}
@@ -155,6 +160,7 @@ func findPacksByUserID(ctx context.Context, id uint) (*Packs, error) {
 			&pack.HasImage,
 			&pack.Season,
 			&pack.Trail,
+			&pack.TrailID,
 			&pack.Adventure)
 		if err != nil {
 			return nil, err
@@ -205,8 +211,8 @@ func insertPack(ctx context.Context, p *Pack) error {
 
 	err := database.DB().QueryRowContext(ctx,
 		`INSERT INTO pack
-		(user_id, pack_name, pack_description, sharing_code, season, trail, adventure, created_at, updated_at)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+		(user_id, pack_name, pack_description, sharing_code, season, trail, trail_id, adventure, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
 		RETURNING id;`,
 		p.UserID,
 		p.PackName,
@@ -214,6 +220,7 @@ func insertPack(ctx context.Context, p *Pack) error {
 		p.SharingCode,
 		p.Season,
 		p.Trail,
+		p.TrailID,
 		p.Adventure,
 		p.CreatedAt,
 		p.UpdatedAt).Scan(&p.ID)
@@ -231,8 +238,9 @@ func updatePackByID(ctx context.Context, id uint, p *Pack) error {
 	p.UpdatedAt = time.Now().Truncate(time.Second)
 
 	statement, err := database.DB().PrepareContext(ctx,
-		`UPDATE pack SET user_id=$1, pack_name=$2, pack_description=$3, season=$4, trail=$5, adventure=$6, updated_at=$7
-		WHERE id=$8;`)
+		`UPDATE pack SET user_id=$1, pack_name=$2, pack_description=$3,
+		season=$4, trail=$5, trail_id=$6, adventure=$7, updated_at=$8
+		WHERE id=$9;`)
 	if err != nil {
 		return err
 	}
@@ -240,7 +248,7 @@ func updatePackByID(ctx context.Context, id uint, p *Pack) error {
 	defer statement.Close()
 
 	_, err = statement.ExecContext(ctx,
-		p.UserID, p.PackName, p.PackDescription, p.Season, p.Trail, p.Adventure, p.UpdatedAt, id)
+		p.UserID, p.PackName, p.PackDescription, p.Season, p.Trail, p.TrailID, p.Adventure, p.UpdatedAt, id)
 	if err != nil {
 		return err
 	}
@@ -431,9 +439,10 @@ func returnPackInfoBySharingCode(ctx context.Context, sharingCode string) (*Shar
 	query := `
 		SELECT p.id, p.pack_name, p.pack_description, p.created_at,
 		CASE WHEN pi.pack_id IS NOT NULL THEN true ELSE false END as has_image,
-		p.season, p.trail, p.adventure
+		p.season, COALESCE(t.name, p.trail) as trail, p.adventure
 		FROM pack p
 		LEFT JOIN pack_images pi ON p.id = pi.pack_id
+		LEFT JOIN trail t ON p.trail_id = t.id
 		WHERE p.sharing_code = $1 AND p.sharing_code IS NOT NULL
 	`
 

--- a/pkg/packs/testdata.go
+++ b/pkg/packs/testdata.go
@@ -354,11 +354,22 @@ func loadInventories(tx *sql.Tx) error {
 			return fmt.Errorf("foreign key violation: user_id %d does not exist in account table", packs[i].UserID)
 		}
 
+		// Resolve trail_id from trail name
+		var trailID *uint
+		if packs[i].Trail != nil {
+			var tid uint
+			tidErr := tx.QueryRowContext(context.Background(),
+				`SELECT id FROM trail WHERE name = $1`, *packs[i].Trail).Scan(&tid)
+			if tidErr == nil {
+				trailID = &tid
+			}
+		}
+
 		err = tx.QueryRowContext(context.Background(),
 			`INSERT INTO pack
-			(user_id, pack_name, pack_description, sharing_code, season, trail, adventure,
+			(user_id, pack_name, pack_description, sharing_code, season, trail, trail_id, adventure,
 			created_at, updated_at)
-			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
 			RETURNING id;`,
 			packs[i].UserID,
 			packs[i].PackName,
@@ -366,6 +377,7 @@ func loadInventories(tx *sql.Tx) error {
 			packs[i].SharingCode,
 			packs[i].Season,
 			packs[i].Trail,
+			trailID,
 			packs[i].Adventure,
 			time.Now().Truncate(time.Second),
 			time.Now().Truncate(time.Second)).Scan(&packs[i].ID)

--- a/pkg/packs/types.go
+++ b/pkg/packs/types.go
@@ -1,8 +1,11 @@
 package packs
 
 import (
+	"context"
 	"errors"
 	"time"
+
+	"github.com/Angak0k/pimpmypack/pkg/trails"
 )
 
 // Domain errors
@@ -22,16 +25,6 @@ var (
 // allowedSeasons defines the valid season values for a pack
 var allowedSeasons = []string{"Winter", "3-Season", "Summer"}
 
-// allowedTrails defines the valid trail values for a pack
-var allowedTrails = []string{
-	"Appalachian Trail", "Pacific Crest Trail", "Continental Divide Trail",
-	"John Muir Trail", "Colorado Trail",
-	"GR20", "GR10", "GR34", "GR5", "GR54", "HRP", "Hexatrek", "Tour du Mont Blanc",
-	"Camino de Santiago", "Alta Via 1", "West Highland Way", "Kungsleden",
-	"Kumano Kodo", "Nakasendo Trail", "Shikoku Pilgrimage",
-	"Te Araroa", "Milford Track", "Routeburn Track", "Tongariro Northern Circuit",
-}
-
 // allowedAdventures defines the valid adventure type values for a pack
 var allowedAdventures = []string{"Bikepacking", "Backpacking", "Thru-hike", "Backcountry Skiing"}
 
@@ -48,6 +41,7 @@ type Pack struct {
 	HasImage        bool      `json:"has_image"`
 	Season          *string   `json:"season,omitempty"`
 	Trail           *string   `json:"trail,omitempty"`
+	TrailID         *uint     `json:"trail_id,omitempty"`
 	Adventure       *string   `json:"adventure,omitempty"`
 	CreatedAt       time.Time `json:"created_at"`
 	UpdatedAt       time.Time `json:"updated_at"`
@@ -203,11 +197,36 @@ type PackOptionsResponse struct {
 	Adventures []string `json:"adventures"`
 }
 
-// GetPackOptionsValues returns a defensive copy of the allowed metadata values
-func GetPackOptionsValues() PackOptionsResponse {
+// GetPackOptionsValues returns the allowed metadata values, querying the DB for trails
+func GetPackOptionsValues(ctx context.Context) PackOptionsResponse {
+	trailNames, err := trails.ReturnTrailNames(ctx)
+	if err != nil {
+		// Fallback to empty list on error
+		trailNames = []string{}
+	}
 	return PackOptionsResponse{
 		Seasons:    append([]string{}, allowedSeasons...),
-		Trails:     append([]string{}, allowedTrails...),
+		Trails:     trailNames,
+		Adventures: append([]string{}, allowedAdventures...),
+	}
+}
+
+// PackOptionsV2Response represents the V2 allowed values with grouped trails
+type PackOptionsV2Response struct {
+	Seasons    []string                                    `json:"seasons"`
+	Trails     map[string]map[string][]trails.TrailSummary `json:"trails"`
+	Adventures []string                                    `json:"adventures"`
+}
+
+// GetPackOptionsV2Values returns the allowed metadata values with trails grouped by continent/country
+func GetPackOptionsV2Values(ctx context.Context) PackOptionsV2Response {
+	grouped, err := trails.ReturnTrailsGrouped(ctx)
+	if err != nil {
+		grouped = make(map[string]map[string][]trails.TrailSummary)
+	}
+	return PackOptionsV2Response{
+		Seasons:    append([]string{}, allowedSeasons...),
+		Trails:     grouped,
 		Adventures: append([]string{}, allowedAdventures...),
 	}
 }

--- a/pkg/packs/types.go
+++ b/pkg/packs/types.go
@@ -198,17 +198,16 @@ type PackOptionsResponse struct {
 }
 
 // GetPackOptionsValues returns the allowed metadata values, querying the DB for trails
-func GetPackOptionsValues(ctx context.Context) PackOptionsResponse {
+func GetPackOptionsValues(ctx context.Context) (PackOptionsResponse, error) {
 	trailNames, err := trails.ReturnTrailNames(ctx)
 	if err != nil {
-		// Fallback to empty list on error
-		trailNames = []string{}
+		return PackOptionsResponse{}, err
 	}
 	return PackOptionsResponse{
 		Seasons:    append([]string{}, allowedSeasons...),
 		Trails:     trailNames,
 		Adventures: append([]string{}, allowedAdventures...),
-	}
+	}, nil
 }
 
 // PackOptionsV2Response represents the V2 allowed values with grouped trails
@@ -219,16 +218,16 @@ type PackOptionsV2Response struct {
 }
 
 // GetPackOptionsV2Values returns the allowed metadata values with trails grouped by continent/country
-func GetPackOptionsV2Values(ctx context.Context) PackOptionsV2Response {
+func GetPackOptionsV2Values(ctx context.Context) (PackOptionsV2Response, error) {
 	grouped, err := trails.ReturnTrailsGrouped(ctx)
 	if err != nil {
-		grouped = make(map[string]map[string][]trails.TrailSummary)
+		return PackOptionsV2Response{}, err
 	}
 	return PackOptionsV2Response{
 		Seasons:    append([]string{}, allowedSeasons...),
 		Trails:     grouped,
 		Adventures: append([]string{}, allowedAdventures...),
-	}
+	}, nil
 }
 
 // isAllowedValue checks if a value is in the allowed list.

--- a/pkg/profiles/repository.go
+++ b/pkg/profiles/repository.go
@@ -63,18 +63,19 @@ func returnSharedPacksByUsername(ctx context.Context, username string) ([]Shared
 		    COALESCE(SUM(CASE WHEN pc.worn = false AND pc.consumable = false
 		        THEN i.weight * pc.quantity ELSE 0 END), 0) AS base_weight,
 		    COALESCE(SUM(pc.quantity), 0) AS pack_items_count,
-		    p.sharing_code, p.season, p.trail, p.adventure, p.created_at
+		    p.sharing_code, p.season, COALESCE(t.name, p.trail) as trail, p.adventure, p.created_at
 		FROM pack p
 		JOIN account a ON p.user_id = a.id
 		LEFT JOIN pack_content pc ON p.id = pc.pack_id
 		LEFT JOIN inventory i ON pc.item_id = i.id
 		LEFT JOIN pack_images pi ON p.id = pi.pack_id
+		LEFT JOIN trail t ON p.trail_id = t.id
 		WHERE a.username = $1
 		  AND a.status = 'active'
 		  AND a.is_profile_public = true
 		  AND p.sharing_code IS NOT NULL
 		GROUP BY p.id, p.pack_name, p.pack_description, p.sharing_code,
-		         pi.pack_id, p.season, p.trail, p.adventure, p.created_at
+		         pi.pack_id, p.season, t.name, p.trail, p.adventure, p.created_at
 		ORDER BY p.created_at DESC;`,
 		username,
 	)

--- a/pkg/trails/handlers.go
+++ b/pkg/trails/handlers.go
@@ -1,0 +1,284 @@
+package trails
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/Angak0k/pimpmypack/pkg/helper"
+	"github.com/gin-gonic/gin"
+)
+
+// Get all trails
+// @Summary [ADMIN] Get all trails
+// @Description Get all trails - for admin use only
+// @Security Bearer
+// @Tags Internal
+// @Produce  json
+// @Success 200 {object} Trails
+// @Failure 500 {object} apitypes.ErrorResponse
+// @Router /admin/trails [get]
+func GetTrails(c *gin.Context) {
+	trails, err := returnTrails(c.Request.Context())
+	if err != nil {
+		helper.LogAndSanitize(err, "get trails: return trails failed")
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	if len(trails) != 0 {
+		c.IndentedJSON(http.StatusOK, trails)
+	} else {
+		c.IndentedJSON(http.StatusNotFound, gin.H{"error": "No trails found"})
+	}
+}
+
+// Get trail by ID
+// @Summary [ADMIN] Get trail by ID
+// @Description Get trail by ID - for admin use only
+// @Security Bearer
+// @Tags Internal
+// @Produce  json
+// @Param id path int true "Trail ID"
+// @Success 200 {object} Trail
+// @Failure 400 {object} apitypes.ErrorResponse "Invalid ID format"
+// @Failure 404 {object} apitypes.ErrorResponse "Trail not found"
+// @Failure 500 {object} apitypes.ErrorResponse "Internal Server Error"
+// @Router /admin/trails/{id} [get]
+func GetTrailByID(c *gin.Context) {
+	id, err := helper.StringToUint(c.Param("id"))
+	if err != nil {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"error": "Invalid ID format"})
+		return
+	}
+
+	trail, err := findTrailByID(c.Request.Context(), id)
+	if err != nil {
+		if errors.Is(err, ErrTrailNotFound) {
+			c.IndentedJSON(http.StatusNotFound, gin.H{"error": "Trail not found"})
+			return
+		}
+		helper.LogAndSanitize(err, "get trail by ID: find trail failed")
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	c.IndentedJSON(http.StatusOK, *trail)
+}
+
+// Create a new trail
+// @Summary [ADMIN] Create a new trail
+// @Description Create a new trail - for admin use only
+// @Security Bearer
+// @Tags Internal
+// @Accept  json
+// @Produce  json
+// @Param trail body TrailCreateRequest true "Trail"
+// @Success 201 {object} Trail
+// @Failure 400 {object} apitypes.ErrorResponse
+// @Failure 409 {object} apitypes.ErrorResponse "Trail name already exists"
+// @Failure 500 {object} apitypes.ErrorResponse
+// @Router /admin/trails [post]
+func PostTrail(c *gin.Context) {
+	var input TrailCreateRequest
+
+	if err := c.BindJSON(&input); err != nil {
+		helper.LogAndSanitize(err, "post trail: bind JSON failed")
+		c.JSON(http.StatusBadRequest, gin.H{"error": helper.ErrMsgBadRequest})
+		return
+	}
+
+	newTrail := Trail{
+		Name:       input.Name,
+		Country:    input.Country,
+		Continent:  input.Continent,
+		DistanceKm: input.DistanceKm,
+		URL:        input.URL,
+	}
+
+	err := insertTrail(c.Request.Context(), &newTrail)
+	if err != nil {
+		if errors.Is(err, ErrTrailNameExists) {
+			c.JSON(http.StatusConflict, gin.H{"error": "Trail name already exists"})
+			return
+		}
+		helper.LogAndSanitize(err, "post trail: insert trail failed")
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	c.IndentedJSON(http.StatusCreated, newTrail)
+}
+
+// Update a trail by ID
+// @Summary [ADMIN] Update a trail by ID
+// @Description Update a trail by ID - for admin use only
+// @Security Bearer
+// @Tags Internal
+// @Accept  json
+// @Produce  json
+// @Param id path int true "Trail ID"
+// @Param trail body TrailUpdateRequest true "Trail"
+// @Success 200 {object} Trail
+// @Failure 400 {object} apitypes.ErrorResponse
+// @Failure 404 {object} apitypes.ErrorResponse "Trail not found"
+// @Failure 409 {object} apitypes.ErrorResponse "Trail name already exists"
+// @Failure 500 {object} apitypes.ErrorResponse
+// @Router /admin/trails/{id} [put]
+func PutTrailByID(c *gin.Context) {
+	id, err := helper.StringToUint(c.Param("id"))
+	if err != nil {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"error": "Invalid ID format"})
+		return
+	}
+
+	var input TrailUpdateRequest
+	if err := c.BindJSON(&input); err != nil {
+		helper.LogAndSanitize(err, "put trail: bind JSON failed")
+		c.JSON(http.StatusBadRequest, gin.H{"error": helper.ErrMsgBadRequest})
+		return
+	}
+
+	existingTrail, err := findTrailByID(c.Request.Context(), id)
+	if err != nil {
+		if errors.Is(err, ErrTrailNotFound) {
+			c.IndentedJSON(http.StatusNotFound, gin.H{"error": "Trail not found"})
+			return
+		}
+		helper.LogAndSanitize(err, "put trail by ID: find trail failed")
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	updatedTrail := *existingTrail
+	updatedTrail.Name = input.Name
+	updatedTrail.Country = input.Country
+	updatedTrail.Continent = input.Continent
+	updatedTrail.DistanceKm = input.DistanceKm
+	updatedTrail.URL = input.URL
+
+	err = updateTrailByID(c.Request.Context(), id, &updatedTrail)
+	if err != nil {
+		if errors.Is(err, ErrTrailNameExists) {
+			c.JSON(http.StatusConflict, gin.H{"error": "Trail name already exists"})
+			return
+		}
+		helper.LogAndSanitize(err, "put trail by ID: update trail failed")
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	c.IndentedJSON(http.StatusOK, updatedTrail)
+}
+
+// Delete a trail by ID
+// @Summary [ADMIN] Delete a trail by ID
+// @Description Delete a trail by ID - for admin use only. Fails if trail is in use by packs.
+// @Security Bearer
+// @Tags Internal
+// @Produce  json
+// @Param id path int true "Trail ID"
+// @Success 200 {object} apitypes.OkResponse "Trail deleted"
+// @Failure 400 {object} apitypes.ErrorResponse "Invalid ID format"
+// @Failure 404 {object} apitypes.ErrorResponse "Trail not found"
+// @Failure 409 {object} apitypes.ErrorResponse "Trail is in use"
+// @Failure 500 {object} apitypes.ErrorResponse
+// @Router /admin/trails/{id} [delete]
+func DeleteTrailByID(c *gin.Context) {
+	id, err := helper.StringToUint(c.Param("id"))
+	if err != nil {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"error": "Invalid ID format"})
+		return
+	}
+
+	err = deleteTrailByID(c.Request.Context(), id)
+	if err != nil {
+		if errors.Is(err, ErrTrailNotFound) {
+			c.IndentedJSON(http.StatusNotFound, gin.H{"error": "Trail not found"})
+			return
+		}
+		if errors.Is(err, ErrTrailInUse) {
+			c.IndentedJSON(http.StatusConflict, gin.H{"error": "Trail is in use by one or more packs"})
+			return
+		}
+		helper.LogAndSanitize(err, "delete trail by ID: delete trail failed")
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	c.IndentedJSON(http.StatusOK, gin.H{"message": "Trail deleted"})
+}
+
+// Bulk create trails
+// @Summary [ADMIN] Bulk create trails
+// @Description Bulk create trails - for admin use only
+// @Security Bearer
+// @Tags Internal
+// @Accept  json
+// @Produce  json
+// @Param trails body TrailBulkCreateRequest true "Trails"
+// @Success 201 {object} Trails
+// @Failure 400 {object} apitypes.ErrorResponse
+// @Failure 409 {object} apitypes.ErrorResponse "Duplicate trail name"
+// @Failure 500 {object} apitypes.ErrorResponse
+// @Router /admin/trails/bulk [post]
+func PostTrailsBulk(c *gin.Context) {
+	var input TrailBulkCreateRequest
+
+	if err := c.BindJSON(&input); err != nil {
+		helper.LogAndSanitize(err, "post trails bulk: bind JSON failed")
+		c.JSON(http.StatusBadRequest, gin.H{"error": helper.ErrMsgBadRequest})
+		return
+	}
+
+	trailsToCreate := make([]Trail, len(input.Trails))
+	for i, req := range input.Trails {
+		trailsToCreate[i] = Trail{
+			Name:       req.Name,
+			Country:    req.Country,
+			Continent:  req.Continent,
+			DistanceKm: req.DistanceKm,
+			URL:        req.URL,
+		}
+	}
+
+	created, err := insertTrailsBulk(c.Request.Context(), trailsToCreate)
+	if err != nil {
+		helper.LogAndSanitize(err, "post trails bulk: insert trails failed")
+		c.IndentedJSON(http.StatusConflict, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.IndentedJSON(http.StatusCreated, created)
+}
+
+// Bulk delete trails
+// @Summary [ADMIN] Bulk delete trails
+// @Description Bulk delete trails - for admin use only. Fails if any trail is in use by packs.
+// @Security Bearer
+// @Tags Internal
+// @Accept  json
+// @Produce  json
+// @Param ids body TrailBulkDeleteRequest true "Trail IDs"
+// @Success 200 {object} apitypes.OkResponse "Trails deleted"
+// @Failure 400 {object} apitypes.ErrorResponse
+// @Failure 409 {object} apitypes.ErrorResponse "Trail in use"
+// @Failure 500 {object} apitypes.ErrorResponse
+// @Router /admin/trails/bulk [delete]
+func DeleteTrailsBulk(c *gin.Context) {
+	var input TrailBulkDeleteRequest
+
+	if err := c.BindJSON(&input); err != nil {
+		helper.LogAndSanitize(err, "delete trails bulk: bind JSON failed")
+		c.JSON(http.StatusBadRequest, gin.H{"error": helper.ErrMsgBadRequest})
+		return
+	}
+
+	err := deleteTrailsBulk(c.Request.Context(), input.IDs)
+	if err != nil {
+		helper.LogAndSanitize(err, "delete trails bulk: delete trails failed")
+		c.IndentedJSON(http.StatusConflict, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.IndentedJSON(http.StatusOK, gin.H{"message": "Trails deleted"})
+}

--- a/pkg/trails/handlers.go
+++ b/pkg/trails/handlers.go
@@ -243,8 +243,12 @@ func PostTrailsBulk(c *gin.Context) {
 
 	created, err := insertTrailsBulk(c.Request.Context(), trailsToCreate)
 	if err != nil {
+		if errors.Is(err, ErrTrailNameExists) {
+			c.JSON(http.StatusConflict, gin.H{"error": "One or more trail names already exist"})
+			return
+		}
 		helper.LogAndSanitize(err, "post trails bulk: insert trails failed")
-		c.IndentedJSON(http.StatusConflict, gin.H{"error": err.Error()})
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
 		return
 	}
 
@@ -275,8 +279,16 @@ func DeleteTrailsBulk(c *gin.Context) {
 
 	err := deleteTrailsBulk(c.Request.Context(), input.IDs)
 	if err != nil {
+		if errors.Is(err, ErrTrailInUse) {
+			c.JSON(http.StatusConflict, gin.H{"error": "One or more trails are in use by packs"})
+			return
+		}
+		if errors.Is(err, ErrTrailNotFound) {
+			c.IndentedJSON(http.StatusNotFound, gin.H{"error": "One or more trail IDs not found"})
+			return
+		}
 		helper.LogAndSanitize(err, "delete trails bulk: delete trails failed")
-		c.IndentedJSON(http.StatusConflict, gin.H{"error": err.Error()})
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
 		return
 	}
 

--- a/pkg/trails/repository.go
+++ b/pkg/trails/repository.go
@@ -1,0 +1,309 @@
+package trails
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Angak0k/pimpmypack/pkg/database"
+)
+
+func returnTrails(ctx context.Context) (Trails, error) {
+	rows, err := database.DB().QueryContext(ctx,
+		`SELECT id, name, country, continent, distance_km, url, created_at, updated_at
+		FROM trail
+		ORDER BY continent, country, name;`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var trails Trails
+	for rows.Next() {
+		var t Trail
+		err := rows.Scan(&t.ID, &t.Name, &t.Country, &t.Continent,
+			&t.DistanceKm, &t.URL, &t.CreatedAt, &t.UpdatedAt)
+		if err != nil {
+			return nil, err
+		}
+		trails = append(trails, t)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return trails, nil
+}
+
+func findTrailByID(ctx context.Context, id uint) (*Trail, error) {
+	var t Trail
+	err := database.DB().QueryRowContext(ctx,
+		`SELECT id, name, country, continent, distance_km, url, created_at, updated_at
+		FROM trail WHERE id = $1;`, id).Scan(
+		&t.ID, &t.Name, &t.Country, &t.Continent,
+		&t.DistanceKm, &t.URL, &t.CreatedAt, &t.UpdatedAt)
+
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrTrailNotFound
+		}
+		return nil, err
+	}
+
+	return &t, nil
+}
+
+func findTrailByName(ctx context.Context, name string) (*Trail, error) {
+	var t Trail
+	err := database.DB().QueryRowContext(ctx,
+		`SELECT id, name, country, continent, distance_km, url, created_at, updated_at
+		FROM trail WHERE name = $1;`, name).Scan(
+		&t.ID, &t.Name, &t.Country, &t.Continent,
+		&t.DistanceKm, &t.URL, &t.CreatedAt, &t.UpdatedAt)
+
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrTrailNotFound
+		}
+		return nil, err
+	}
+
+	return &t, nil
+}
+
+func insertTrail(ctx context.Context, t *Trail) error {
+	if t == nil {
+		return errors.New("payload is empty")
+	}
+	t.CreatedAt = time.Now().Truncate(time.Second)
+	t.UpdatedAt = time.Now().Truncate(time.Second)
+
+	err := database.DB().QueryRowContext(ctx,
+		`INSERT INTO trail (name, country, continent, distance_km, url, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		RETURNING id;`,
+		t.Name, t.Country, t.Continent, t.DistanceKm, t.URL,
+		t.CreatedAt, t.UpdatedAt).Scan(&t.ID)
+
+	if err != nil {
+		if strings.Contains(err.Error(), "idx_trail_name") {
+			return ErrTrailNameExists
+		}
+		return err
+	}
+
+	return nil
+}
+
+func updateTrailByID(ctx context.Context, id uint, t *Trail) error {
+	if t == nil {
+		return errors.New("payload is empty")
+	}
+	t.UpdatedAt = time.Now().Truncate(time.Second)
+
+	result, err := database.DB().ExecContext(ctx,
+		`UPDATE trail SET name=$1, country=$2, continent=$3, distance_km=$4, url=$5, updated_at=$6
+		WHERE id=$7;`,
+		t.Name, t.Country, t.Continent, t.DistanceKm, t.URL, t.UpdatedAt, id)
+	if err != nil {
+		if strings.Contains(err.Error(), "idx_trail_name") {
+			return ErrTrailNameExists
+		}
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return ErrTrailNotFound
+	}
+
+	return nil
+}
+
+func deleteTrailByID(ctx context.Context, id uint) error {
+	// Check if any pack references this trail
+	var count int
+	err := database.DB().QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM pack WHERE trail_id = $1;`, id).Scan(&count)
+	if err != nil {
+		return err
+	}
+	if count > 0 {
+		return ErrTrailInUse
+	}
+
+	result, err := database.DB().ExecContext(ctx,
+		`DELETE FROM trail WHERE id = $1;`, id)
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return ErrTrailNotFound
+	}
+
+	return nil
+}
+
+func insertTrailsBulk(ctx context.Context, trailsToCreate []Trail) ([]Trail, error) {
+	tx, err := database.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	now := time.Now().Truncate(time.Second)
+	created := make([]Trail, 0, len(trailsToCreate))
+
+	for i := range trailsToCreate {
+		t := &trailsToCreate[i]
+		t.CreatedAt = now
+		t.UpdatedAt = now
+
+		err = tx.QueryRowContext(ctx,
+			`INSERT INTO trail (name, country, continent, distance_km, url, created_at, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			RETURNING id;`,
+			t.Name, t.Country, t.Continent, t.DistanceKm, t.URL,
+			t.CreatedAt, t.UpdatedAt).Scan(&t.ID)
+		if err != nil {
+			if strings.Contains(err.Error(), "idx_trail_name") {
+				return nil, fmt.Errorf("trail name %q already exists", t.Name)
+			}
+			return nil, fmt.Errorf("failed to insert trail %q: %w", t.Name, err)
+		}
+		created = append(created, *t)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return nil, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return created, nil
+}
+
+func deleteTrailsBulk(ctx context.Context, ids []uint) error {
+	tx, err := database.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	for _, id := range ids {
+		// Check if any pack references this trail
+		var count int
+		err = tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM pack WHERE trail_id = $1;`, id).Scan(&count)
+		if err != nil {
+			return fmt.Errorf("failed to check trail %d usage: %w", id, err)
+		}
+		if count > 0 {
+			return fmt.Errorf("trail ID %d is in use by %d pack(s)", id, count)
+		}
+
+		result, execErr := tx.ExecContext(ctx, `DELETE FROM trail WHERE id = $1;`, id)
+		if execErr != nil {
+			err = execErr
+			return fmt.Errorf("failed to delete trail %d: %w", id, err)
+		}
+
+		rowsAffected, raErr := result.RowsAffected()
+		if raErr != nil {
+			err = raErr
+			return fmt.Errorf("failed to get rows affected for trail %d: %w", id, err)
+		}
+		if rowsAffected == 0 {
+			err = fmt.Errorf("trail ID %d not found", id)
+			return err
+		}
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+func returnTrailsGrouped(ctx context.Context) (map[string]map[string][]TrailSummary, error) {
+	rows, err := database.DB().QueryContext(ctx,
+		`SELECT id, name, continent, country, distance_km, url
+		FROM trail
+		ORDER BY continent, country, name;`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	grouped := make(map[string]map[string][]TrailSummary)
+	for rows.Next() {
+		var id uint
+		var name, continent, country string
+		var distanceKm *int
+		var url *string
+
+		err := rows.Scan(&id, &name, &continent, &country, &distanceKm, &url)
+		if err != nil {
+			return nil, err
+		}
+
+		if grouped[continent] == nil {
+			grouped[continent] = make(map[string][]TrailSummary)
+		}
+		grouped[continent][country] = append(grouped[continent][country], TrailSummary{
+			ID:         id,
+			Name:       name,
+			DistanceKm: distanceKm,
+			URL:        url,
+		})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return grouped, nil
+}
+
+func returnTrailNames(ctx context.Context) ([]string, error) {
+	rows, err := database.DB().QueryContext(ctx,
+		`SELECT name FROM trail ORDER BY name;`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return names, nil
+}

--- a/pkg/trails/repository.go
+++ b/pkg/trails/repository.go
@@ -5,11 +5,13 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/Angak0k/pimpmypack/pkg/database"
+	"github.com/lib/pq"
 )
+
+const trailNameConstraint = "idx_trail_name"
 
 func returnTrails(ctx context.Context) (Trails, error) {
 	rows, err := database.DB().QueryContext(ctx,
@@ -90,7 +92,8 @@ func insertTrail(ctx context.Context, t *Trail) error {
 		t.CreatedAt, t.UpdatedAt).Scan(&t.ID)
 
 	if err != nil {
-		if strings.Contains(err.Error(), "idx_trail_name") {
+		var pqErr *pq.Error
+		if errors.As(err, &pqErr) && pqErr.Code == "23505" && pqErr.Constraint == trailNameConstraint {
 			return ErrTrailNameExists
 		}
 		return err
@@ -110,7 +113,8 @@ func updateTrailByID(ctx context.Context, id uint, t *Trail) error {
 		WHERE id=$7;`,
 		t.Name, t.Country, t.Continent, t.DistanceKm, t.URL, t.UpdatedAt, id)
 	if err != nil {
-		if strings.Contains(err.Error(), "idx_trail_name") {
+		var pqErr *pq.Error
+		if errors.As(err, &pqErr) && pqErr.Code == "23505" && pqErr.Constraint == trailNameConstraint {
 			return ErrTrailNameExists
 		}
 		return err
@@ -182,8 +186,9 @@ func insertTrailsBulk(ctx context.Context, trailsToCreate []Trail) ([]Trail, err
 			t.Name, t.Country, t.Continent, t.DistanceKm, t.URL,
 			t.CreatedAt, t.UpdatedAt).Scan(&t.ID)
 		if err != nil {
-			if strings.Contains(err.Error(), "idx_trail_name") {
-				return nil, fmt.Errorf("trail name %q already exists", t.Name)
+			var pqErr *pq.Error
+			if errors.As(err, &pqErr) && pqErr.Code == "23505" && pqErr.Constraint == trailNameConstraint {
+				return nil, ErrTrailNameExists
 			}
 			return nil, fmt.Errorf("failed to insert trail %q: %w", t.Name, err)
 		}
@@ -217,7 +222,7 @@ func deleteTrailsBulk(ctx context.Context, ids []uint) error {
 			return fmt.Errorf("failed to check trail %d usage: %w", id, err)
 		}
 		if count > 0 {
-			return fmt.Errorf("trail ID %d is in use by %d pack(s)", id, count)
+			return ErrTrailInUse
 		}
 
 		result, execErr := tx.ExecContext(ctx, `DELETE FROM trail WHERE id = $1;`, id)
@@ -232,7 +237,7 @@ func deleteTrailsBulk(ctx context.Context, ids []uint) error {
 			return fmt.Errorf("failed to get rows affected for trail %d: %w", id, err)
 		}
 		if rowsAffected == 0 {
-			err = fmt.Errorf("trail ID %d not found", id)
+			err = ErrTrailNotFound
 			return err
 		}
 	}

--- a/pkg/trails/service.go
+++ b/pkg/trails/service.go
@@ -1,0 +1,44 @@
+package trails
+
+import (
+	"context"
+	"errors"
+)
+
+// FindTrailByID finds a trail by its ID.
+// This is a public service function used by other packages.
+func FindTrailByID(ctx context.Context, id uint) (*Trail, error) {
+	return findTrailByID(ctx, id)
+}
+
+// FindTrailByName finds a trail by its name.
+// This is a public service function used by other packages (e.g., packs for V1 resolution).
+func FindTrailByName(ctx context.Context, name string) (*Trail, error) {
+	return findTrailByName(ctx, name)
+}
+
+// ReturnTrailNames returns a flat list of trail names for V1 pack-options.
+func ReturnTrailNames(ctx context.Context) ([]string, error) {
+	return returnTrailNames(ctx)
+}
+
+// ReturnTrailsGrouped returns trails grouped by continent and country for V2 pack-options.
+func ReturnTrailsGrouped(ctx context.Context) (map[string]map[string][]TrailSummary, error) {
+	return returnTrailsGrouped(ctx)
+}
+
+// IsValidTrailName checks if a trail name exists in the database.
+// Returns true if name is nil (optional field) or found in the database.
+func IsValidTrailName(ctx context.Context, name *string) (bool, error) {
+	if name == nil {
+		return true, nil
+	}
+	_, err := findTrailByName(ctx, *name)
+	if err != nil {
+		if errors.Is(err, ErrTrailNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/pkg/trails/testdata.go
+++ b/pkg/trails/testdata.go
@@ -1,0 +1,171 @@
+package trails
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Angak0k/pimpmypack/pkg/accounts"
+	"github.com/Angak0k/pimpmypack/pkg/database"
+	"github.com/Angak0k/pimpmypack/pkg/security"
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+var testUsers = []accounts.User{
+	{
+		Username:     "trailuser-" + random.UniqueId(),
+		Email:        "trailuser-" + random.UniqueId() + "@example.com",
+		Firstname:    "Trail",
+		Lastname:     "Tester",
+		Role:         "admin",
+		Status:       "active",
+		Password:     "password",
+		LastPassword: "password",
+	},
+}
+
+var testTrails = Trails{
+	{
+		Name:      "Test Trail Alpha",
+		Country:   "France",
+		Continent: "Europe",
+	},
+	{
+		Name:      "Test Trail Beta",
+		Country:   "United States",
+		Continent: "North America",
+	},
+	{
+		Name:      "Test Trail Gamma",
+		Country:   "Japan",
+		Continent: "Asia",
+	},
+}
+
+func loadingTrailDataset() error {
+	tx, err := database.DB().BeginTx(context.Background(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := loadTrailTestAccounts(tx); err != nil {
+		return fmt.Errorf("failed to load accounts: %w", err)
+	}
+
+	if err := loadTrailTestData(tx); err != nil {
+		return fmt.Errorf("failed to load trails: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+func loadTrailTestAccounts(tx *sql.Tx) error {
+	println("-> Loading trail test accounts...")
+	for i := range testUsers {
+		var existingID int
+		err := tx.QueryRowContext(context.Background(),
+			"SELECT id FROM account WHERE username = $1", testUsers[i].Username).Scan(&existingID)
+		if err == nil {
+			if existingID < 0 {
+				return fmt.Errorf("invalid user ID: negative value %d", existingID)
+			}
+			testUsers[i].ID = uint(existingID)
+			continue
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("failed to check existing user: %w", err)
+		}
+
+		err = tx.QueryRowContext(context.Background(),
+			`INSERT INTO account (username, email, firstname, lastname, role, status, created_at, updated_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+			RETURNING id;`,
+			testUsers[i].Username, testUsers[i].Email,
+			testUsers[i].Firstname, testUsers[i].Lastname,
+			testUsers[i].Role, testUsers[i].Status,
+			time.Now().Truncate(time.Second),
+			time.Now().Truncate(time.Second)).Scan(&testUsers[i].ID)
+		if err != nil {
+			return fmt.Errorf("failed to insert user: %w", err)
+		}
+
+		hashedPassword, err := security.HashPassword(testUsers[i].Password)
+		if err != nil {
+			return fmt.Errorf("failed to hash password: %w", err)
+		}
+
+		hashedLastPassword, err := security.HashPassword(testUsers[i].LastPassword)
+		if err != nil {
+			return fmt.Errorf("failed to hash last password: %w", err)
+		}
+
+		var passwordID uint
+		err = tx.QueryRowContext(context.Background(),
+			`INSERT INTO password (user_id, password, last_password, updated_at) VALUES ($1,$2,$3,$4)
+			RETURNING id;`,
+			testUsers[i].ID, hashedPassword, hashedLastPassword,
+			time.Now().Truncate(time.Second)).Scan(&passwordID)
+		if err != nil {
+			return fmt.Errorf("failed to insert password: %w", err)
+		}
+	}
+	println("-> Trail test accounts loaded...")
+	return nil
+}
+
+func loadTrailTestData(tx *sql.Tx) error {
+	println("-> Loading trail test data...")
+	now := time.Now().Truncate(time.Second)
+
+	for i := range testTrails {
+		err := tx.QueryRowContext(context.Background(),
+			`INSERT INTO trail (name, country, continent, distance_km, url, created_at, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			RETURNING id;`,
+			testTrails[i].Name, testTrails[i].Country, testTrails[i].Continent,
+			testTrails[i].DistanceKm, testTrails[i].URL,
+			now, now).Scan(&testTrails[i].ID)
+		if err != nil {
+			return fmt.Errorf("failed to insert trail %q: %w", testTrails[i].Name, err)
+		}
+	}
+
+	println("-> Trail test data loaded...")
+	return nil
+}
+
+func cleanupTrailDataset() error {
+	ctx := context.Background()
+	println("-> Cleaning up trail test data...")
+
+	for _, t := range testTrails {
+		if t.ID != 0 {
+			_, err := database.DB().ExecContext(ctx, "DELETE FROM trail WHERE id = $1", t.ID)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("failed to delete trail %d: %w", t.ID, err)
+			}
+		}
+	}
+
+	for _, user := range testUsers {
+		if user.ID != 0 {
+			_, err := database.DB().ExecContext(ctx, "DELETE FROM account WHERE id = $1", user.ID)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("failed to delete user %d: %w", user.ID, err)
+			}
+		}
+	}
+
+	println("-> Trail test data cleaned up...")
+	return nil
+}

--- a/pkg/trails/trails_test.go
+++ b/pkg/trails/trails_test.go
@@ -1,0 +1,506 @@
+package trails
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/Angak0k/pimpmypack/pkg/config"
+	"github.com/Angak0k/pimpmypack/pkg/database"
+	"github.com/Angak0k/pimpmypack/pkg/security"
+	"github.com/gin-gonic/gin"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMain(m *testing.M) {
+	err := config.EnvInit("../../.env")
+	if err != nil {
+		log.Fatalf("Error loading .env file or environment variable : %v", err)
+	}
+	println("Environment variables loaded")
+
+	err = database.Initialization()
+	if err != nil {
+		log.Fatalf("Error connecting database : %v", err)
+	}
+	println("Database connected")
+
+	err = database.Migrate()
+	if err != nil {
+		log.Fatalf("Error migrating database : %v", err)
+	}
+	println("Database migrated")
+
+	println("Loading dataset...")
+	err = loadingTrailDataset()
+	if err != nil {
+		log.Fatalf("Error loading dataset : %v", err)
+	}
+	println("Dataset loaded...")
+
+	ret := m.Run()
+
+	println("Cleaning up test data...")
+	err = cleanupTrailDataset()
+	if err != nil {
+		log.Printf("Warning: Error cleaning up dataset : %v", err)
+	}
+
+	os.Exit(ret)
+}
+
+func TestGetTrails(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.Default()
+	router.GET("/api/admin/trails", GetTrails)
+
+	token, err := security.GenerateToken(testUsers[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/trails", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var trails Trails
+	err = json.Unmarshal(w.Body.Bytes(), &trails)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(trails) < 3 {
+		t.Errorf("Expected at least 3 trails, got %d", len(trails))
+	}
+}
+
+func TestGetTrailByID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.Default()
+	router.GET("/api/admin/trails/:id", GetTrailByID)
+
+	token, err := security.GenerateToken(testUsers[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("success", func(t *testing.T) {
+		url := fmt.Sprintf("/api/admin/trails/%d", testTrails[0].ID)
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status %d, got %d: %s",
+				http.StatusOK, w.Code, w.Body.String())
+		}
+
+		var trail Trail
+		err = json.Unmarshal(w.Body.Bytes(), &trail)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(testTrails[0].Name, trail.Name); diff != "" {
+			t.Errorf("Trail name mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet,
+			"/api/admin/trails/999999", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("Expected status %d, got %d",
+				http.StatusNotFound, w.Code)
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet,
+			"/api/admin/trails/abc", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("Expected status %d, got %d",
+				http.StatusBadRequest, w.Code)
+		}
+	})
+}
+
+func TestPostTrail(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.Default()
+	router.POST("/api/admin/trails", PostTrail)
+
+	token, err := security.GenerateToken(testUsers[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("success", func(t *testing.T) {
+		input := TrailCreateRequest{
+			Name:      "Test New Trail",
+			Country:   "Switzerland",
+			Continent: "Europe",
+		}
+		body, _ := json.Marshal(input)
+
+		req := httptest.NewRequest(http.MethodPost,
+			"/api/admin/trails", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusCreated {
+			t.Errorf("Expected status %d, got %d: %s",
+				http.StatusCreated, w.Code, w.Body.String())
+		}
+
+		var trail Trail
+		err = json.Unmarshal(w.Body.Bytes(), &trail)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if trail.ID == 0 {
+			t.Error("Expected trail ID to be set")
+		}
+
+		// Clean up
+		_, _ = database.DB().ExecContext(
+			req.Context(), "DELETE FROM trail WHERE id = $1", trail.ID)
+	})
+
+	t.Run("duplicate name", func(t *testing.T) {
+		input := TrailCreateRequest{
+			Name:      testTrails[0].Name,
+			Country:   "France",
+			Continent: "Europe",
+		}
+		body, _ := json.Marshal(input)
+
+		req := httptest.NewRequest(http.MethodPost,
+			"/api/admin/trails", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusConflict {
+			t.Errorf("Expected status %d, got %d: %s",
+				http.StatusConflict, w.Code, w.Body.String())
+		}
+	})
+}
+
+func TestPutTrailByID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.Default()
+	router.PUT("/api/admin/trails/:id", PutTrailByID)
+
+	token, err := security.GenerateToken(testUsers[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("success", func(t *testing.T) {
+		input := TrailUpdateRequest{
+			Name:      testTrails[0].Name,
+			Country:   "France",
+			Continent: "Europe",
+		}
+		body, _ := json.Marshal(input)
+
+		url := fmt.Sprintf("/api/admin/trails/%d", testTrails[0].ID)
+		req := httptest.NewRequest(http.MethodPut, url,
+			bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status %d, got %d: %s",
+				http.StatusOK, w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		input := TrailUpdateRequest{
+			Name:      "Nonexistent",
+			Country:   "France",
+			Continent: "Europe",
+		}
+		body, _ := json.Marshal(input)
+
+		req := httptest.NewRequest(http.MethodPut,
+			"/api/admin/trails/999999", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("Expected status %d, got %d",
+				http.StatusNotFound, w.Code)
+		}
+	})
+}
+
+func TestDeleteTrailByID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.Default()
+	router.DELETE("/api/admin/trails/:id", DeleteTrailByID)
+
+	token, err := security.GenerateToken(testUsers[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("success", func(t *testing.T) {
+		ctx := t.Context()
+		var trailID uint
+		err := database.DB().QueryRowContext(ctx,
+			`INSERT INTO trail (name, country, continent,
+			created_at, updated_at)
+			VALUES ($1, $2, $3, NOW(), NOW()) RETURNING id;`,
+			"Trail To Delete", "France", "Europe").Scan(&trailID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		url := fmt.Sprintf("/api/admin/trails/%d", trailID)
+		req := httptest.NewRequest(http.MethodDelete, url, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status %d, got %d: %s",
+				http.StatusOK, w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodDelete,
+			"/api/admin/trails/999999", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("Expected status %d, got %d",
+				http.StatusNotFound, w.Code)
+		}
+	})
+}
+
+func TestPostTrailsBulk(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.Default()
+	router.POST("/api/admin/trails/bulk", PostTrailsBulk)
+
+	token, err := security.GenerateToken(testUsers[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("success", func(t *testing.T) {
+		input := TrailBulkCreateRequest{
+			Trails: []TrailCreateRequest{
+				{Name: "Bulk Trail 1", Country: "Germany",
+					Continent: "Europe"},
+				{Name: "Bulk Trail 2", Country: "Austria",
+					Continent: "Europe"},
+			},
+		}
+		body, _ := json.Marshal(input)
+
+		req := httptest.NewRequest(http.MethodPost,
+			"/api/admin/trails/bulk", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusCreated {
+			t.Errorf("Expected status %d, got %d: %s",
+				http.StatusCreated, w.Code, w.Body.String())
+		}
+
+		var created Trails
+		err = json.Unmarshal(w.Body.Bytes(), &created)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(created) != 2 {
+			t.Errorf("Expected 2 trails, got %d", len(created))
+		}
+
+		// Clean up
+		for _, trail := range created {
+			_, _ = database.DB().ExecContext(
+				req.Context(),
+				"DELETE FROM trail WHERE id = $1", trail.ID)
+		}
+	})
+}
+
+func TestDeleteTrailsBulk(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.Default()
+	router.DELETE("/api/admin/trails/bulk", DeleteTrailsBulk)
+
+	token, err := security.GenerateToken(testUsers[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("success", func(t *testing.T) {
+		ctx := t.Context()
+		var id1, id2 uint
+		err := database.DB().QueryRowContext(ctx,
+			`INSERT INTO trail (name, country, continent,
+			created_at, updated_at)
+			VALUES ($1, $2, $3, NOW(), NOW()) RETURNING id;`,
+			"Bulk Delete 1", "France", "Europe").Scan(&id1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = database.DB().QueryRowContext(ctx,
+			`INSERT INTO trail (name, country, continent,
+			created_at, updated_at)
+			VALUES ($1, $2, $3, NOW(), NOW()) RETURNING id;`,
+			"Bulk Delete 2", "France", "Europe").Scan(&id2)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		input := TrailBulkDeleteRequest{IDs: []uint{id1, id2}}
+		body, _ := json.Marshal(input)
+
+		req := httptest.NewRequest(http.MethodDelete,
+			"/api/admin/trails/bulk", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status %d, got %d: %s",
+				http.StatusOK, w.Code, w.Body.String())
+		}
+	})
+}
+
+func TestFindTrailByName(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("found", func(t *testing.T) {
+		trail, err := FindTrailByName(ctx, testTrails[0].Name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if trail.Name != testTrails[0].Name {
+			t.Errorf("Expected %q, got %q",
+				testTrails[0].Name, trail.Name)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := FindTrailByName(ctx, "Nonexistent Trail XYZ")
+		if !errors.Is(err, ErrTrailNotFound) {
+			t.Errorf("Expected ErrTrailNotFound, got %v", err)
+		}
+	})
+}
+
+func TestIsValidTrailName(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("valid", func(t *testing.T) {
+		name := testTrails[0].Name
+		valid, err := IsValidTrailName(ctx, &name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !valid {
+			t.Error("Expected trail to be valid")
+		}
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		valid, err := IsValidTrailName(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !valid {
+			t.Error("Expected nil trail to be valid")
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		name := "Invalid Trail XYZ"
+		valid, err := IsValidTrailName(ctx, &name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if valid {
+			t.Error("Expected trail to be invalid")
+		}
+	})
+}
+
+func TestReturnTrailNames(t *testing.T) {
+	ctx := t.Context()
+
+	names, err := ReturnTrailNames(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(names) < 3 {
+		t.Errorf("Expected at least 3 trail names, got %d", len(names))
+	}
+}
+
+func TestReturnTrailsGrouped(t *testing.T) {
+	ctx := t.Context()
+
+	grouped, err := ReturnTrailsGrouped(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(grouped) == 0 {
+		t.Error("Expected non-empty grouped result")
+	}
+	if _, ok := grouped["Europe"]; !ok {
+		t.Error("Expected Europe continent in grouped result")
+	}
+}

--- a/pkg/trails/types.go
+++ b/pkg/trails/types.go
@@ -1,0 +1,69 @@
+package trails
+
+import (
+	"errors"
+	"time"
+)
+
+// Domain errors
+var (
+	ErrTrailNotFound   = errors.New("trail not found")
+	ErrTrailNameExists = errors.New("trail name already exists")
+	ErrTrailInUse      = errors.New("trail is in use by one or more packs")
+)
+
+// Trail represents a trail with its metadata
+type Trail struct {
+	ID         uint      `json:"id"`
+	Name       string    `json:"name"`
+	Country    string    `json:"country"`
+	Continent  string    `json:"continent"`
+	DistanceKm *int      `json:"distance_km,omitempty"`
+	URL        *string   `json:"url,omitempty"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// Trails represents a collection of trails
+type Trails []Trail
+
+// TrailCreateRequest represents the input for creating a trail
+type TrailCreateRequest struct {
+	Name       string  `json:"name" binding:"required"`
+	Country    string  `json:"country" binding:"required"`
+	Continent  string  `json:"continent" binding:"required"`
+	DistanceKm *int    `json:"distance_km"`
+	URL        *string `json:"url"`
+}
+
+// TrailUpdateRequest represents the input for updating a trail
+type TrailUpdateRequest struct {
+	Name       string  `json:"name" binding:"required"`
+	Country    string  `json:"country" binding:"required"`
+	Continent  string  `json:"continent" binding:"required"`
+	DistanceKm *int    `json:"distance_km"`
+	URL        *string `json:"url"`
+}
+
+// TrailBulkCreateRequest represents the input for bulk creating trails
+type TrailBulkCreateRequest struct {
+	Trails []TrailCreateRequest `json:"trails" binding:"required,min=1"`
+}
+
+// TrailBulkDeleteRequest represents the input for bulk deleting trails
+type TrailBulkDeleteRequest struct {
+	IDs []uint `json:"ids" binding:"required,min=1"`
+}
+
+// TrailSummary is a lightweight trail representation for options endpoints
+type TrailSummary struct {
+	ID         uint    `json:"id"`
+	Name       string  `json:"name"`
+	DistanceKm *int    `json:"distance_km,omitempty"`
+	URL        *string `json:"url,omitempty"`
+}
+
+// GroupedResponse represents trails grouped by continent and country
+type GroupedResponse struct {
+	Continents map[string]map[string][]TrailSummary `json:"continents"`
+}

--- a/specs/008_trails-database.md
+++ b/specs/008_trails-database.md
@@ -1,0 +1,174 @@
+# Trails Database & Admin Management - Specification
+
+**Status**: Draft
+**Author**: Claude Agent
+**Date**: 2026-03-07
+**Issue**: #187
+
+---
+
+## Overview
+
+### Purpose
+Move trails from a hardcoded 24-item string allowlist to a database table with country/continent classification, providing admin CRUD+bulk endpoints and a V2 pack-options endpoint with grouped trail hierarchy.
+
+### Goals
+- Store trails in a database table with country, continent, distance, and URL metadata
+- Provide admin CRUD and bulk endpoints for trail management
+- V2 pack-options endpoint returning trails grouped by continent/country
+- Maintain V1 backward compatibility (trail name strings still work)
+
+### Non-Goals
+- V2 pack create/update endpoints with trail_id (follow-up issue)
+- Removing the legacy `trail` TEXT column from pack table (future migration)
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+#### FR1: Trail Database Table
+**Description**: Trails are stored in a dedicated table with metadata.
+
+**Acceptance Criteria**:
+- [ ] `trail` table with id, name, country, continent, distance_km, url, timestamps
+- [ ] Unique index on trail name
+- [ ] Seeded with existing 24 trails plus ~50-80 additional curated trails
+- [ ] `pack` table gains `trail_id` FK column (nullable, ON DELETE SET NULL)
+- [ ] Existing pack trail values are migrated to trail_id via name matching
+
+**Priority**: High
+
+#### FR2: Admin Trail CRUD
+**Description**: Admin users can manage trails via REST endpoints.
+
+**Acceptance Criteria**:
+- [ ] GET /admin/trails - list all trails
+- [ ] GET /admin/trails/:id - get trail by ID
+- [ ] POST /admin/trails - create a trail
+- [ ] PUT /admin/trails/:id - update a trail
+- [ ] DELETE /admin/trails/:id - delete a trail (reject if in use by packs)
+- [ ] POST /admin/trails/bulk - bulk create trails
+- [ ] DELETE /admin/trails/bulk - bulk delete trails
+
+**Priority**: High
+
+#### FR3: V2 Pack Options
+**Description**: New endpoint returns trails grouped by continent and country.
+
+**Acceptance Criteria**:
+- [ ] GET /v2/pack-options returns trails grouped: `{continent: {country: [trails]}}`
+- [ ] V1 GET /v1/pack-options still returns flat trail name list (from DB)
+
+**Priority**: High
+
+#### FR4: V1 Backward Compatibility
+**Description**: Existing V1 pack create/update still accepts trail names.
+
+**Acceptance Criteria**:
+- [ ] Pack create/update with trail name resolves to trail_id internally
+- [ ] Invalid trail names are rejected with 400 error
+- [ ] Pack responses still include trail name string
+- [ ] Dual-write: both trail (TEXT) and trail_id (FK) are written
+
+**Priority**: High
+
+---
+
+## Design
+
+### Data Model
+
+#### New Table: trail
+```sql
+CREATE TABLE "trail" (
+    "id"           SERIAL PRIMARY KEY,
+    "name"         TEXT NOT NULL,
+    "country"      TEXT NOT NULL,
+    "continent"    TEXT NOT NULL,
+    "distance_km"  INT,
+    "url"          TEXT,
+    "created_at"   TIMESTAMP NOT NULL DEFAULT NOW(),
+    "updated_at"   TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX idx_trail_name ON trail(name);
+```
+
+#### Modified Table: pack
+```sql
+ALTER TABLE "pack" ADD COLUMN "trail_id" INT REFERENCES trail(id) ON DELETE SET NULL;
+-- Backfill existing data
+UPDATE pack SET trail_id = t.id FROM trail t WHERE pack.trail = t.name;
+```
+
+### API Design
+
+#### Admin Endpoints (all under /api/admin)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /trails | List all trails |
+| GET | /trails/:id | Get trail by ID |
+| POST | /trails | Create trail |
+| PUT | /trails/:id | Update trail |
+| DELETE | /trails/:id | Delete trail |
+| POST | /trails/bulk | Bulk create |
+| DELETE | /trails/bulk | Bulk delete |
+
+#### V2 Endpoint
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /v2/pack-options | Grouped trail hierarchy |
+
+### Package Structure
+
+New package: `pkg/trails/`
+- `types.go` - Trail structs and request/response types
+- `repository.go` - Database access layer
+- `service.go` - Public service functions for cross-package use
+- `handlers.go` - Admin CRUD + bulk handlers
+- `trails_test.go` - Test suite
+- `testdata.go` - Test fixtures
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+- Full CRUD cycle for admin endpoints
+- Bulk create/delete operations
+- V1 pack-options returns DB-driven flat trail list
+- V2 pack-options returns grouped hierarchy
+- Trail validation in pack create/update
+- Delete rejection when trail is in use
+
+### API Tests
+- Scenario 008: admin trail CRUD, bulk operations, V1/V2 pack-options, pack create with trail
+
+---
+
+## Implementation Plan
+
+### Phase 1: Database Migrations
+- [ ] 000023_trail.up.sql - trail table + seed data
+- [ ] 000024_pack_trail_fk.up.sql - add trail_id FK to pack
+
+### Phase 2: Trails Package
+- [ ] types.go, repository.go, service.go, handlers.go
+- [ ] trails_test.go, testdata.go
+
+### Phase 3: Pack Integration
+- [ ] Update packs to use DB trails for validation
+- [ ] Add trail_id to pack queries (dual-write)
+- [ ] Add V2 pack-options handler
+
+### Phase 4: Route Registration
+- [ ] Admin trail routes in main.go
+- [ ] V2 pack-options route
+
+### Phase 5: Testing & Verification
+- [ ] Unit tests pass
+- [ ] API test scenario 008
+- [ ] Linter clean

--- a/tests/api-scenarios/008-trails-management.yaml
+++ b/tests/api-scenarios/008-trails-management.yaml
@@ -1,0 +1,132 @@
+name: "Trails Database & Admin Management"
+base_url: "http://localhost:8080/api"
+scenarios:
+  # --- Setup: Register admin user ---
+  - name: "Register admin user for trail testing"
+    request:
+      method: POST
+      endpoint: "/register"
+      body:
+        username: "test_trail_admin_{{timestamp}}"
+        email: "trail_admin_{{timestamp}}@example.com"
+        password: "TrailAdmin123!"
+        firstname: "Trail"
+        lastname: "Admin"
+    assertions:
+      - type: status_code
+        expected: 200
+    store:
+      admin_username: "{{request.body.username}}"
+      admin_email: "{{request.body.email}}"
+      admin_password: "{{request.body.password}}"
+
+  - name: "Confirm admin email"
+    request:
+      method: GET
+      endpoint: "/confirmemail?username={{admin_username}}&email={{admin_email}}"
+    assertions:
+      - type: status_code
+        expected: 200
+
+  - name: "Login admin user"
+    request:
+      method: POST
+      endpoint: "/login"
+      body:
+        username: "{{admin_username}}"
+        password: "{{admin_password}}"
+    assertions:
+      - type: status_code
+        expected: 200
+    store:
+      admin_token: "{{response.access_token}}"
+
+  # --- V1 backward compat: pack-options still returns flat trail names ---
+  - name: "V1 pack-options returns flat trail list from DB"
+    request:
+      method: GET
+      endpoint: "/v1/pack-options"
+      headers:
+        Authorization: "Bearer {{admin_token}}"
+    assertions:
+      - type: status_code
+        expected: 200
+      - type: json_path
+        path: "$.seasons"
+        exists: true
+      - type: json_path
+        path: "$.trails"
+        exists: true
+      - type: json_path
+        path: "$.adventures"
+        exists: true
+
+  # --- V2 pack-options returns grouped trails ---
+  - name: "V2 pack-options returns grouped trail hierarchy"
+    request:
+      method: GET
+      endpoint: "/v2/pack-options"
+      headers:
+        Authorization: "Bearer {{admin_token}}"
+    assertions:
+      - type: status_code
+        expected: 200
+      - type: json_path
+        path: "$.seasons"
+        exists: true
+      - type: json_path
+        path: "$.trails"
+        exists: true
+      - type: json_path
+        path: "$.adventures"
+        exists: true
+
+  # --- Pack create with trail name still works (V1 compat) ---
+  - name: "Create pack with valid trail name"
+    request:
+      method: POST
+      endpoint: "/v1/mypack"
+      headers:
+        Authorization: "Bearer {{admin_token}}"
+      body:
+        pack_name: "Trail Test Pack"
+        pack_description: "Pack with trail from DB"
+        season: "3-Season"
+        trail: "GR20"
+        adventure: "Thru-hike"
+    assertions:
+      - type: status_code
+        expected: 201
+      - type: json_path
+        path: "$.trail"
+        equals: "GR20"
+      - type: json_path
+        path: "$.trail_id"
+        exists: true
+    store:
+      pack_id: "{{response.id}}"
+
+  - name: "Create pack with invalid trail name is rejected"
+    request:
+      method: POST
+      endpoint: "/v1/mypack"
+      headers:
+        Authorization: "Bearer {{admin_token}}"
+      body:
+        pack_name: "Invalid Trail Pack"
+        pack_description: "Should fail"
+        trail: "Nonexistent Trail XYZ"
+    assertions:
+      - type: status_code
+        expected: 400
+
+  # --- Cleanup: delete test pack ---
+  - name: "Delete test pack"
+    request:
+      method: DELETE
+      endpoint: "/v1/mypack/{{pack_id}}"
+      headers:
+        Authorization: "Bearer {{admin_token}}"
+    assertions:
+      - type: status_code
+        expected: 200


### PR DESCRIPTION
## Summary

- Moves trails from a hardcoded 24-item allowlist to a database table with ~70 curated trails including country, continent, and distance metadata
- Adds `trail_id` FK to `pack` table with automatic backfill migration from existing `trail` text values
- New `pkg/trails/` package with full admin CRUD endpoints (GET/POST/PUT/DELETE) plus bulk create/delete
- New V2 endpoint `GET /api/v2/pack-options` returning trails grouped by continent and country
- V1 `GET /api/v1/pack-options` now queries the database instead of returning hardcoded list
- Pack create/update with trail name resolves to `trail_id` internally (dual-write for transition)
- All pack SELECT queries JOIN the trail table for name resolution via `COALESCE(t.name, p.trail)`

### New files
| File | Purpose |
|------|---------|
| `pkg/database/migration/.../000023_trail.up.sql` | Trail table + ~70 seed trails |
| `pkg/database/migration/.../000024_pack_trail_fk.up.sql` | Add `trail_id` FK to pack |
| `pkg/trails/types.go` | Trail structs and request/response types |
| `pkg/trails/repository.go` | Database access layer |
| `pkg/trails/service.go` | Public service functions for cross-package use |
| `pkg/trails/handlers.go` | Admin CRUD + bulk handlers with Swagger annotations |
| `pkg/trails/trails_test.go` | Full test suite (64% coverage) |
| `pkg/trails/testdata.go` | Test fixtures |
| `specs/008_trails-database.md` | Technical specification |
| `tests/api-scenarios/008-trails-management.yaml` | API test scenario |

### Modified files
- `main.go` - Register admin trail routes + V2 pack-options route
- `pkg/packs/types.go` - Remove hardcoded trails, add TrailID field, DB-driven options
- `pkg/packs/repository.go` - JOIN trail table, dual-write trail_id
- `pkg/packs/handlers.go` - Trail name resolution, V2 handler, DB-based validation
- `pkg/profiles/repository.go` - JOIN trail table for shared packs
- `pkg/database/seed/` - Resolve trail_id in seed data

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)