### PR TITLE
feat: add inventory merge endpoint

### DIFF
--- a/api-doc/docs.go
+++ b/api-doc/docs.go
@@ -1068,6 +1068,75 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/myinventory/merge": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Merges the source inventory item into the target item. Pack references are consolidated.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Inventories"
+                ],
+                "summary": "Merge two inventory items",
+                "parameters": [
+                    {
+                        "description": "Merge request",
+                        "name": "merge",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/inventories.MergeInventoryRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Merged inventory item",
+                        "schema": {
+                            "$ref": "#/definitions/inventories.Inventory"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid payload or source equals target",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Item does not belong to you",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Item not found",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/myinventory/{id}": {
             "get": {
                 "security": [
@@ -2942,6 +3011,9 @@ const docTemplate = `{
                 "item_name": {
                     "type": "string"
                 },
+                "pack_count": {
+                    "type": "integer"
+                },
                 "price": {
                     "type": "integer"
                 },
@@ -3009,6 +3081,53 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "price": {
+                    "type": "integer"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "weight": {
+                    "type": "integer"
+                }
+            }
+        },
+        "inventories.MergeInventoryRequest": {
+            "type": "object",
+            "required": [
+                "category",
+                "image_source",
+                "item_name",
+                "source_item_id",
+                "target_item_id"
+            ],
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "image_source": {
+                    "type": "string",
+                    "enum": [
+                        "source",
+                        "target",
+                        "none"
+                    ]
+                },
+                "item_name": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "integer"
+                },
+                "source_item_id": {
+                    "type": "integer"
+                },
+                "target_item_id": {
                     "type": "integer"
                 },
                 "url": {

--- a/api-doc/swagger.json
+++ b/api-doc/swagger.json
@@ -1065,6 +1065,75 @@
                 }
             }
         },
+        "/v1/myinventory/merge": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Merges the source inventory item into the target item. Pack references are consolidated.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Inventories"
+                ],
+                "summary": "Merge two inventory items",
+                "parameters": [
+                    {
+                        "description": "Merge request",
+                        "name": "merge",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/inventories.MergeInventoryRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Merged inventory item",
+                        "schema": {
+                            "$ref": "#/definitions/inventories.Inventory"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid payload or source equals target",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Item does not belong to you",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Item not found",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/myinventory/{id}": {
             "get": {
                 "security": [
@@ -2939,6 +3008,9 @@
                 "item_name": {
                     "type": "string"
                 },
+                "pack_count": {
+                    "type": "integer"
+                },
                 "price": {
                     "type": "integer"
                 },
@@ -3006,6 +3078,53 @@
                     "type": "string"
                 },
                 "price": {
+                    "type": "integer"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "weight": {
+                    "type": "integer"
+                }
+            }
+        },
+        "inventories.MergeInventoryRequest": {
+            "type": "object",
+            "required": [
+                "category",
+                "image_source",
+                "item_name",
+                "source_item_id",
+                "target_item_id"
+            ],
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "image_source": {
+                    "type": "string",
+                    "enum": [
+                        "source",
+                        "target",
+                        "none"
+                    ]
+                },
+                "item_name": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "integer"
+                },
+                "source_item_id": {
+                    "type": "integer"
+                },
+                "target_item_id": {
                     "type": "integer"
                 },
                 "url": {

--- a/api-doc/swagger.yaml
+++ b/api-doc/swagger.yaml
@@ -152,6 +152,8 @@ definitions:
         type: integer
       item_name:
         type: string
+      pack_count:
+        type: integer
       price:
         type: integer
       updated_at:
@@ -202,6 +204,39 @@ definitions:
     required:
     - category
     - item_name
+    type: object
+  inventories.MergeInventoryRequest:
+    properties:
+      category:
+        type: string
+      currency:
+        type: string
+      description:
+        type: string
+      image_source:
+        enum:
+        - source
+        - target
+        - none
+        type: string
+      item_name:
+        type: string
+      price:
+        type: integer
+      source_item_id:
+        type: integer
+      target_item_id:
+        type: integer
+      url:
+        type: string
+      weight:
+        type: integer
+    required:
+    - category
+    - image_source
+    - item_name
+    - source_item_id
+    - target_item_id
     type: object
   packs.ImportExternalPackResponse:
     properties:
@@ -1484,6 +1519,51 @@ paths:
       summary: Upload or update inventory item image
       tags:
       - Inventory Images
+  /v1/myinventory/merge:
+    post:
+      consumes:
+      - application/json
+      description: Merges the source inventory item into the target item. Pack references
+        are consolidated.
+      parameters:
+      - description: Merge request
+        in: body
+        name: merge
+        required: true
+        schema:
+          $ref: '#/definitions/inventories.MergeInventoryRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Merged inventory item
+          schema:
+            $ref: '#/definitions/inventories.Inventory'
+        "400":
+          description: Invalid payload or source equals target
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "403":
+          description: Item does not belong to you
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "404":
+          description: Item not found
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+      security:
+      - Bearer: []
+      summary: Merge two inventory items
+      tags:
+      - Inventories
   /v1/mypack:
     post:
       consumes:

--- a/main.go
+++ b/main.go
@@ -158,6 +158,7 @@ func setupProtectedRoutes(router *gin.Engine) {
 	protected.POST("/mypack/:id/packcontent", packs.PostMyPackContent)
 	protected.PUT("/mypack/:id/packcontent/:item_id", packs.PutMyPackContentByID)
 	protected.DELETE("/mypack/:id/packcontent/:item_id", packs.DeleteMyPackContentByID)
+	protected.POST("/myinventory/merge", inventories.PostMyInventoryMerge)
 	protected.GET("/myinventory/:id", inventories.GetMyInventoryByID)
 	protected.POST("/myinventory", inventories.PostMyInventory)
 	protected.PUT("/myinventory/:id", inventories.PutMyInventoryByID)

--- a/pkg/inventories/handlers.go
+++ b/pkg/inventories/handlers.go
@@ -454,6 +454,11 @@ func PostMyInventoryMerge(c *gin.Context) {
 		return
 	}
 
+	// Default currency if empty
+	if input.Currency == "" {
+		input.Currency = DefaultCurrency
+	}
+
 	// Verify source != target
 	if input.SourceItemID == input.TargetItemID {
 		c.IndentedJSON(http.StatusBadRequest, gin.H{"error": "Source and target items must be different"})

--- a/pkg/inventories/handlers.go
+++ b/pkg/inventories/handlers.go
@@ -424,6 +424,85 @@ func PutMyInventoryByID(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, updatedInventory)
 }
 
+// PostMyInventoryMerge merges two inventory items into one
+// @Summary Merge two inventory items
+// @Description Merges the source inventory item into the target item. Pack references are consolidated.
+// @Security Bearer
+// @Tags Inventories
+// @Accept json
+// @Produce json
+// @Param merge body inventories.MergeInventoryRequest true "Merge request"
+// @Success 200 {object} inventories.Inventory "Merged inventory item"
+// @Failure 400 {object} apitypes.ErrorResponse "Invalid payload or source equals target"
+// @Failure 401 {object} apitypes.ErrorResponse "Unauthorized"
+// @Failure 403 {object} apitypes.ErrorResponse "Item does not belong to you"
+// @Failure 404 {object} apitypes.ErrorResponse "Item not found"
+// @Failure 500 {object} apitypes.ErrorResponse "Internal Server Error"
+// @Router /v1/myinventory/merge [post]
+func PostMyInventoryMerge(c *gin.Context) {
+	userID, err := security.ExtractTokenID(c)
+	if err != nil {
+		helper.LogAndSanitize(err, "post my inventory merge: extract token ID failed")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": helper.ErrMsgUnauthorized})
+		return
+	}
+
+	var input MergeInventoryRequest
+	if err := c.BindJSON(&input); err != nil {
+		helper.LogAndSanitize(err, "post my inventory merge: bind JSON failed")
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"error": helper.ErrMsgBadRequest})
+		return
+	}
+
+	// Verify source != target
+	if input.SourceItemID == input.TargetItemID {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"error": "Source and target items must be different"})
+		return
+	}
+
+	// Verify ownership of source item
+	sourceItem, err := findInventoryByID(c.Request.Context(), uint(input.SourceItemID))
+	if err != nil {
+		if errors.Is(err, ErrNoItemFound) {
+			c.IndentedJSON(http.StatusNotFound, gin.H{"error": "Source inventory item not found"})
+			return
+		}
+		helper.LogAndSanitize(err, "post my inventory merge: find source item failed")
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+	if sourceItem.UserID != userID {
+		c.IndentedJSON(http.StatusForbidden, gin.H{"error": "This item does not belong to you"})
+		return
+	}
+
+	// Verify ownership of target item
+	targetItem, err := findInventoryByID(c.Request.Context(), uint(input.TargetItemID))
+	if err != nil {
+		if errors.Is(err, ErrNoItemFound) {
+			c.IndentedJSON(http.StatusNotFound, gin.H{"error": "Target inventory item not found"})
+			return
+		}
+		helper.LogAndSanitize(err, "post my inventory merge: find target item failed")
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+	if targetItem.UserID != userID {
+		c.IndentedJSON(http.StatusForbidden, gin.H{"error": "This item does not belong to you"})
+		return
+	}
+
+	// Perform merge
+	mergedItem, err := mergeInventoryItems(c.Request.Context(), &input)
+	if err != nil {
+		helper.LogAndSanitize(err, "post my inventory merge: merge items failed")
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	c.IndentedJSON(http.StatusOK, mergedItem)
+}
+
 // DeleteInventoryByID deletes an inventory by ID
 // @Summary [ADMIN] Delete an inventory by ID
 // @Description Deletes an inventory by ID - for admin use only

--- a/pkg/inventories/handlers.go
+++ b/pkg/inventories/handlers.go
@@ -461,7 +461,7 @@ func PostMyInventoryMerge(c *gin.Context) {
 	}
 
 	// Verify ownership of source item
-	sourceItem, err := findInventoryByID(c.Request.Context(), uint(input.SourceItemID))
+	sourceItem, err := findInventoryByID(c.Request.Context(), input.SourceItemID)
 	if err != nil {
 		if errors.Is(err, ErrNoItemFound) {
 			c.IndentedJSON(http.StatusNotFound, gin.H{"error": "Source inventory item not found"})
@@ -477,7 +477,7 @@ func PostMyInventoryMerge(c *gin.Context) {
 	}
 
 	// Verify ownership of target item
-	targetItem, err := findInventoryByID(c.Request.Context(), uint(input.TargetItemID))
+	targetItem, err := findInventoryByID(c.Request.Context(), input.TargetItemID)
 	if err != nil {
 		if errors.Is(err, ErrNoItemFound) {
 			c.IndentedJSON(http.StatusNotFound, gin.H{"error": "Target inventory item not found"})

--- a/pkg/inventories/inventories_test.go
+++ b/pkg/inventories/inventories_test.go
@@ -706,445 +706,347 @@ func TestPostMyInventoryMerge(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("Merge with shared pack - quantities summed", func(t *testing.T) {
-		// Setup merge test data
-		err := createMergeTestData(ctx)
-		if err != nil {
-			t.Fatalf("Failed to create merge test data: %v", err)
-		}
-		defer cleanupMergeTestData(ctx)
-
-		source := mergeTestItems[0]
-		target := mergeTestItems[1]
-
-		router := gin.Default()
-		router.POST("/myinventory/merge", PostMyInventoryMerge)
-
-		token, err := security.GenerateToken(users[0].ID)
-		if err != nil {
-			t.Fatalf("Failed to generate token: %v", err)
-		}
-
-		mergeReq := MergeInventoryRequest{
-			SourceItemID: int(source.ID),
-			TargetItemID: int(target.ID),
-			ItemName:     "Merged Item",
-			Category:     "Merged Category",
-			Description:  "Merged description",
-			Weight:       300,
-			URL:          "https://example.com/merged",
-			Price:        30,
-			Currency:     "EUR",
-			ImageSource:  "none",
-		}
-
-		jsonData, err := json.Marshal(mergeReq)
-		if err != nil {
-			t.Fatalf("Failed to marshal merge request: %v", err)
-		}
-
-		req, err := http.NewRequest(http.MethodPost, "/myinventory/merge", bytes.NewBuffer(jsonData))
-		if err != nil {
-			t.Fatalf("Failed to create request: %v", err)
-		}
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", "Bearer "+token)
-
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		if w.Code != http.StatusOK {
-			t.Errorf("Expected status code %d but got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
-			return
-		}
-
-		var mergedItem Inventory
-		if err := json.Unmarshal(w.Body.Bytes(), &mergedItem); err != nil {
-			t.Fatalf("Failed to unmarshal response body: %v", err)
-		}
-
-		// Verify merged item properties
-		if mergedItem.ID != target.ID {
-			t.Errorf("Expected merged item ID %d but got %d", target.ID, mergedItem.ID)
-		}
-		if mergedItem.ItemName != "Merged Item" {
-			t.Errorf("Expected item name 'Merged Item' but got '%s'", mergedItem.ItemName)
-		}
-		if mergedItem.Category != "Merged Category" {
-			t.Errorf("Expected category 'Merged Category' but got '%s'", mergedItem.Category)
-		}
-		if mergedItem.Weight != 300 {
-			t.Errorf("Expected weight 300 but got %d", mergedItem.Weight)
-		}
-
-		// Verify target is in 2 packs (shared + non-shared reassigned)
-		if mergedItem.PackCount != 2 {
-			t.Errorf("Expected pack count 2 but got %d", mergedItem.PackCount)
-		}
-
-		// Verify source item is deleted
-		_, err = findInventoryByID(ctx, source.ID)
-		if !errors.Is(err, ErrNoItemFound) {
-			t.Errorf("Expected source item to be deleted, got err: %v", err)
-		}
-
-		// Verify shared pack quantity was summed (2 + 3 = 5)
-		var quantity int
-		err = database.DB().QueryRowContext(ctx,
-			`SELECT quantity FROM pack_content WHERE pack_id = $1 AND item_id = $2`,
-			mergeTestPackIDs[0], target.ID).Scan(&quantity)
-		if err != nil {
-			t.Fatalf("Failed to query pack_content: %v", err)
-		}
-		if quantity != 5 {
-			t.Errorf("Expected quantity 5 in shared pack but got %d", quantity)
-		}
-
-		// Verify non-shared pack was reassigned to target
-		var nonSharedQuantity int
-		err = database.DB().QueryRowContext(ctx,
-			`SELECT quantity FROM pack_content WHERE pack_id = $1 AND item_id = $2`,
-			mergeTestPackIDs[1], target.ID).Scan(&nonSharedQuantity)
-		if err != nil {
-			t.Fatalf("Failed to query non-shared pack_content: %v", err)
-		}
-		if nonSharedQuantity != 1 {
-			t.Errorf("Expected quantity 1 in non-shared pack but got %d", nonSharedQuantity)
-		}
+		testMergeSharedPack(ctx, t)
 	})
-
 	t.Run("Merge with no pack overlap", func(t *testing.T) {
-		err := createMergeTestData(ctx)
-		if err != nil {
-			t.Fatalf("Failed to create merge test data: %v", err)
-		}
-		defer cleanupMergeTestData(ctx)
-
-		source := mergeTestItems[0]
-		target := mergeTestItems[1]
-
-		// Remove target from shared pack so there's no overlap
-		_, err = database.DB().ExecContext(ctx,
-			`DELETE FROM pack_content WHERE pack_id = $1 AND item_id = $2`,
-			mergeTestPackIDs[0], target.ID)
-		if err != nil {
-			t.Fatalf("Failed to remove target from shared pack: %v", err)
-		}
-
-		router := gin.Default()
-		router.POST("/myinventory/merge", PostMyInventoryMerge)
-
-		token, err := security.GenerateToken(users[0].ID)
-		if err != nil {
-			t.Fatalf("Failed to generate token: %v", err)
-		}
-
-		mergeReq := MergeInventoryRequest{
-			SourceItemID: int(source.ID),
-			TargetItemID: int(target.ID),
-			ItemName:     "No Overlap Merged",
-			Category:     "Test",
-			Description:  "",
-			Weight:       150,
-			URL:          "",
-			Price:        15,
-			Currency:     "USD",
-			ImageSource:  "none",
-		}
-
-		jsonData, _ := json.Marshal(mergeReq)
-		req, _ := http.NewRequest(http.MethodPost, "/myinventory/merge", bytes.NewBuffer(jsonData))
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", "Bearer "+token)
-
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		if w.Code != http.StatusOK {
-			t.Errorf("Expected status code %d but got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
-			return
-		}
-
-		var mergedItem Inventory
-		if err := json.Unmarshal(w.Body.Bytes(), &mergedItem); err != nil {
-			t.Fatalf("Failed to unmarshal response: %v", err)
-		}
-
-		// Source had 2 packs (shared + non-shared), all reassigned to target
-		if mergedItem.PackCount != 2 {
-			t.Errorf("Expected pack count 2 but got %d", mergedItem.PackCount)
-		}
+		testMergeNoPackOverlap(ctx, t)
 	})
-
 	t.Run("Merge with image_source=source", func(t *testing.T) {
-		err := createMergeTestData(ctx)
-		if err != nil {
-			t.Fatalf("Failed to create merge test data: %v", err)
-		}
-		defer cleanupMergeTestData(ctx)
-
-		source := mergeTestItems[0]
-		target := mergeTestItems[1]
-
-		// Insert a source image
-		now := time.Now()
-		_, err = database.DB().ExecContext(ctx,
-			`INSERT INTO inventory_images (item_id, image_data, mime_type, file_size, width, height, uploaded_at, updated_at)
-			VALUES ($1, $2, 'image/jpeg', 100, 50, 50, $3, $4)`,
-			source.ID, []byte("fake-source-image"), now, now)
-		if err != nil {
-			t.Fatalf("Failed to insert source image: %v", err)
-		}
-
-		// Insert a target image
-		_, err = database.DB().ExecContext(ctx,
-			`INSERT INTO inventory_images (item_id, image_data, mime_type, file_size, width, height, uploaded_at, updated_at)
-			VALUES ($1, $2, 'image/jpeg', 200, 100, 100, $3, $4)`,
-			target.ID, []byte("fake-target-image"), now, now)
-		if err != nil {
-			t.Fatalf("Failed to insert target image: %v", err)
-		}
-
-		router := gin.Default()
-		router.POST("/myinventory/merge", PostMyInventoryMerge)
-
-		token, _ := security.GenerateToken(users[0].ID)
-		mergeReq := MergeInventoryRequest{
-			SourceItemID: int(source.ID),
-			TargetItemID: int(target.ID),
-			ItemName:     "Image Source Test",
-			Category:     "Test",
-			Weight:       100,
-			Currency:     "USD",
-			ImageSource:  "source",
-		}
-
-		jsonData, _ := json.Marshal(mergeReq)
-		req, _ := http.NewRequest(http.MethodPost, "/myinventory/merge", bytes.NewBuffer(jsonData))
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", "Bearer "+token)
-
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		if w.Code != http.StatusOK {
-			t.Errorf("Expected status code %d but got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
-			return
-		}
-
-		var mergedItem Inventory
-		json.Unmarshal(w.Body.Bytes(), &mergedItem)
-
-		// Verify the merged item has an image (source image was reassigned to target)
-		if !mergedItem.HasImage {
-			t.Errorf("Expected merged item to have image (source image reassigned)")
-		}
-
-		// Verify the image data is the source image
-		var imageData []byte
-		err = database.DB().QueryRowContext(ctx,
-			`SELECT image_data FROM inventory_images WHERE item_id = $1`, target.ID).Scan(&imageData)
-		if err != nil {
-			t.Fatalf("Failed to query image: %v", err)
-		}
-		if string(imageData) != "fake-source-image" {
-			t.Errorf("Expected source image data but got different data")
-		}
+		testMergeImageSource(ctx, t)
 	})
-
 	t.Run("Merge with image_source=target", func(t *testing.T) {
-		err := createMergeTestData(ctx)
-		if err != nil {
-			t.Fatalf("Failed to create merge test data: %v", err)
-		}
-		defer cleanupMergeTestData(ctx)
-
-		source := mergeTestItems[0]
-		target := mergeTestItems[1]
-
-		// Insert a target image only
-		now := time.Now()
-		_, err = database.DB().ExecContext(ctx,
-			`INSERT INTO inventory_images (item_id, image_data, mime_type, file_size, width, height, uploaded_at, updated_at)
-			VALUES ($1, $2, 'image/jpeg', 200, 100, 100, $3, $4)`,
-			target.ID, []byte("fake-target-image"), now, now)
-		if err != nil {
-			t.Fatalf("Failed to insert target image: %v", err)
-		}
-
-		router := gin.Default()
-		router.POST("/myinventory/merge", PostMyInventoryMerge)
-
-		token, _ := security.GenerateToken(users[0].ID)
-		mergeReq := MergeInventoryRequest{
-			SourceItemID: int(source.ID),
-			TargetItemID: int(target.ID),
-			ItemName:     "Image Target Test",
-			Category:     "Test",
-			Weight:       100,
-			Currency:     "USD",
-			ImageSource:  "target",
-		}
-
-		jsonData, _ := json.Marshal(mergeReq)
-		req, _ := http.NewRequest(http.MethodPost, "/myinventory/merge", bytes.NewBuffer(jsonData))
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", "Bearer "+token)
-
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		if w.Code != http.StatusOK {
-			t.Errorf("Expected status code %d but got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
-			return
-		}
-
-		var mergedItem Inventory
-		json.Unmarshal(w.Body.Bytes(), &mergedItem)
-
-		// Verify the merged item still has the target image
-		if !mergedItem.HasImage {
-			t.Errorf("Expected merged item to have image (target image kept)")
-		}
+		testMergeImageTarget(ctx, t)
 	})
-
 	t.Run("Merge with image_source=none", func(t *testing.T) {
-		err := createMergeTestData(ctx)
-		if err != nil {
-			t.Fatalf("Failed to create merge test data: %v", err)
-		}
-		defer cleanupMergeTestData(ctx)
-
-		source := mergeTestItems[0]
-		target := mergeTestItems[1]
-
-		// Insert images for both
-		now := time.Now()
-		_, _ = database.DB().ExecContext(ctx,
-			`INSERT INTO inventory_images (item_id, image_data, mime_type, file_size, width, height, uploaded_at, updated_at)
-			VALUES ($1, $2, 'image/jpeg', 100, 50, 50, $3, $4)`,
-			source.ID, []byte("fake-source-image"), now, now)
-		_, _ = database.DB().ExecContext(ctx,
-			`INSERT INTO inventory_images (item_id, image_data, mime_type, file_size, width, height, uploaded_at, updated_at)
-			VALUES ($1, $2, 'image/jpeg', 200, 100, 100, $3, $4)`,
-			target.ID, []byte("fake-target-image"), now, now)
-
-		router := gin.Default()
-		router.POST("/myinventory/merge", PostMyInventoryMerge)
-
-		token, _ := security.GenerateToken(users[0].ID)
-		mergeReq := MergeInventoryRequest{
-			SourceItemID: int(source.ID),
-			TargetItemID: int(target.ID),
-			ItemName:     "Image None Test",
-			Category:     "Test",
-			Weight:       100,
-			Currency:     "USD",
-			ImageSource:  "none",
-		}
-
-		jsonData, _ := json.Marshal(mergeReq)
-		req, _ := http.NewRequest(http.MethodPost, "/myinventory/merge", bytes.NewBuffer(jsonData))
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", "Bearer "+token)
-
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		if w.Code != http.StatusOK {
-			t.Errorf("Expected status code %d but got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
-			return
-		}
-
-		var mergedItem Inventory
-		json.Unmarshal(w.Body.Bytes(), &mergedItem)
-
-		// Verify no image on the merged item
-		if mergedItem.HasImage {
-			t.Errorf("Expected merged item to have no image with image_source=none")
-		}
+		testMergeImageNone(ctx, t)
 	})
-
 	t.Run("Merge fails - source equals target", func(t *testing.T) {
-		router := gin.Default()
-		router.POST("/myinventory/merge", PostMyInventoryMerge)
-
-		token, _ := security.GenerateToken(users[0].ID)
-		mergeReq := MergeInventoryRequest{
-			SourceItemID: int(inventories[0].ID),
-			TargetItemID: int(inventories[0].ID),
-			ItemName:     "Same Item",
-			Category:     "Test",
-			Currency:     "USD",
-			ImageSource:  "none",
-		}
-
-		jsonData, _ := json.Marshal(mergeReq)
-		req, _ := http.NewRequest(http.MethodPost, "/myinventory/merge", bytes.NewBuffer(jsonData))
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", "Bearer "+token)
-
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		if w.Code != http.StatusBadRequest {
-			t.Errorf("Expected status code %d but got %d", http.StatusBadRequest, w.Code)
-		}
+		testMergeSourceEqualsTarget(t)
 	})
-
 	t.Run("Merge fails - ownership validation", func(t *testing.T) {
-		router := gin.Default()
-		router.POST("/myinventory/merge", PostMyInventoryMerge)
-
-		// User 2 tries to merge user 1's items
-		token, _ := security.GenerateToken(users[1].ID)
-		mergeReq := MergeInventoryRequest{
-			SourceItemID: int(inventories[0].ID),
-			TargetItemID: int(inventories[1].ID),
-			ItemName:     "Stolen Merge",
-			Category:     "Test",
-			Currency:     "USD",
-			ImageSource:  "none",
-		}
-
-		jsonData, _ := json.Marshal(mergeReq)
-		req, _ := http.NewRequest(http.MethodPost, "/myinventory/merge", bytes.NewBuffer(jsonData))
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", "Bearer "+token)
-
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		if w.Code != http.StatusForbidden {
-			t.Errorf("Expected status code %d but got %d", http.StatusForbidden, w.Code)
-		}
+		testMergeOwnershipValidation(t)
 	})
-
 	t.Run("Merge fails - source not found", func(t *testing.T) {
-		router := gin.Default()
-		router.POST("/myinventory/merge", PostMyInventoryMerge)
-
-		token, _ := security.GenerateToken(users[0].ID)
-		mergeReq := MergeInventoryRequest{
-			SourceItemID: 999999,
-			TargetItemID: int(inventories[0].ID),
-			ItemName:     "Missing Source",
-			Category:     "Test",
-			Currency:     "USD",
-			ImageSource:  "none",
-		}
-
-		jsonData, _ := json.Marshal(mergeReq)
-		req, _ := http.NewRequest(http.MethodPost, "/myinventory/merge", bytes.NewBuffer(jsonData))
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", "Bearer "+token)
-
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		if w.Code != http.StatusNotFound {
-			t.Errorf("Expected status code %d but got %d", http.StatusNotFound, w.Code)
-		}
+		testMergeSourceNotFound(t)
 	})
+}
+
+func testMergeSharedPack(ctx context.Context, t *testing.T) {
+	err := createMergeTestData(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create merge test data: %v", err)
+	}
+	defer cleanupMergeTestData(ctx)
+
+	source := mergeTestItems[0]
+	target := mergeTestItems[1]
+
+	w := executeMergeRequest(t, MergeInventoryRequest{
+		SourceItemID: source.ID,
+		TargetItemID: target.ID,
+		ItemName:     "Merged Item",
+		Category:     "Merged Category",
+		Description:  "Merged description",
+		Weight:       300,
+		URL:          "https://example.com/merged",
+		Price:        30,
+		Currency:     "EUR",
+		ImageSource:  "none",
+	}, users[0].ID)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d but got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var mergedItem Inventory
+	if err := json.Unmarshal(w.Body.Bytes(), &mergedItem); err != nil {
+		t.Fatalf("Failed to unmarshal response body: %v", err)
+	}
+
+	if mergedItem.ID != target.ID {
+		t.Errorf("Expected merged item ID %d but got %d", target.ID, mergedItem.ID)
+	}
+	if mergedItem.ItemName != "Merged Item" {
+		t.Errorf("Expected item name 'Merged Item' but got '%s'", mergedItem.ItemName)
+	}
+	if mergedItem.PackCount != 2 {
+		t.Errorf("Expected pack count 2 but got %d", mergedItem.PackCount)
+	}
+
+	// Verify source item is deleted
+	_, err = findInventoryByID(ctx, source.ID)
+	if !errors.Is(err, ErrNoItemFound) {
+		t.Errorf("Expected source item to be deleted, got err: %v", err)
+	}
+
+	// Verify shared pack quantity was summed (2 + 3 = 5)
+	var quantity int
+	err = database.DB().QueryRowContext(ctx,
+		`SELECT quantity FROM pack_content WHERE pack_id = $1 AND item_id = $2`,
+		mergeTestPackIDs[0], target.ID).Scan(&quantity)
+	if err != nil {
+		t.Fatalf("Failed to query pack_content: %v", err)
+	}
+	if quantity != 5 {
+		t.Errorf("Expected quantity 5 in shared pack but got %d", quantity)
+	}
+}
+
+func testMergeNoPackOverlap(ctx context.Context, t *testing.T) {
+	err := createMergeTestData(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create merge test data: %v", err)
+	}
+	defer cleanupMergeTestData(ctx)
+
+	source := mergeTestItems[0]
+	target := mergeTestItems[1]
+
+	// Remove target from shared pack so there's no overlap
+	_, err = database.DB().ExecContext(ctx,
+		`DELETE FROM pack_content WHERE pack_id = $1 AND item_id = $2`,
+		mergeTestPackIDs[0], target.ID)
+	if err != nil {
+		t.Fatalf("Failed to remove target from shared pack: %v", err)
+	}
+
+	w := executeMergeRequest(t, MergeInventoryRequest{
+		SourceItemID: source.ID,
+		TargetItemID: target.ID,
+		ItemName:     "No Overlap Merged",
+		Category:     "Test",
+		Weight:       150,
+		Price:        15,
+		Currency:     "USD",
+		ImageSource:  "none",
+	}, users[0].ID)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d but got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var mergedItem Inventory
+	if err := json.Unmarshal(w.Body.Bytes(), &mergedItem); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	if mergedItem.PackCount != 2 {
+		t.Errorf("Expected pack count 2 but got %d", mergedItem.PackCount)
+	}
+}
+
+func testMergeImageSource(ctx context.Context, t *testing.T) {
+	err := createMergeTestData(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create merge test data: %v", err)
+	}
+	defer cleanupMergeTestData(ctx)
+
+	source := mergeTestItems[0]
+	target := mergeTestItems[1]
+	now := time.Now()
+
+	insertTestImage(ctx, t, source.ID, "fake-source-image", now)
+	insertTestImage(ctx, t, target.ID, "fake-target-image", now)
+
+	w := executeMergeRequest(t, MergeInventoryRequest{
+		SourceItemID: source.ID,
+		TargetItemID: target.ID,
+		ItemName:     "Image Source Test",
+		Category:     "Test",
+		Weight:       100,
+		Currency:     "USD",
+		ImageSource:  "source",
+	}, users[0].ID)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d but got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var mergedItem Inventory
+	if err := json.Unmarshal(w.Body.Bytes(), &mergedItem); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+	if !mergedItem.HasImage {
+		t.Errorf("Expected merged item to have image (source image reassigned)")
+	}
+
+	var imageData []byte
+	err = database.DB().QueryRowContext(ctx,
+		`SELECT image_data FROM inventory_images WHERE item_id = $1`,
+		target.ID).Scan(&imageData)
+	if err != nil {
+		t.Fatalf("Failed to query image: %v", err)
+	}
+	if string(imageData) != "fake-source-image" {
+		t.Errorf("Expected source image data but got different data")
+	}
+}
+
+func testMergeImageTarget(ctx context.Context, t *testing.T) {
+	err := createMergeTestData(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create merge test data: %v", err)
+	}
+	defer cleanupMergeTestData(ctx)
+
+	source := mergeTestItems[0]
+	target := mergeTestItems[1]
+
+	insertTestImage(ctx, t, target.ID, "fake-target-image", time.Now())
+
+	w := executeMergeRequest(t, MergeInventoryRequest{
+		SourceItemID: source.ID,
+		TargetItemID: target.ID,
+		ItemName:     "Image Target Test",
+		Category:     "Test",
+		Weight:       100,
+		Currency:     "USD",
+		ImageSource:  "target",
+	}, users[0].ID)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d but got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var mergedItem Inventory
+	if err := json.Unmarshal(w.Body.Bytes(), &mergedItem); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+	if !mergedItem.HasImage {
+		t.Errorf("Expected merged item to have image (target image kept)")
+	}
+}
+
+func testMergeImageNone(ctx context.Context, t *testing.T) {
+	err := createMergeTestData(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create merge test data: %v", err)
+	}
+	defer cleanupMergeTestData(ctx)
+
+	source := mergeTestItems[0]
+	target := mergeTestItems[1]
+	now := time.Now()
+
+	insertTestImage(ctx, t, source.ID, "fake-source-image", now)
+	insertTestImage(ctx, t, target.ID, "fake-target-image", now)
+
+	w := executeMergeRequest(t, MergeInventoryRequest{
+		SourceItemID: source.ID,
+		TargetItemID: target.ID,
+		ItemName:     "Image None Test",
+		Category:     "Test",
+		Weight:       100,
+		Currency:     "USD",
+		ImageSource:  "none",
+	}, users[0].ID)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d but got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var mergedItem Inventory
+	if err := json.Unmarshal(w.Body.Bytes(), &mergedItem); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+	if mergedItem.HasImage {
+		t.Errorf("Expected merged item to have no image with image_source=none")
+	}
+}
+
+func testMergeSourceEqualsTarget(t *testing.T) {
+	w := executeMergeRequest(t, MergeInventoryRequest{
+		SourceItemID: inventories[0].ID,
+		TargetItemID: inventories[0].ID,
+		ItemName:     "Same Item",
+		Category:     "Test",
+		Currency:     "USD",
+		ImageSource:  "none",
+	}, users[0].ID)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d but got %d", http.StatusBadRequest, w.Code)
+	}
+}
+
+func testMergeOwnershipValidation(t *testing.T) {
+	w := executeMergeRequest(t, MergeInventoryRequest{
+		SourceItemID: inventories[0].ID,
+		TargetItemID: inventories[1].ID,
+		ItemName:     "Stolen Merge",
+		Category:     "Test",
+		Currency:     "USD",
+		ImageSource:  "none",
+	}, users[1].ID)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("Expected status %d but got %d", http.StatusForbidden, w.Code)
+	}
+}
+
+func testMergeSourceNotFound(t *testing.T) {
+	w := executeMergeRequest(t, MergeInventoryRequest{
+		SourceItemID: 999999,
+		TargetItemID: inventories[0].ID,
+		ItemName:     "Missing Source",
+		Category:     "Test",
+		Currency:     "USD",
+		ImageSource:  "none",
+	}, users[0].ID)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status %d but got %d", http.StatusNotFound, w.Code)
+	}
+}
+
+// executeMergeRequest is a helper that sends a merge request and returns the recorder.
+func executeMergeRequest(
+	t *testing.T,
+	mergeReq MergeInventoryRequest,
+	userID uint,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	router := gin.Default()
+	router.POST("/myinventory/merge", PostMyInventoryMerge)
+
+	token, err := security.GenerateToken(userID)
+	if err != nil {
+		t.Fatalf("Failed to generate token: %v", err)
+	}
+
+	jsonData, err := json.Marshal(mergeReq)
+	if err != nil {
+		t.Fatalf("Failed to marshal merge request: %v", err)
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPost, "/myinventory/merge", bytes.NewBuffer(jsonData))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// insertTestImage inserts a fake image for testing merge image handling.
+func insertTestImage(
+	ctx context.Context, t *testing.T, itemID uint, data string, now time.Time,
+) {
+	t.Helper()
+	_, err := database.DB().ExecContext(ctx,
+		`INSERT INTO inventory_images
+		(item_id, image_data, mime_type, file_size, width, height, uploaded_at, updated_at)
+		VALUES ($1, $2, 'image/jpeg', 100, 50, 50, $3, $4)`,
+		itemID, []byte(data), now, now)
+	if err != nil {
+		t.Fatalf("Failed to insert test image: %v", err)
+	}
 }
 
 // Helper functions to reduce cognitive complexity

--- a/pkg/inventories/inventories_test.go
+++ b/pkg/inventories/inventories_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/Angak0k/pimpmypack/pkg/config"
 	"github.com/Angak0k/pimpmypack/pkg/database"
@@ -696,6 +697,452 @@ func TestGetMyInventoryByID(t *testing.T) {
 		// Check the HTTP status code
 		if w.Code != http.StatusForbidden {
 			t.Errorf("Expected status code %d but got %d", http.StatusForbidden, w.Code)
+		}
+	})
+}
+
+func TestPostMyInventoryMerge(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx := context.Background()
+
+	t.Run("Merge with shared pack - quantities summed", func(t *testing.T) {
+		// Setup merge test data
+		err := createMergeTestData(ctx)
+		if err != nil {
+			t.Fatalf("Failed to create merge test data: %v", err)
+		}
+		defer cleanupMergeTestData(ctx)
+
+		source := mergeTestItems[0]
+		target := mergeTestItems[1]
+
+		router := gin.Default()
+		router.POST("/myinventory/merge", PostMyInventoryMerge)
+
+		token, err := security.GenerateToken(users[0].ID)
+		if err != nil {
+			t.Fatalf("Failed to generate token: %v", err)
+		}
+
+		mergeReq := MergeInventoryRequest{
+			SourceItemID: int(source.ID),
+			TargetItemID: int(target.ID),
+			ItemName:     "Merged Item",
+			Category:     "Merged Category",
+			Description:  "Merged description",
+			Weight:       300,
+			URL:          "https://example.com/merged",
+			Price:        30,
+			Currency:     "EUR",
+			ImageSource:  "none",
+		}
+
+		jsonData, err := json.Marshal(mergeReq)
+		if err != nil {
+			t.Fatalf("Failed to marshal merge request: %v", err)
+		}
+
+		req, err := http.NewRequest(http.MethodPost, "/myinventory/merge", bytes.NewBuffer(jsonData))
+		if err != nil {
+			t.Fatalf("Failed to create request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status code %d but got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+			return
+		}
+
+		var mergedItem Inventory
+		if err := json.Unmarshal(w.Body.Bytes(), &mergedItem); err != nil {
+			t.Fatalf("Failed to unmarshal response body: %v", err)
+		}
+
+		// Verify merged item properties
+		if mergedItem.ID != target.ID {
+			t.Errorf("Expected merged item ID %d but got %d", target.ID, mergedItem.ID)
+		}
+		if mergedItem.ItemName != "Merged Item" {
+			t.Errorf("Expected item name 'Merged Item' but got '%s'", mergedItem.ItemName)
+		}
+		if mergedItem.Category != "Merged Category" {
+			t.Errorf("Expected category 'Merged Category' but got '%s'", mergedItem.Category)
+		}
+		if mergedItem.Weight != 300 {
+			t.Errorf("Expected weight 300 but got %d", mergedItem.Weight)
+		}
+
+		// Verify target is in 2 packs (shared + non-shared reassigned)
+		if mergedItem.PackCount != 2 {
+			t.Errorf("Expected pack count 2 but got %d", mergedItem.PackCount)
+		}
+
+		// Verify source item is deleted
+		_, err = findInventoryByID(ctx, source.ID)
+		if !errors.Is(err, ErrNoItemFound) {
+			t.Errorf("Expected source item to be deleted, got err: %v", err)
+		}
+
+		// Verify shared pack quantity was summed (2 + 3 = 5)
+		var quantity int
+		err = database.DB().QueryRowContext(ctx,
+			`SELECT quantity FROM pack_content WHERE pack_id = $1 AND item_id = $2`,
+			mergeTestPackIDs[0], target.ID).Scan(&quantity)
+		if err != nil {
+			t.Fatalf("Failed to query pack_content: %v", err)
+		}
+		if quantity != 5 {
+			t.Errorf("Expected quantity 5 in shared pack but got %d", quantity)
+		}
+
+		// Verify non-shared pack was reassigned to target
+		var nonSharedQuantity int
+		err = database.DB().QueryRowContext(ctx,
+			`SELECT quantity FROM pack_content WHERE pack_id = $1 AND item_id = $2`,
+			mergeTestPackIDs[1], target.ID).Scan(&nonSharedQuantity)
+		if err != nil {
+			t.Fatalf("Failed to query non-shared pack_content: %v", err)
+		}
+		if nonSharedQuantity != 1 {
+			t.Errorf("Expected quantity 1 in non-shared pack but got %d", nonSharedQuantity)
+		}
+	})
+
+	t.Run("Merge with no pack overlap", func(t *testing.T) {
+		err := createMergeTestData(ctx)
+		if err != nil {
+			t.Fatalf("Failed to create merge test data: %v", err)
+		}
+		defer cleanupMergeTestData(ctx)
+
+		source := mergeTestItems[0]
+		target := mergeTestItems[1]
+
+		// Remove target from shared pack so there's no overlap
+		_, err = database.DB().ExecContext(ctx,
+			`DELETE FROM pack_content WHERE pack_id = $1 AND item_id = $2`,
+			mergeTestPackIDs[0], target.ID)
+		if err != nil {
+			t.Fatalf("Failed to remove target from shared pack: %v", err)
+		}
+
+		router := gin.Default()
+		router.POST("/myinventory/merge", PostMyInventoryMerge)
+
+		token, err := security.GenerateToken(users[0].ID)
+		if err != nil {
+			t.Fatalf("Failed to generate token: %v", err)
+		}
+
+		mergeReq := MergeInventoryRequest{
+			SourceItemID: int(source.ID),
+			TargetItemID: int(target.ID),
+			ItemName:     "No Overlap Merged",
+			Category:     "Test",
+			Description:  "",
+			Weight:       150,
+			URL:          "",
+			Price:        15,
+			Currency:     "USD",
+			ImageSource:  "none",
+		}
+
+		jsonData, _ := json.Marshal(mergeReq)
+		req, _ := http.NewRequest(http.MethodPost, "/myinventory/merge", bytes.NewBuffer(jsonData))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status code %d but got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+			return
+		}
+
+		var mergedItem Inventory
+		if err := json.Unmarshal(w.Body.Bytes(), &mergedItem); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+
+		// Source had 2 packs (shared + non-shared), all reassigned to target
+		if mergedItem.PackCount != 2 {
+			t.Errorf("Expected pack count 2 but got %d", mergedItem.PackCount)
+		}
+	})
+
+	t.Run("Merge with image_source=source", func(t *testing.T) {
+		err := createMergeTestData(ctx)
+		if err != nil {
+			t.Fatalf("Failed to create merge test data: %v", err)
+		}
+		defer cleanupMergeTestData(ctx)
+
+		source := mergeTestItems[0]
+		target := mergeTestItems[1]
+
+		// Insert a source image
+		now := time.Now()
+		_, err = database.DB().ExecContext(ctx,
+			`INSERT INTO inventory_images (item_id, image_data, mime_type, file_size, width, height, uploaded_at, updated_at)
+			VALUES ($1, $2, 'image/jpeg', 100, 50, 50, $3, $4)`,
+			source.ID, []byte("fake-source-image"), now, now)
+		if err != nil {
+			t.Fatalf("Failed to insert source image: %v", err)
+		}
+
+		// Insert a target image
+		_, err = database.DB().ExecContext(ctx,
+			`INSERT INTO inventory_images (item_id, image_data, mime_type, file_size, width, height, uploaded_at, updated_at)
+			VALUES ($1, $2, 'image/jpeg', 200, 100, 100, $3, $4)`,
+			target.ID, []byte("fake-target-image"), now, now)
+		if err != nil {
+			t.Fatalf("Failed to insert target image: %v", err)
+		}
+
+		router := gin.Default()
+		router.POST("/myinventory/merge", PostMyInventoryMerge)
+
+		token, _ := security.GenerateToken(users[0].ID)
+		mergeReq := MergeInventoryRequest{
+			SourceItemID: int(source.ID),
+			TargetItemID: int(target.ID),
+			ItemName:     "Image Source Test",
+			Category:     "Test",
+			Weight:       100,
+			Currency:     "USD",
+			ImageSource:  "source",
+		}
+
+		jsonData, _ := json.Marshal(mergeReq)
+		req, _ := http.NewRequest(http.MethodPost, "/myinventory/merge", bytes.NewBuffer(jsonData))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status code %d but got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+			return
+		}
+
+		var mergedItem Inventory
+		json.Unmarshal(w.Body.Bytes(), &mergedItem)
+
+		// Verify the merged item has an image (source image was reassigned to target)
+		if !mergedItem.HasImage {
+			t.Errorf("Expected merged item to have image (source image reassigned)")
+		}
+
+		// Verify the image data is the source image
+		var imageData []byte
+		err = database.DB().QueryRowContext(ctx,
+			`SELECT image_data FROM inventory_images WHERE item_id = $1`, target.ID).Scan(&imageData)
+		if err != nil {
+			t.Fatalf("Failed to query image: %v", err)
+		}
+		if string(imageData) != "fake-source-image" {
+			t.Errorf("Expected source image data but got different data")
+		}
+	})
+
+	t.Run("Merge with image_source=target", func(t *testing.T) {
+		err := createMergeTestData(ctx)
+		if err != nil {
+			t.Fatalf("Failed to create merge test data: %v", err)
+		}
+		defer cleanupMergeTestData(ctx)
+
+		source := mergeTestItems[0]
+		target := mergeTestItems[1]
+
+		// Insert a target image only
+		now := time.Now()
+		_, err = database.DB().ExecContext(ctx,
+			`INSERT INTO inventory_images (item_id, image_data, mime_type, file_size, width, height, uploaded_at, updated_at)
+			VALUES ($1, $2, 'image/jpeg', 200, 100, 100, $3, $4)`,
+			target.ID, []byte("fake-target-image"), now, now)
+		if err != nil {
+			t.Fatalf("Failed to insert target image: %v", err)
+		}
+
+		router := gin.Default()
+		router.POST("/myinventory/merge", PostMyInventoryMerge)
+
+		token, _ := security.GenerateToken(users[0].ID)
+		mergeReq := MergeInventoryRequest{
+			SourceItemID: int(source.ID),
+			TargetItemID: int(target.ID),
+			ItemName:     "Image Target Test",
+			Category:     "Test",
+			Weight:       100,
+			Currency:     "USD",
+			ImageSource:  "target",
+		}
+
+		jsonData, _ := json.Marshal(mergeReq)
+		req, _ := http.NewRequest(http.MethodPost, "/myinventory/merge", bytes.NewBuffer(jsonData))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status code %d but got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+			return
+		}
+
+		var mergedItem Inventory
+		json.Unmarshal(w.Body.Bytes(), &mergedItem)
+
+		// Verify the merged item still has the target image
+		if !mergedItem.HasImage {
+			t.Errorf("Expected merged item to have image (target image kept)")
+		}
+	})
+
+	t.Run("Merge with image_source=none", func(t *testing.T) {
+		err := createMergeTestData(ctx)
+		if err != nil {
+			t.Fatalf("Failed to create merge test data: %v", err)
+		}
+		defer cleanupMergeTestData(ctx)
+
+		source := mergeTestItems[0]
+		target := mergeTestItems[1]
+
+		// Insert images for both
+		now := time.Now()
+		_, _ = database.DB().ExecContext(ctx,
+			`INSERT INTO inventory_images (item_id, image_data, mime_type, file_size, width, height, uploaded_at, updated_at)
+			VALUES ($1, $2, 'image/jpeg', 100, 50, 50, $3, $4)`,
+			source.ID, []byte("fake-source-image"), now, now)
+		_, _ = database.DB().ExecContext(ctx,
+			`INSERT INTO inventory_images (item_id, image_data, mime_type, file_size, width, height, uploaded_at, updated_at)
+			VALUES ($1, $2, 'image/jpeg', 200, 100, 100, $3, $4)`,
+			target.ID, []byte("fake-target-image"), now, now)
+
+		router := gin.Default()
+		router.POST("/myinventory/merge", PostMyInventoryMerge)
+
+		token, _ := security.GenerateToken(users[0].ID)
+		mergeReq := MergeInventoryRequest{
+			SourceItemID: int(source.ID),
+			TargetItemID: int(target.ID),
+			ItemName:     "Image None Test",
+			Category:     "Test",
+			Weight:       100,
+			Currency:     "USD",
+			ImageSource:  "none",
+		}
+
+		jsonData, _ := json.Marshal(mergeReq)
+		req, _ := http.NewRequest(http.MethodPost, "/myinventory/merge", bytes.NewBuffer(jsonData))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status code %d but got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+			return
+		}
+
+		var mergedItem Inventory
+		json.Unmarshal(w.Body.Bytes(), &mergedItem)
+
+		// Verify no image on the merged item
+		if mergedItem.HasImage {
+			t.Errorf("Expected merged item to have no image with image_source=none")
+		}
+	})
+
+	t.Run("Merge fails - source equals target", func(t *testing.T) {
+		router := gin.Default()
+		router.POST("/myinventory/merge", PostMyInventoryMerge)
+
+		token, _ := security.GenerateToken(users[0].ID)
+		mergeReq := MergeInventoryRequest{
+			SourceItemID: int(inventories[0].ID),
+			TargetItemID: int(inventories[0].ID),
+			ItemName:     "Same Item",
+			Category:     "Test",
+			Currency:     "USD",
+			ImageSource:  "none",
+		}
+
+		jsonData, _ := json.Marshal(mergeReq)
+		req, _ := http.NewRequest(http.MethodPost, "/myinventory/merge", bytes.NewBuffer(jsonData))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("Expected status code %d but got %d", http.StatusBadRequest, w.Code)
+		}
+	})
+
+	t.Run("Merge fails - ownership validation", func(t *testing.T) {
+		router := gin.Default()
+		router.POST("/myinventory/merge", PostMyInventoryMerge)
+
+		// User 2 tries to merge user 1's items
+		token, _ := security.GenerateToken(users[1].ID)
+		mergeReq := MergeInventoryRequest{
+			SourceItemID: int(inventories[0].ID),
+			TargetItemID: int(inventories[1].ID),
+			ItemName:     "Stolen Merge",
+			Category:     "Test",
+			Currency:     "USD",
+			ImageSource:  "none",
+		}
+
+		jsonData, _ := json.Marshal(mergeReq)
+		req, _ := http.NewRequest(http.MethodPost, "/myinventory/merge", bytes.NewBuffer(jsonData))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusForbidden {
+			t.Errorf("Expected status code %d but got %d", http.StatusForbidden, w.Code)
+		}
+	})
+
+	t.Run("Merge fails - source not found", func(t *testing.T) {
+		router := gin.Default()
+		router.POST("/myinventory/merge", PostMyInventoryMerge)
+
+		token, _ := security.GenerateToken(users[0].ID)
+		mergeReq := MergeInventoryRequest{
+			SourceItemID: 999999,
+			TargetItemID: int(inventories[0].ID),
+			ItemName:     "Missing Source",
+			Category:     "Test",
+			Currency:     "USD",
+			ImageSource:  "none",
+		}
+
+		jsonData, _ := json.Marshal(mergeReq)
+		req, _ := http.NewRequest(http.MethodPost, "/myinventory/merge", bytes.NewBuffer(jsonData))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("Expected status code %d but got %d", http.StatusNotFound, w.Code)
 		}
 	})
 }

--- a/pkg/inventories/inventories_test.go
+++ b/pkg/inventories/inventories_test.go
@@ -736,7 +736,11 @@ func testMergeSharedPack(ctx context.Context, t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create merge test data: %v", err)
 	}
-	defer cleanupMergeTestData(ctx)
+	defer func() {
+		if err := cleanupMergeTestData(ctx); err != nil {
+			t.Errorf("Failed to cleanup merge test data: %v", err)
+		}
+	}()
 
 	source := mergeTestItems[0]
 	target := mergeTestItems[1]
@@ -797,7 +801,11 @@ func testMergeNoPackOverlap(ctx context.Context, t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create merge test data: %v", err)
 	}
-	defer cleanupMergeTestData(ctx)
+	defer func() {
+		if err := cleanupMergeTestData(ctx); err != nil {
+			t.Errorf("Failed to cleanup merge test data: %v", err)
+		}
+	}()
 
 	source := mergeTestItems[0]
 	target := mergeTestItems[1]
@@ -840,7 +848,11 @@ func testMergeImageSource(ctx context.Context, t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create merge test data: %v", err)
 	}
-	defer cleanupMergeTestData(ctx)
+	defer func() {
+		if err := cleanupMergeTestData(ctx); err != nil {
+			t.Errorf("Failed to cleanup merge test data: %v", err)
+		}
+	}()
 
 	source := mergeTestItems[0]
 	target := mergeTestItems[1]
@@ -888,7 +900,11 @@ func testMergeImageTarget(ctx context.Context, t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create merge test data: %v", err)
 	}
-	defer cleanupMergeTestData(ctx)
+	defer func() {
+		if err := cleanupMergeTestData(ctx); err != nil {
+			t.Errorf("Failed to cleanup merge test data: %v", err)
+		}
+	}()
 
 	source := mergeTestItems[0]
 	target := mergeTestItems[1]
@@ -923,7 +939,11 @@ func testMergeImageNone(ctx context.Context, t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create merge test data: %v", err)
 	}
-	defer cleanupMergeTestData(ctx)
+	defer func() {
+		if err := cleanupMergeTestData(ctx); err != nil {
+			t.Errorf("Failed to cleanup merge test data: %v", err)
+		}
+	}()
 
 	source := mergeTestItems[0]
 	target := mergeTestItems[1]

--- a/pkg/inventories/repository.go
+++ b/pkg/inventories/repository.go
@@ -367,7 +367,7 @@ func mergeUpdateTargetAndPackContent(ctx context.Context, tx *sql.Tx, req *Merge
 	// Sum quantities for packs containing both items
 	_, err = tx.ExecContext(ctx,
 		`UPDATE pack_content AS t
-		SET quantity = t.quantity + s.quantity, updated_at = NOW()
+		SET quantity = COALESCE(t.quantity, 0) + COALESCE(s.quantity, 0), updated_at = NOW()
 		FROM pack_content AS s
 		WHERE s.item_id = $1 AND t.item_id = $2 AND s.pack_id = t.pack_id;`,
 		req.SourceItemID, req.TargetItemID)
@@ -386,7 +386,7 @@ func mergeUpdateTargetAndPackContent(ctx context.Context, tx *sql.Tx, req *Merge
 
 	// Reassign remaining source pack_content rows to target
 	_, err = tx.ExecContext(ctx,
-		`UPDATE pack_content SET item_id = $1 WHERE item_id = $2;`,
+		`UPDATE pack_content SET item_id = $1, updated_at = NOW() WHERE item_id = $2;`,
 		req.TargetItemID, req.SourceItemID)
 	return err
 }

--- a/pkg/inventories/repository.go
+++ b/pkg/inventories/repository.go
@@ -310,6 +310,139 @@ func deleteInventoryByID(ctx context.Context, id uint) error {
 	return nil
 }
 
+// mergeInventoryItems merges the source inventory item into the target inventory item within a transaction.
+// It updates the target item properties, consolidates pack_content references, handles images,
+// and deletes the source item.
+func mergeInventoryItems(ctx context.Context, req *MergeInventoryRequest) (*Inventory, error) {
+	tx, err := database.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	sourceID := uint(req.SourceItemID)
+	targetID := uint(req.TargetItemID)
+
+	// Step 1: Update target item with merged property values
+	_, err = tx.ExecContext(ctx,
+		`UPDATE inventory
+		SET item_name = $1, category = $2, description = $3, weight = $4,
+			url = $5, price = $6, currency = $7, updated_at = NOW()
+		WHERE id = $8;`,
+		req.ItemName, req.Category, req.Description, req.Weight,
+		req.URL, req.Price, req.Currency, targetID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 2: Sum quantities for packs containing both items
+	_, err = tx.ExecContext(ctx,
+		`UPDATE pack_content AS t
+		SET quantity = t.quantity + s.quantity, updated_at = NOW()
+		FROM pack_content AS s
+		WHERE s.item_id = $1 AND t.item_id = $2 AND s.pack_id = t.pack_id;`,
+		sourceID, targetID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 3: Delete overlapping source pack_content rows
+	_, err = tx.ExecContext(ctx,
+		`DELETE FROM pack_content WHERE item_id = $1
+		AND pack_id IN (SELECT pack_id FROM pack_content WHERE item_id = $2);`,
+		sourceID, targetID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 4: Reassign remaining source pack_content rows to target
+	_, err = tx.ExecContext(ctx,
+		`UPDATE pack_content SET item_id = $1 WHERE item_id = $2;`,
+		targetID, sourceID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 5: Handle image based on image_source
+	switch req.ImageSource {
+	case "source":
+		// Delete target image, then update source image's item_id to target
+		_, err = tx.ExecContext(ctx, `DELETE FROM inventory_images WHERE item_id = $1;`, targetID)
+		if err != nil {
+			return nil, err
+		}
+		_, err = tx.ExecContext(ctx, `UPDATE inventory_images SET item_id = $1 WHERE item_id = $2;`, targetID, sourceID)
+		if err != nil {
+			return nil, err
+		}
+	case "target":
+		// Delete source image (if any) so it doesn't block source item deletion
+		_, err = tx.ExecContext(ctx, `DELETE FROM inventory_images WHERE item_id = $1;`, sourceID)
+		if err != nil {
+			return nil, err
+		}
+	case "none":
+		// Delete both images
+		_, err = tx.ExecContext(ctx, `DELETE FROM inventory_images WHERE item_id IN ($1, $2);`, sourceID, targetID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Step 6: Delete source inventory item (CASCADE cleans up remaining refs)
+	_, err = tx.ExecContext(ctx, `DELETE FROM inventory WHERE id = $1;`, sourceID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 7: Return updated target item (query it back after all updates)
+	var inventory Inventory
+	err = tx.QueryRowContext(ctx,
+		`SELECT i.id,
+			i.user_id,
+			i.item_name,
+			i.category,
+			i.description,
+			i.weight,
+			i.url,
+			i.price,
+			i.currency,
+			CASE WHEN ii.item_id IS NOT NULL THEN true ELSE false END as has_image,
+			(SELECT COUNT(DISTINCT pc.pack_id) FROM pack_content pc WHERE pc.item_id = i.id) as pack_count,
+			i.created_at,
+			i.updated_at
+		FROM inventory i
+		LEFT JOIN inventory_images ii ON i.id = ii.item_id
+		WHERE i.id = $1;`,
+		targetID).Scan(
+		&inventory.ID,
+		&inventory.UserID,
+		&inventory.ItemName,
+		&inventory.Category,
+		&inventory.Description,
+		&inventory.Weight,
+		&inventory.URL,
+		&inventory.Price,
+		&inventory.Currency,
+		&inventory.HasImage,
+		&inventory.PackCount,
+		&inventory.CreatedAt,
+		&inventory.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return &inventory, nil
+}
+
 // checkInventoryOwnership verifies if an inventory item belongs to a specific user
 func checkInventoryOwnership(ctx context.Context, id uint, userID uint) (bool, error) {
 	var rows int

--- a/pkg/inventories/repository.go
+++ b/pkg/inventories/repository.go
@@ -324,114 +324,21 @@ func mergeInventoryItems(ctx context.Context, req *MergeInventoryRequest) (*Inve
 		}
 	}()
 
-	sourceID := uint(req.SourceItemID)
-	targetID := uint(req.TargetItemID)
+	if err = mergeUpdateTargetAndPackContent(ctx, tx, req); err != nil {
+		return nil, err
+	}
 
-	// Step 1: Update target item with merged property values
-	_, err = tx.ExecContext(ctx,
-		`UPDATE inventory
-		SET item_name = $1, category = $2, description = $3, weight = $4,
-			url = $5, price = $6, currency = $7, updated_at = NOW()
-		WHERE id = $8;`,
-		req.ItemName, req.Category, req.Description, req.Weight,
-		req.URL, req.Price, req.Currency, targetID)
+	if err = mergeHandleImages(ctx, tx, req); err != nil {
+		return nil, err
+	}
+
+	// Delete source inventory item (CASCADE cleans up remaining refs)
+	_, err = tx.ExecContext(ctx, `DELETE FROM inventory WHERE id = $1;`, req.SourceItemID)
 	if err != nil {
 		return nil, err
 	}
 
-	// Step 2: Sum quantities for packs containing both items
-	_, err = tx.ExecContext(ctx,
-		`UPDATE pack_content AS t
-		SET quantity = t.quantity + s.quantity, updated_at = NOW()
-		FROM pack_content AS s
-		WHERE s.item_id = $1 AND t.item_id = $2 AND s.pack_id = t.pack_id;`,
-		sourceID, targetID)
-	if err != nil {
-		return nil, err
-	}
-
-	// Step 3: Delete overlapping source pack_content rows
-	_, err = tx.ExecContext(ctx,
-		`DELETE FROM pack_content WHERE item_id = $1
-		AND pack_id IN (SELECT pack_id FROM pack_content WHERE item_id = $2);`,
-		sourceID, targetID)
-	if err != nil {
-		return nil, err
-	}
-
-	// Step 4: Reassign remaining source pack_content rows to target
-	_, err = tx.ExecContext(ctx,
-		`UPDATE pack_content SET item_id = $1 WHERE item_id = $2;`,
-		targetID, sourceID)
-	if err != nil {
-		return nil, err
-	}
-
-	// Step 5: Handle image based on image_source
-	switch req.ImageSource {
-	case "source":
-		// Delete target image, then update source image's item_id to target
-		_, err = tx.ExecContext(ctx, `DELETE FROM inventory_images WHERE item_id = $1;`, targetID)
-		if err != nil {
-			return nil, err
-		}
-		_, err = tx.ExecContext(ctx, `UPDATE inventory_images SET item_id = $1 WHERE item_id = $2;`, targetID, sourceID)
-		if err != nil {
-			return nil, err
-		}
-	case "target":
-		// Delete source image (if any) so it doesn't block source item deletion
-		_, err = tx.ExecContext(ctx, `DELETE FROM inventory_images WHERE item_id = $1;`, sourceID)
-		if err != nil {
-			return nil, err
-		}
-	case "none":
-		// Delete both images
-		_, err = tx.ExecContext(ctx, `DELETE FROM inventory_images WHERE item_id IN ($1, $2);`, sourceID, targetID)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// Step 6: Delete source inventory item (CASCADE cleans up remaining refs)
-	_, err = tx.ExecContext(ctx, `DELETE FROM inventory WHERE id = $1;`, sourceID)
-	if err != nil {
-		return nil, err
-	}
-
-	// Step 7: Return updated target item (query it back after all updates)
-	var inventory Inventory
-	err = tx.QueryRowContext(ctx,
-		`SELECT i.id,
-			i.user_id,
-			i.item_name,
-			i.category,
-			i.description,
-			i.weight,
-			i.url,
-			i.price,
-			i.currency,
-			CASE WHEN ii.item_id IS NOT NULL THEN true ELSE false END as has_image,
-			(SELECT COUNT(DISTINCT pc.pack_id) FROM pack_content pc WHERE pc.item_id = i.id) as pack_count,
-			i.created_at,
-			i.updated_at
-		FROM inventory i
-		LEFT JOIN inventory_images ii ON i.id = ii.item_id
-		WHERE i.id = $1;`,
-		targetID).Scan(
-		&inventory.ID,
-		&inventory.UserID,
-		&inventory.ItemName,
-		&inventory.Category,
-		&inventory.Description,
-		&inventory.Weight,
-		&inventory.URL,
-		&inventory.Price,
-		&inventory.Currency,
-		&inventory.HasImage,
-		&inventory.PackCount,
-		&inventory.CreatedAt,
-		&inventory.UpdatedAt)
+	inventory, err := mergeQueryResult(ctx, tx, req.TargetItemID)
 	if err != nil {
 		return nil, err
 	}
@@ -440,6 +347,95 @@ func mergeInventoryItems(ctx context.Context, req *MergeInventoryRequest) (*Inve
 		return nil, err
 	}
 
+	return inventory, nil
+}
+
+// mergeUpdateTargetAndPackContent updates the target item properties and consolidates pack_content rows.
+func mergeUpdateTargetAndPackContent(ctx context.Context, tx *sql.Tx, req *MergeInventoryRequest) error {
+	// Update target item with merged property values
+	_, err := tx.ExecContext(ctx,
+		`UPDATE inventory
+		SET item_name = $1, category = $2, description = $3, weight = $4,
+			url = $5, price = $6, currency = $7, updated_at = NOW()
+		WHERE id = $8;`,
+		req.ItemName, req.Category, req.Description, req.Weight,
+		req.URL, req.Price, req.Currency, req.TargetItemID)
+	if err != nil {
+		return err
+	}
+
+	// Sum quantities for packs containing both items
+	_, err = tx.ExecContext(ctx,
+		`UPDATE pack_content AS t
+		SET quantity = t.quantity + s.quantity, updated_at = NOW()
+		FROM pack_content AS s
+		WHERE s.item_id = $1 AND t.item_id = $2 AND s.pack_id = t.pack_id;`,
+		req.SourceItemID, req.TargetItemID)
+	if err != nil {
+		return err
+	}
+
+	// Delete overlapping source pack_content rows
+	_, err = tx.ExecContext(ctx,
+		`DELETE FROM pack_content WHERE item_id = $1
+		AND pack_id IN (SELECT pack_id FROM pack_content WHERE item_id = $2);`,
+		req.SourceItemID, req.TargetItemID)
+	if err != nil {
+		return err
+	}
+
+	// Reassign remaining source pack_content rows to target
+	_, err = tx.ExecContext(ctx,
+		`UPDATE pack_content SET item_id = $1 WHERE item_id = $2;`,
+		req.TargetItemID, req.SourceItemID)
+	return err
+}
+
+// mergeHandleImages handles image reassignment based on the image_source selection.
+func mergeHandleImages(ctx context.Context, tx *sql.Tx, req *MergeInventoryRequest) error {
+	switch req.ImageSource {
+	case "source":
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM inventory_images WHERE item_id = $1;`, req.TargetItemID); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx,
+			`UPDATE inventory_images SET item_id = $1 WHERE item_id = $2;`,
+			req.TargetItemID, req.SourceItemID)
+		return err
+	case "target":
+		_, err := tx.ExecContext(ctx,
+			`DELETE FROM inventory_images WHERE item_id = $1;`, req.SourceItemID)
+		return err
+	case "none":
+		_, err := tx.ExecContext(ctx,
+			`DELETE FROM inventory_images WHERE item_id IN ($1, $2);`,
+			req.SourceItemID, req.TargetItemID)
+		return err
+	}
+	return nil
+}
+
+// mergeQueryResult queries the updated target item after the merge.
+func mergeQueryResult(ctx context.Context, tx *sql.Tx, targetID uint) (*Inventory, error) {
+	var inventory Inventory
+	err := tx.QueryRowContext(ctx,
+		`SELECT i.id, i.user_id, i.item_name, i.category, i.description,
+			i.weight, i.url, i.price, i.currency,
+			CASE WHEN ii.item_id IS NOT NULL THEN true ELSE false END as has_image,
+			(SELECT COUNT(DISTINCT pc.pack_id) FROM pack_content pc WHERE pc.item_id = i.id) as pack_count,
+			i.created_at, i.updated_at
+		FROM inventory i
+		LEFT JOIN inventory_images ii ON i.id = ii.item_id
+		WHERE i.id = $1;`,
+		targetID).Scan(
+		&inventory.ID, &inventory.UserID, &inventory.ItemName, &inventory.Category,
+		&inventory.Description, &inventory.Weight, &inventory.URL, &inventory.Price,
+		&inventory.Currency, &inventory.HasImage, &inventory.PackCount,
+		&inventory.CreatedAt, &inventory.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
 	return &inventory, nil
 }
 

--- a/pkg/inventories/testdata.go
+++ b/pkg/inventories/testdata.go
@@ -295,7 +295,8 @@ func createMergeTestData(ctx context.Context) error {
 		UpdatedAt:   now,
 	}
 	err := database.DB().QueryRowContext(ctx,
-		`INSERT INTO inventory (user_id, item_name, category, description, weight, url, price, currency, created_at, updated_at)
+		`INSERT INTO inventory (user_id, item_name, category, description,
+		weight, url, price, currency, created_at, updated_at)
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) RETURNING id;`,
 		source.UserID, source.ItemName, source.Category, source.Description,
 		source.Weight, source.URL, source.Price, source.Currency, now, now).Scan(&source.ID)
@@ -317,7 +318,8 @@ func createMergeTestData(ctx context.Context) error {
 		UpdatedAt:   now,
 	}
 	err = database.DB().QueryRowContext(ctx,
-		`INSERT INTO inventory (user_id, item_name, category, description, weight, url, price, currency, created_at, updated_at)
+		`INSERT INTO inventory (user_id, item_name, category, description,
+		weight, url, price, currency, created_at, updated_at)
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) RETURNING id;`,
 		target.UserID, target.ItemName, target.Category, target.Description,
 		target.Weight, target.URL, target.Price, target.Currency, now, now).Scan(&target.ID)

--- a/pkg/inventories/testdata.go
+++ b/pkg/inventories/testdata.go
@@ -277,7 +277,7 @@ func cleanupInventoryDataset() error {
 
 // createMergeTestData creates inventory items and pack_content rows for merge testing.
 // It creates a source and target item, a shared pack, and a non-shared pack.
-// Returns (sourceItem, targetItem, sharedPackID, nonSharedPackID).
+// It returns an error if any of the test data creation steps fail.
 func createMergeTestData(ctx context.Context) error {
 	now := time.Now().Truncate(time.Second)
 
@@ -377,16 +377,26 @@ func createMergeTestData(ctx context.Context) error {
 }
 
 // cleanupMergeTestData removes all merge test data
-func cleanupMergeTestData(ctx context.Context) {
+func cleanupMergeTestData(ctx context.Context) error {
 	for _, packID := range mergeTestPackIDs {
-		_, _ = database.DB().ExecContext(ctx, "DELETE FROM pack WHERE id = $1", packID)
+		if _, err := database.DB().ExecContext(ctx,
+			"DELETE FROM pack WHERE id = $1", packID); err != nil {
+			return fmt.Errorf("failed to delete merge test pack %d: %w", packID, err)
+		}
 	}
 	for _, item := range mergeTestItems {
 		if item.ID != 0 {
-			_, _ = database.DB().ExecContext(ctx, "DELETE FROM inventory_images WHERE item_id = $1", item.ID)
-			_, _ = database.DB().ExecContext(ctx, "DELETE FROM inventory WHERE id = $1", item.ID)
+			if _, err := database.DB().ExecContext(ctx,
+				"DELETE FROM inventory_images WHERE item_id = $1", item.ID); err != nil {
+				return fmt.Errorf("failed to delete merge test image for item %d: %w", item.ID, err)
+			}
+			if _, err := database.DB().ExecContext(ctx,
+				"DELETE FROM inventory WHERE id = $1", item.ID); err != nil {
+				return fmt.Errorf("failed to delete merge test item %d: %w", item.ID, err)
+			}
 		}
 	}
 	mergeTestItems = nil
 	mergeTestPackIDs = nil
+	return nil
 }

--- a/pkg/inventories/testdata.go
+++ b/pkg/inventories/testdata.go
@@ -76,6 +76,11 @@ var inventories = Inventories{
 	},
 }
 
+// mergeTestItems holds extra inventory items created specifically for merge tests.
+// These are populated by createMergeTestData and cleaned up by cleanupMergeTestData.
+var mergeTestItems []Inventory
+var mergeTestPackIDs []int
+
 func loadingInventoryDataset() error {
 	// Start a transaction
 	tx, err := database.DB().BeginTx(context.Background(), nil)
@@ -268,4 +273,118 @@ func cleanupInventoryDataset() error {
 
 	println("-> Inventory test data cleaned up...")
 	return nil
+}
+
+// createMergeTestData creates inventory items and pack_content rows for merge testing.
+// It creates a source and target item, a shared pack, and a non-shared pack.
+// Returns (sourceItem, targetItem, sharedPackID, nonSharedPackID).
+func createMergeTestData(ctx context.Context) error {
+	now := time.Now().Truncate(time.Second)
+
+	// Create source item
+	source := Inventory{
+		UserID:      users[0].ID,
+		ItemName:    "Merge Source",
+		Category:    "Test",
+		Description: "Source item for merge test",
+		Weight:      100,
+		URL:         "https://example.com/source",
+		Price:       10,
+		Currency:    "USD",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	err := database.DB().QueryRowContext(ctx,
+		`INSERT INTO inventory (user_id, item_name, category, description, weight, url, price, currency, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) RETURNING id;`,
+		source.UserID, source.ItemName, source.Category, source.Description,
+		source.Weight, source.URL, source.Price, source.Currency, now, now).Scan(&source.ID)
+	if err != nil {
+		return fmt.Errorf("failed to insert merge source item: %w", err)
+	}
+
+	// Create target item
+	target := Inventory{
+		UserID:      users[0].ID,
+		ItemName:    "Merge Target",
+		Category:    "Test",
+		Description: "Target item for merge test",
+		Weight:      200,
+		URL:         "https://example.com/target",
+		Price:       20,
+		Currency:    "USD",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	err = database.DB().QueryRowContext(ctx,
+		`INSERT INTO inventory (user_id, item_name, category, description, weight, url, price, currency, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) RETURNING id;`,
+		target.UserID, target.ItemName, target.Category, target.Description,
+		target.Weight, target.URL, target.Price, target.Currency, now, now).Scan(&target.ID)
+	if err != nil {
+		return fmt.Errorf("failed to insert merge target item: %w", err)
+	}
+
+	mergeTestItems = []Inventory{source, target}
+
+	// Create a shared pack (both items in it)
+	var sharedPackID, nonSharedPackID int
+	err = database.DB().QueryRowContext(ctx,
+		`INSERT INTO pack (user_id, pack_name, pack_description, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5) RETURNING id;`,
+		users[0].ID, "Merge Shared Pack", "Shared pack for merge test", now, now).Scan(&sharedPackID)
+	if err != nil {
+		return fmt.Errorf("failed to insert merge shared pack: %w", err)
+	}
+
+	// Add both source and target to the shared pack with different quantities
+	_, err = database.DB().ExecContext(ctx,
+		`INSERT INTO pack_content (pack_id, item_id, quantity, worn, consumable, created_at, updated_at)
+		VALUES ($1, $2, 2, false, false, $3, $4);`,
+		sharedPackID, source.ID, now, now)
+	if err != nil {
+		return fmt.Errorf("failed to insert source into shared pack: %w", err)
+	}
+	_, err = database.DB().ExecContext(ctx,
+		`INSERT INTO pack_content (pack_id, item_id, quantity, worn, consumable, created_at, updated_at)
+		VALUES ($1, $2, 3, false, false, $3, $4);`,
+		sharedPackID, target.ID, now, now)
+	if err != nil {
+		return fmt.Errorf("failed to insert target into shared pack: %w", err)
+	}
+
+	// Create a non-shared pack (only source in it)
+	err = database.DB().QueryRowContext(ctx,
+		`INSERT INTO pack (user_id, pack_name, pack_description, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5) RETURNING id;`,
+		users[0].ID, "Merge Non-Shared Pack", "Non-shared pack for merge test", now, now).Scan(&nonSharedPackID)
+	if err != nil {
+		return fmt.Errorf("failed to insert merge non-shared pack: %w", err)
+	}
+	_, err = database.DB().ExecContext(ctx,
+		`INSERT INTO pack_content (pack_id, item_id, quantity, worn, consumable, created_at, updated_at)
+		VALUES ($1, $2, 1, false, false, $3, $4);`,
+		nonSharedPackID, source.ID, now, now)
+	if err != nil {
+		return fmt.Errorf("failed to insert source into non-shared pack: %w", err)
+	}
+
+	mergeTestPackIDs = []int{sharedPackID, nonSharedPackID}
+
+	return nil
+}
+
+// cleanupMergeTestData removes all merge test data
+func cleanupMergeTestData(ctx context.Context) {
+	for _, packID := range mergeTestPackIDs {
+		_, _ = database.DB().ExecContext(ctx, "DELETE FROM pack WHERE id = $1", packID)
+	}
+	for _, item := range mergeTestItems {
+		if item.ID != 0 {
+			_, _ = database.DB().ExecContext(ctx, "DELETE FROM inventory_images WHERE item_id = $1", item.ID)
+			_, _ = database.DB().ExecContext(ctx, "DELETE FROM inventory WHERE id = $1", item.ID)
+		}
+	}
+	mergeTestItems = nil
+	mergeTestPackIDs = nil
 }

--- a/pkg/inventories/types.go
+++ b/pkg/inventories/types.go
@@ -62,8 +62,8 @@ type InventoryUpdateRequest struct {
 
 // MergeInventoryRequest represents the input for merging two inventory items
 type MergeInventoryRequest struct {
-	SourceItemID int    `json:"source_item_id" binding:"required"`
-	TargetItemID int    `json:"target_item_id" binding:"required"`
+	SourceItemID uint   `json:"source_item_id" binding:"required"`
+	TargetItemID uint   `json:"target_item_id" binding:"required"`
 	ItemName     string `json:"item_name" binding:"required"`
 	Category     string `json:"category" binding:"required"`
 	Description  string `json:"description"`

--- a/pkg/inventories/types.go
+++ b/pkg/inventories/types.go
@@ -62,8 +62,8 @@ type InventoryUpdateRequest struct {
 
 // MergeInventoryRequest represents the input for merging two inventory items
 type MergeInventoryRequest struct {
-	SourceItemID uint   `json:"source_item_id" binding:"required"`
-	TargetItemID uint   `json:"target_item_id" binding:"required"`
+	SourceItemID uint   `json:"source_item_id" binding:"required,gt=0"`
+	TargetItemID uint   `json:"target_item_id" binding:"required,gt=0"`
 	ItemName     string `json:"item_name" binding:"required"`
 	Category     string `json:"category" binding:"required"`
 	Description  string `json:"description"`

--- a/pkg/inventories/types.go
+++ b/pkg/inventories/types.go
@@ -59,3 +59,17 @@ type InventoryUpdateRequest struct {
 	Price       int    `json:"price"`
 	Currency    string `json:"currency"`
 }
+
+// MergeInventoryRequest represents the input for merging two inventory items
+type MergeInventoryRequest struct {
+	SourceItemID int    `json:"source_item_id" binding:"required"`
+	TargetItemID int    `json:"target_item_id" binding:"required"`
+	ItemName     string `json:"item_name" binding:"required"`
+	Category     string `json:"category" binding:"required"`
+	Description  string `json:"description"`
+	Weight       int    `json:"weight"`
+	URL          string `json:"url"`
+	Price        int    `json:"price"`
+	Currency     string `json:"currency"`
+	ImageSource  string `json:"image_source" binding:"required,oneof=source target none"`
+}


### PR DESCRIPTION
## Summary
- Add `POST /v1/myinventory/merge` endpoint that merges a source inventory item into a target item
- Transactional merge: updates target properties, consolidates pack_content (sums quantities for shared packs), handles image source selection (`source`/`target`/`none`), deletes source item
- Handler validates JWT auth, ownership of both items, and source != target
- Route registered before `/:id` routes to avoid Gin routing conflicts

## Changes
- `pkg/inventories/types.go` — `MergeInventoryRequest` struct with binding validation
- `pkg/inventories/repository.go` — `mergeInventoryItems()` transactional function (7-step merge)
- `pkg/inventories/handlers.go` — `PostMyInventoryMerge` handler with swagger docs
- `main.go` — route registration
- `pkg/inventories/testdata.go` — merge test data helpers
- `pkg/inventories/inventories_test.go` — 8 test cases (shared/non-shared packs, image variations, error cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)