### PR TITLE
feat: add pack_count field to inventory items

### DIFF
--- a/pkg/inventories/inventories_test.go
+++ b/pkg/inventories/inventories_test.go
@@ -119,6 +119,46 @@ func TestGetInventories(t *testing.T) {
 	})
 }
 
+func TestGetInventoriesPackCount(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	router.GET("/inventories", GetInventories)
+
+	t.Run("PackCount values are correct", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/inventories", nil)
+		if err != nil {
+			t.Fatalf("Failed to create request: %v", err)
+		}
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		var allInventories Inventories
+		if err := json.Unmarshal(w.Body.Bytes(), &allInventories); err != nil {
+			t.Fatalf("Failed to unmarshal response body: %v", err)
+		}
+
+		// Build a lookup by ID
+		byID := make(map[uint]Inventory)
+		for _, inv := range allInventories {
+			byID[inv.ID] = inv
+		}
+
+		// Backpack (inventories[0]) is in 2 packs
+		if got := byID[inventories[0].ID].PackCount; got != 2 {
+			t.Errorf("Expected Backpack PackCount=2, got %d", got)
+		}
+		// Tent (inventories[1]) is in 1 pack
+		if got := byID[inventories[1].ID].PackCount; got != 1 {
+			t.Errorf("Expected Tent PackCount=1, got %d", got)
+		}
+		// Sleeping Bag (inventories[2]) is in 0 packs
+		if got := byID[inventories[2].ID].PackCount; got != 0 {
+			t.Errorf("Expected Sleeping Bag PackCount=0, got %d", got)
+		}
+	})
+}
+
 // validateInventory checks if the expected inventory exists in the response and validates its fields
 func validateInventory(t *testing.T, responseInventories Inventories, expectedInventory Inventory) {
 	// Find the matching inventory in the response by both UserID and ItemName
@@ -159,6 +199,8 @@ func compareInventoryFields(t *testing.T, found, expected *Inventory) {
 		t.Errorf("Expected Price %v but got %v", expected.Price, found.Price)
 	case !cmp.Equal(found.Currency, expected.Currency):
 		t.Errorf("Expected Currency %v but got %v", expected.Currency, found.Currency)
+	case !cmp.Equal(found.PackCount, expected.PackCount):
+		t.Errorf("Expected PackCount %v but got %v", expected.PackCount, found.PackCount)
 	}
 }
 

--- a/pkg/inventories/repository.go
+++ b/pkg/inventories/repository.go
@@ -26,6 +26,7 @@ func returnInventories(ctx context.Context) (*Inventories, error) {
 			i.price,
 			i.currency,
 			CASE WHEN ii.item_id IS NOT NULL THEN true ELSE false END as has_image,
+			(SELECT COUNT(DISTINCT pc.pack_id) FROM pack_content pc WHERE pc.item_id = i.id) as pack_count,
 			i.created_at,
 			i.updated_at
 		FROM inventory i
@@ -48,6 +49,7 @@ func returnInventories(ctx context.Context) (*Inventories, error) {
 			&inventory.Price,
 			&inventory.Currency,
 			&inventory.HasImage,
+			&inventory.PackCount,
 			&inventory.CreatedAt,
 			&inventory.UpdatedAt)
 		if err != nil {
@@ -78,6 +80,7 @@ func returnInventoriesByUserID(ctx context.Context, userID uint) (*Inventories, 
 			i.price,
 			i.currency,
 			CASE WHEN ii.item_id IS NOT NULL THEN true ELSE false END as has_image,
+			(SELECT COUNT(DISTINCT pc.pack_id) FROM pack_content pc WHERE pc.item_id = i.id) as pack_count,
 			i.created_at,
 			i.updated_at
 		FROM inventory i
@@ -102,6 +105,7 @@ func returnInventoriesByUserID(ctx context.Context, userID uint) (*Inventories, 
 			&inventory.Price,
 			&inventory.Currency,
 			&inventory.HasImage,
+			&inventory.PackCount,
 			&inventory.CreatedAt,
 			&inventory.UpdatedAt)
 		if err != nil {
@@ -132,6 +136,7 @@ func findInventoryByID(ctx context.Context, id uint) (*Inventory, error) {
 			i.price,
 			i.currency,
 			CASE WHEN ii.item_id IS NOT NULL THEN true ELSE false END as has_image,
+			(SELECT COUNT(DISTINCT pc.pack_id) FROM pack_content pc WHERE pc.item_id = i.id) as pack_count,
 			i.created_at,
 			i.updated_at
 		FROM inventory i
@@ -149,6 +154,7 @@ func findInventoryByID(ctx context.Context, id uint) (*Inventory, error) {
 		&inventory.Price,
 		&inventory.Currency,
 		&inventory.HasImage,
+		&inventory.PackCount,
 		&inventory.CreatedAt,
 		&inventory.UpdatedAt)
 
@@ -182,6 +188,7 @@ func findInventoryItemByAttributes(
 			i.price,
 			i.currency,
 			CASE WHEN ii.item_id IS NOT NULL THEN true ELSE false END as has_image,
+			(SELECT COUNT(DISTINCT pc.pack_id) FROM pack_content pc WHERE pc.item_id = i.id) as pack_count,
 			i.created_at,
 			i.updated_at
 		FROM inventory i
@@ -201,6 +208,7 @@ func findInventoryItemByAttributes(
 		&inventory.Price,
 		&inventory.Currency,
 		&inventory.HasImage,
+		&inventory.PackCount,
 		&inventory.CreatedAt,
 		&inventory.UpdatedAt)
 

--- a/pkg/inventories/testdata.go
+++ b/pkg/inventories/testdata.go
@@ -2,6 +2,7 @@ package inventories
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"time"
 
@@ -162,69 +163,66 @@ func loadingInventoryDataset() error {
 		}
 	}
 
-	// Insert a test pack for user 1
-	var testPackID int
-	err = tx.QueryRowContext(context.Background(),
+	// Insert test packs and pack_content for pack_count testing
+	if err := insertTestPackData(tx); err != nil {
+		return err
+	}
+
+	// Commit the transaction
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// insertTestPackData creates test packs and links them to inventory items for pack_count testing.
+// Backpack → 2 packs, Tent → 1 pack, Sleeping Bag → 0 packs.
+func insertTestPackData(tx *sql.Tx) error {
+	now := time.Now().Truncate(time.Second)
+	ctx := context.Background()
+
+	var testPackID, testPackID2 int
+
+	err := tx.QueryRowContext(ctx,
 		`INSERT INTO pack (user_id, pack_name, pack_description, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5)
 		RETURNING id;`,
-		inventories[0].UserID,
-		"Test Pack",
-		"Pack for testing pack_count",
-		time.Now().Truncate(time.Second),
-		time.Now().Truncate(time.Second)).Scan(&testPackID)
+		inventories[0].UserID, "Test Pack", "Pack for testing pack_count", now, now).Scan(&testPackID)
 	if err != nil {
 		return fmt.Errorf("failed to insert test pack: %w", err)
 	}
 
-	// Insert a second test pack for user 1
-	var testPackID2 int
-	err = tx.QueryRowContext(context.Background(),
+	err = tx.QueryRowContext(ctx,
 		`INSERT INTO pack (user_id, pack_name, pack_description, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5)
 		RETURNING id;`,
-		inventories[0].UserID,
-		"Test Pack 2",
-		"Second pack for testing pack_count",
-		time.Now().Truncate(time.Second),
-		time.Now().Truncate(time.Second)).Scan(&testPackID2)
+		inventories[0].UserID, "Test Pack 2", "Second pack for testing pack_count", now, now).Scan(&testPackID2)
 	if err != nil {
 		return fmt.Errorf("failed to insert test pack 2: %w", err)
 	}
 
 	// Link Backpack (inventories[0]) to both packs → pack_count=2
 	for _, packID := range []int{testPackID, testPackID2} {
-		_, err = tx.ExecContext(context.Background(),
+		_, err = tx.ExecContext(ctx,
 			`INSERT INTO pack_content (pack_id, item_id, quantity, worn, consumable, created_at, updated_at)
 			VALUES ($1, $2, 1, false, false, $3, $4);`,
-			packID, inventories[0].ID,
-			time.Now().Truncate(time.Second),
-			time.Now().Truncate(time.Second))
+			packID, inventories[0].ID, now, now)
 		if err != nil {
 			return fmt.Errorf("failed to insert pack_content: %w", err)
 		}
 	}
 
 	// Link Tent (inventories[1]) to first pack only → pack_count=1
-	_, err = tx.ExecContext(context.Background(),
+	_, err = tx.ExecContext(ctx,
 		`INSERT INTO pack_content (pack_id, item_id, quantity, worn, consumable, created_at, updated_at)
 		VALUES ($1, $2, 1, false, false, $3, $4);`,
-		testPackID, inventories[1].ID,
-		time.Now().Truncate(time.Second),
-		time.Now().Truncate(time.Second))
+		testPackID, inventories[1].ID, now, now)
 	if err != nil {
 		return fmt.Errorf("failed to insert pack_content for tent: %w", err)
 	}
 
-	// Sleeping Bag (inventories[2]) is not linked to any pack → pack_count=0
-
-	// Store pack IDs for cleanup
 	testPackIDs = []int{testPackID, testPackID2}
-
-	// Commit the transaction
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit transaction: %w", err)
-	}
 
 	return nil
 }

--- a/pkg/inventories/testdata.go
+++ b/pkg/inventories/testdata.go
@@ -34,6 +34,8 @@ var users = []accounts.User{
 	},
 }
 
+var testPackIDs []int
+
 var inventories = Inventories{
 	{
 		UserID:   1,
@@ -160,6 +162,65 @@ func loadingInventoryDataset() error {
 		}
 	}
 
+	// Insert a test pack for user 1
+	var testPackID int
+	err = tx.QueryRowContext(context.Background(),
+		`INSERT INTO pack (user_id, pack_name, pack_description, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id;`,
+		inventories[0].UserID,
+		"Test Pack",
+		"Pack for testing pack_count",
+		time.Now().Truncate(time.Second),
+		time.Now().Truncate(time.Second)).Scan(&testPackID)
+	if err != nil {
+		return fmt.Errorf("failed to insert test pack: %w", err)
+	}
+
+	// Insert a second test pack for user 1
+	var testPackID2 int
+	err = tx.QueryRowContext(context.Background(),
+		`INSERT INTO pack (user_id, pack_name, pack_description, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id;`,
+		inventories[0].UserID,
+		"Test Pack 2",
+		"Second pack for testing pack_count",
+		time.Now().Truncate(time.Second),
+		time.Now().Truncate(time.Second)).Scan(&testPackID2)
+	if err != nil {
+		return fmt.Errorf("failed to insert test pack 2: %w", err)
+	}
+
+	// Link Backpack (inventories[0]) to both packs → pack_count=2
+	for _, packID := range []int{testPackID, testPackID2} {
+		_, err = tx.ExecContext(context.Background(),
+			`INSERT INTO pack_content (pack_id, item_id, quantity, worn, consumable, created_at, updated_at)
+			VALUES ($1, $2, 1, false, false, $3, $4);`,
+			packID, inventories[0].ID,
+			time.Now().Truncate(time.Second),
+			time.Now().Truncate(time.Second))
+		if err != nil {
+			return fmt.Errorf("failed to insert pack_content: %w", err)
+		}
+	}
+
+	// Link Tent (inventories[1]) to first pack only → pack_count=1
+	_, err = tx.ExecContext(context.Background(),
+		`INSERT INTO pack_content (pack_id, item_id, quantity, worn, consumable, created_at, updated_at)
+		VALUES ($1, $2, 1, false, false, $3, $4);`,
+		testPackID, inventories[1].ID,
+		time.Now().Truncate(time.Second),
+		time.Now().Truncate(time.Second))
+	if err != nil {
+		return fmt.Errorf("failed to insert pack_content for tent: %w", err)
+	}
+
+	// Sleeping Bag (inventories[2]) is not linked to any pack → pack_count=0
+
+	// Store pack IDs for cleanup
+	testPackIDs = []int{testPackID, testPackID2}
+
 	// Commit the transaction
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("failed to commit transaction: %w", err)
@@ -174,7 +235,15 @@ func cleanupInventoryDataset() error {
 
 	println("-> Cleaning up inventory test data...")
 
-	// Delete inventories first
+	// Delete test packs first (pack_content will cascade)
+	for _, packID := range testPackIDs {
+		_, err := database.DB().ExecContext(ctx, "DELETE FROM pack WHERE id = $1", packID)
+		if err != nil {
+			return fmt.Errorf("failed to delete test pack %d: %w", packID, err)
+		}
+	}
+
+	// Delete inventories
 	for _, inv := range inventories {
 		if inv.ID != 0 {
 			_, err := database.DB().ExecContext(ctx, "DELETE FROM inventory WHERE id = $1", inv.ID)

--- a/pkg/inventories/testdata.go
+++ b/pkg/inventories/testdata.go
@@ -168,6 +168,11 @@ func loadingInventoryDataset() error {
 		return err
 	}
 
+	// Set expected PackCount values to match inserted pack_content data
+	inventories[0].PackCount = 2 // Backpack → 2 packs
+	inventories[1].PackCount = 1 // Tent → 1 pack
+	// inventories[2] and inventories[3] remain 0 (not linked to any pack)
+
 	// Commit the transaction
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("failed to commit transaction: %w", err)

--- a/pkg/inventories/types.go
+++ b/pkg/inventories/types.go
@@ -18,6 +18,7 @@ type Inventory struct {
 	Price       int       `json:"price"`
 	Currency    string    `json:"currency"`
 	HasImage    bool      `json:"has_image"`
+	PackCount   int       `json:"pack_count"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
 }


### PR DESCRIPTION
## Summary
- Adds a `pack_count` integer field to the `Inventory` struct, computed via a correlated subquery `COUNT(DISTINCT pack_id) FROM pack_content`
- Updates all 4 SELECT queries in `repository.go` (returnInventories, returnInventoriesByUserID, findInventoryByID, findInventoryItemByAttributes)
- Adds test packs and pack_content entries in `testdata.go` to exercise the new field

🤖 Generated with [Claude Code](https://claude.com/claude-code)