### PR TITLE
feat: add has_image to pack contents and public item image endpoint

### DIFF
--- a/api-doc/docs.go
+++ b/api-doc/docs.go
@@ -2633,6 +2633,60 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/packs/{id}/items/{itemId}/image": {
+            "get": {
+                "description": "Get the image for an inventory item within a pack. Public packs are accessible without authentication.",
+                "produces": [
+                    "image/jpeg"
+                ],
+                "tags": [
+                    "Pack Images"
+                ],
+                "summary": "Get pack item image",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Pack ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Item (Inventory) ID",
+                        "name": "itemId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid pack ID or item ID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Pack not found, item not in pack, or has no image",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/v2/pack-options": {
             "get": {
                 "security": [
@@ -3099,6 +3153,9 @@ const docTemplate = `{
                 },
                 "currency": {
                     "type": "string"
+                },
+                "has_image": {
+                    "type": "boolean"
                 },
                 "inventory_id": {
                     "type": "integer"

--- a/api-doc/swagger.json
+++ b/api-doc/swagger.json
@@ -2630,6 +2630,60 @@
                 }
             }
         },
+        "/v1/packs/{id}/items/{itemId}/image": {
+            "get": {
+                "description": "Get the image for an inventory item within a pack. Public packs are accessible without authentication.",
+                "produces": [
+                    "image/jpeg"
+                ],
+                "tags": [
+                    "Pack Images"
+                ],
+                "summary": "Get pack item image",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Pack ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Item (Inventory) ID",
+                        "name": "itemId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid pack ID or item ID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Pack not found, item not in pack, or has no image",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/v2/pack-options": {
             "get": {
                 "security": [
@@ -3096,6 +3150,9 @@
                 },
                 "currency": {
                     "type": "string"
+                },
+                "has_image": {
+                    "type": "boolean"
                 },
                 "inventory_id": {
                     "type": "integer"

--- a/api-doc/swagger.yaml
+++ b/api-doc/swagger.yaml
@@ -292,6 +292,8 @@ definitions:
         type: boolean
       currency:
         type: string
+      has_image:
+        type: boolean
       inventory_id:
         type: integer
       item_description:
@@ -2211,6 +2213,43 @@ paths:
           schema:
             type: string
       summary: Get pack image
+      tags:
+      - Pack Images
+  /v1/packs/{id}/items/{itemId}/image:
+    get:
+      description: Get the image for an inventory item within a pack. Public packs
+        are accessible without authentication.
+      parameters:
+      - description: Pack ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Item (Inventory) ID
+        in: path
+        name: itemId
+        required: true
+        type: integer
+      produces:
+      - image/jpeg
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: file
+        "400":
+          description: Invalid pack ID or item ID
+          schema:
+            type: string
+        "404":
+          description: Pack not found, item not in pack, or has no image
+          schema:
+            type: string
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      summary: Get pack item image
       tags:
       - Pack Images
   /v2/pack-options:

--- a/main.go
+++ b/main.go
@@ -133,6 +133,7 @@ func setupPublicRoutes(router *gin.Engine) {
 	public.GET("/sharedlist/:sharing_code", packs.SharedList)
 	public.GET("/user/:username", profiles.GetPublicProfile)
 	public.GET("/v1/packs/:id/image", images.GetPackImage)
+	public.GET("/v1/packs/:id/items/:itemId/image", images.GetPackItemImage)
 	public.GET("/v1/accounts/:id/image", images.GetProfileImage)
 	public.GET("/v1/accounts/:id/banner", images.GetBannerImage)
 }

--- a/pkg/images/handlers_pack_item.go
+++ b/pkg/images/handlers_pack_item.go
@@ -2,7 +2,6 @@ package images
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/Angak0k/pimpmypack/pkg/helper"
@@ -80,8 +79,6 @@ func GetPackItemImage(c *gin.Context) {
 
 	// Set cache headers for public access
 	c.Header("Cache-Control", "public, max-age=86400")
-	etag := fmt.Sprintf(`"%d-%d"`, packID, itemID)
-	c.Header("ETag", etag)
 
 	// Return image binary
 	c.Data(http.StatusOK, img.Metadata.MimeType, img.Data)

--- a/pkg/images/handlers_pack_item.go
+++ b/pkg/images/handlers_pack_item.go
@@ -1,0 +1,88 @@
+package images
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/Angak0k/pimpmypack/pkg/helper"
+	"github.com/Angak0k/pimpmypack/pkg/packs"
+	"github.com/gin-gonic/gin"
+)
+
+// GetPackItemImage retrieves an image for an item within a pack
+// @Summary Get pack item image
+// @Description Get the image for an inventory item within a pack. Public packs are accessible without authentication.
+// @Tags Pack Images
+// @Produce image/jpeg
+// @Param id path int true "Pack ID"
+// @Param itemId path int true "Item (Inventory) ID"
+// @Success 200 {file} image/jpeg "Item image"
+// @Failure 400 {string} string "Invalid pack ID or item ID"
+// @Failure 404 {string} string "Pack not found, item not in pack, or has no image"
+// @Failure 500 {string} string "Internal server error"
+// @Router /v1/packs/{id}/items/{itemId}/image [get]
+func GetPackItemImage(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	// Parse pack ID from URL
+	packID, err := helper.StringToUint(c.Param("id"))
+	if err != nil {
+		c.String(http.StatusBadRequest, "Invalid pack ID format")
+		return
+	}
+
+	// Parse item ID from URL
+	itemID, err := helper.StringToUint(c.Param("itemId"))
+	if err != nil {
+		c.String(http.StatusBadRequest, "Invalid item ID format")
+		return
+	}
+
+	// Check if pack exists and if it's public
+	pack, err := packs.FindPackByID(ctx, packID)
+	if err != nil {
+		if errors.Is(err, packs.ErrPackNotFound) {
+			c.String(http.StatusNotFound, "Pack not found")
+			return
+		}
+		c.String(http.StatusInternalServerError, "Failed to retrieve pack")
+		return
+	}
+
+	// Only allow access to public (shared) packs
+	if pack.SharingCode == nil || *pack.SharingCode == "" {
+		c.String(http.StatusNotFound, "Pack not found")
+		return
+	}
+
+	// Check that the item is part of this pack
+	inPack, err := packs.CheckItemInPack(ctx, packID, itemID)
+	if err != nil {
+		c.String(http.StatusInternalServerError, "Failed to verify item in pack")
+		return
+	}
+	if !inPack {
+		c.String(http.StatusNotFound, "Item not found in pack")
+		return
+	}
+
+	// Retrieve image from inventory storage
+	img, err := inventoryStorage.Get(ctx, itemID)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			c.String(http.StatusNotFound, "Item has no image")
+			return
+		}
+		c.String(http.StatusInternalServerError, "Failed to retrieve image")
+		return
+	}
+
+	// Set cache headers for public access
+	c.Header("Cache-Control", "public, max-age=86400")
+	etag := fmt.Sprintf(`"%d-%d"`, packID, itemID)
+	c.Header("ETag", etag)
+
+	// Return image binary
+	c.Data(http.StatusOK, img.Metadata.MimeType, img.Data)
+}

--- a/pkg/packs/packs_test.go
+++ b/pkg/packs/packs_test.go
@@ -832,6 +832,9 @@ func TestGetPackContentsByPackID(t *testing.T) {
 		case packContentWithItems[0].Consumable != packWithItems[0].Consumable:
 			t.Errorf("Expected Consumable %v but got %v", packWithItems[0].Consumable,
 				packContentWithItems[0].Consumable)
+		case packContentWithItems[0].HasImage != packWithItems[0].HasImage:
+			t.Errorf("Expected HasImage %v but got %v", packWithItems[0].HasImage,
+				packContentWithItems[0].HasImage)
 		}
 	})
 

--- a/pkg/packs/repository.go
+++ b/pkg/packs/repository.go
@@ -585,8 +585,11 @@ func returnPackContentsByPackID(ctx context.Context, id uint) (*PackContentWithI
 			i.currency,
 			pc.quantity,
 			pc.worn,
-			pc.consumable
-			FROM pack_content pc JOIN inventory i ON pc.item_id = i.id
+			pc.consumable,
+			CASE WHEN ii.item_id IS NOT NULL THEN true ELSE false END as has_image
+			FROM pack_content pc
+			JOIN inventory i ON pc.item_id = i.id
+			LEFT JOIN inventory_images ii ON i.id = ii.item_id
 			WHERE pc.pack_id = $1;`,
 		id)
 
@@ -610,7 +613,8 @@ func returnPackContentsByPackID(ctx context.Context, id uint) (*PackContentWithI
 			&item.Currency,
 			&item.Quantity,
 			&item.Worn,
-			&item.Consumable)
+			&item.Consumable,
+			&item.HasImage)
 		if err != nil {
 			return nil, err
 		}
@@ -622,6 +626,18 @@ func returnPackContentsByPackID(ctx context.Context, id uint) (*PackContentWithI
 	}
 
 	return &packWithItems, nil
+}
+
+// checkItemInPack verifies if an inventory item is part of a pack's contents
+func checkItemInPack(ctx context.Context, packID uint, itemID uint) (bool, error) {
+	var count int
+	err := database.DB().QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM pack_content WHERE pack_id = $1 AND item_id = $2",
+		packID, itemID).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
 // Pack content writes

--- a/pkg/packs/repository.go
+++ b/pkg/packs/repository.go
@@ -630,14 +630,14 @@ func returnPackContentsByPackID(ctx context.Context, id uint) (*PackContentWithI
 
 // checkItemInPack verifies if an inventory item is part of a pack's contents
 func checkItemInPack(ctx context.Context, packID uint, itemID uint) (bool, error) {
-	var count int
+	var exists bool
 	err := database.DB().QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM pack_content WHERE pack_id = $1 AND item_id = $2",
-		packID, itemID).Scan(&count)
+		"SELECT EXISTS(SELECT 1 FROM pack_content WHERE pack_id = $1 AND item_id = $2)",
+		packID, itemID).Scan(&exists)
 	if err != nil {
 		return false, err
 	}
-	return count > 0, nil
+	return exists, nil
 }
 
 // Pack content writes

--- a/pkg/packs/service.go
+++ b/pkg/packs/service.go
@@ -14,6 +14,11 @@ func CheckPackOwnership(ctx context.Context, packID uint, userID uint) (bool, er
 	return checkPackOwnership(ctx, packID, userID)
 }
 
+// CheckItemInPack verifies if an inventory item is part of a pack's contents
+func CheckItemInPack(ctx context.Context, packID uint, itemID uint) (bool, error) {
+	return checkItemInPack(ctx, packID, itemID)
+}
+
 // FindPackIDByPackName finds a pack ID by its name
 // Returns 0 if not found
 func FindPackIDByPackName(packs Packs, packname string) uint {

--- a/pkg/packs/testdata.go
+++ b/pkg/packs/testdata.go
@@ -179,6 +179,7 @@ var packWithItems = PackContentWithItems{
 		Quantity:        2,
 		Worn:            false,
 		Consumable:      false,
+		HasImage:        false,
 	},
 }
 

--- a/pkg/packs/types.go
+++ b/pkg/packs/types.go
@@ -108,6 +108,7 @@ type PackContentWithItem struct {
 	Quantity        int    `json:"quantity"`
 	Worn            bool   `json:"worn"`
 	Consumable      bool   `json:"consumable"`
+	HasImage        bool   `json:"has_image"`
 }
 
 // PackContentWithItems represents a collection of pack contents with item details


### PR DESCRIPTION
## Summary

Backend changes for #31

- Add `has_image` boolean field to `PackContentWithItem` struct via `LEFT JOIN inventory_images`, so pack content responses (both authenticated and shared) indicate whether each item has an image
- Add public endpoint `GET /v1/packs/{id}/items/{itemId}/image` to serve item image thumbnails for shared/public packs without authentication
- Add `CheckItemInPack` service function to verify an item belongs to a pack before serving its image
- Regenerate Swagger docs

## API Changes

**`PackContentWithItem`** (used by `GET /v1/mypack/{id}/packcontents` and `GET /sharedlist/{sharing_code}`):
```json
{
  "pack_content_id": 1,
  "inventory_id": 42,
  "item_name": "Tent",
  "has_image": true,
  ...
}
```

**New endpoint:** `GET /v1/packs/{packId}/items/{itemId}/image`
- Returns `image/jpeg` binary for items in public packs
- Returns 404 for private packs, items not in pack, or items without images
- Cache headers: `Cache-Control: public, max-age=86400`

🤖 Generated with [Claude Code](https://claude.com/claude-code)