### PR TITLE
Fix EXIF orientation for iPhone photo uploads

### DIFF
--- a/pkg/images/orientation.go
+++ b/pkg/images/orientation.go
@@ -48,13 +48,22 @@ func readEXIFOrientation(data []byte) int {
 			return 1
 		}
 
-		// APP1 marker (0xE1) — EXIF data
+		segEnd := offset + 2 + segLen
+		if segEnd > len(data) {
+			return 1
+		}
+
+		// APP1 marker (0xE1) — possible EXIF data
 		if marker == 0xE1 {
-			return parseEXIFOrientation(data[offset+4 : offset+2+segLen])
+			segmentBody := data[offset+4 : segEnd]
+			// Only treat as EXIF if it has the standard header; skip XMP or other APP1 segments
+			if len(segmentBody) >= 6 && string(segmentBody[0:6]) == "Exif\x00\x00" {
+				return parseEXIFOrientation(segmentBody)
+			}
 		}
 
 		// Skip to next marker
-		offset += 2 + segLen
+		offset = segEnd
 	}
 
 	return 1

--- a/pkg/images/orientation.go
+++ b/pkg/images/orientation.go
@@ -10,63 +10,58 @@ import (
 // Returns 1-8 for valid orientations, defaults to 1 (normal) on any error,
 // non-JPEG input, or missing EXIF data.
 func readEXIFOrientation(data []byte) int {
-	// Need at least enough bytes for JPEG SOI + APP1 marker
-	if len(data) < 14 {
+	exifBody := findEXIFSegment(data)
+	if exifBody == nil {
 		return 1
 	}
+	return parseEXIFOrientation(exifBody)
+}
 
-	// Verify JPEG SOI marker
-	if data[0] != 0xFF || data[1] != 0xD8 {
-		return 1
+// findEXIFSegment walks JPEG markers and returns the body of the first EXIF APP1 segment.
+// Returns nil if not found or if the data is not a valid JPEG.
+func findEXIFSegment(data []byte) []byte {
+	// Need at least JPEG SOI + one marker header
+	if len(data) < 14 || data[0] != 0xFF || data[1] != 0xD8 {
+		return nil
 	}
 
-	// Walk through JPEG markers to find APP1 (EXIF)
 	offset := 2
 	for offset+4 <= len(data) {
 		if data[offset] != 0xFF {
-			return 1
+			return nil
 		}
 
 		marker := data[offset+1]
-		// Skip padding bytes
 		if marker == 0xFF {
 			offset++
 			continue
 		}
-
 		// SOS marker — no more metadata segments
 		if marker == 0xDA {
-			return 1
+			return nil
 		}
 
-		// Read segment length
-		if offset+4 > len(data) {
-			return 1
-		}
 		segLen := int(binary.BigEndian.Uint16(data[offset+2 : offset+4]))
 		if segLen < 2 {
-			return 1
+			return nil
 		}
 
 		segEnd := offset + 2 + segLen
 		if segEnd > len(data) {
-			return 1
+			return nil
 		}
 
-		// APP1 marker (0xE1) — possible EXIF data
 		if marker == 0xE1 {
-			segmentBody := data[offset+4 : segEnd]
-			// Only treat as EXIF if it has the standard header; skip XMP or other APP1 segments
-			if len(segmentBody) >= 6 && string(segmentBody[0:6]) == "Exif\x00\x00" {
-				return parseEXIFOrientation(segmentBody)
+			body := data[offset+4 : segEnd]
+			if len(body) >= 6 && string(body[0:6]) == "Exif\x00\x00" {
+				return body
 			}
 		}
 
-		// Skip to next marker
 		offset = segEnd
 	}
 
-	return 1
+	return nil
 }
 
 // parseEXIFOrientation extracts the orientation value from an APP1 EXIF segment body.
@@ -158,26 +153,33 @@ func applyOrientation(img image.Image, orientation int) image.Image {
 	for y := 0; y < h; y++ {
 		for x := 0; x < w; x++ {
 			c := img.At(bounds.Min.X+x, bounds.Min.Y+y)
-			var dx, dy int
-			switch orientation {
-			case 2: // Flip horizontal
-				dx, dy = w-1-x, y
-			case 3: // Rotate 180
-				dx, dy = w-1-x, h-1-y
-			case 4: // Flip vertical
-				dx, dy = x, h-1-y
-			case 5: // Transpose
-				dx, dy = y, x
-			case 6: // Rotate 90 CW
-				dx, dy = h-1-y, x
-			case 7: // Transverse
-				dx, dy = h-1-y, w-1-x
-			case 8: // Rotate 270 CW
-				dx, dy = y, w-1-x
-			}
+			dx, dy := mapOrientation(orientation, x, y, w, h)
 			dst.Set(dx, dy, color.NRGBAModel.Convert(c))
 		}
 	}
 
 	return dst
+}
+
+// mapOrientation returns the destination coordinates for a pixel at (x, y)
+// given the EXIF orientation value and image dimensions w×h.
+func mapOrientation(orientation, x, y, w, h int) (int, int) {
+	switch orientation {
+	case 2: // Flip horizontal
+		return w - 1 - x, y
+	case 3: // Rotate 180
+		return w - 1 - x, h - 1 - y
+	case 4: // Flip vertical
+		return x, h - 1 - y
+	case 5: // Transpose
+		return y, x
+	case 6: // Rotate 90 CW
+		return h - 1 - y, x
+	case 7: // Transverse
+		return h - 1 - y, w - 1 - x
+	case 8: // Rotate 270 CW
+		return y, w - 1 - x
+	default:
+		return x, y
+	}
 }

--- a/pkg/images/orientation.go
+++ b/pkg/images/orientation.go
@@ -1,0 +1,174 @@
+package images
+
+import (
+	"encoding/binary"
+	"image"
+	"image/color"
+)
+
+// readEXIFOrientation parses JPEG EXIF data to extract the orientation tag.
+// Returns 1-8 for valid orientations, defaults to 1 (normal) on any error,
+// non-JPEG input, or missing EXIF data.
+func readEXIFOrientation(data []byte) int {
+	// Need at least enough bytes for JPEG SOI + APP1 marker
+	if len(data) < 14 {
+		return 1
+	}
+
+	// Verify JPEG SOI marker
+	if data[0] != 0xFF || data[1] != 0xD8 {
+		return 1
+	}
+
+	// Walk through JPEG markers to find APP1 (EXIF)
+	offset := 2
+	for offset+4 <= len(data) {
+		if data[offset] != 0xFF {
+			return 1
+		}
+
+		marker := data[offset+1]
+		// Skip padding bytes
+		if marker == 0xFF {
+			offset++
+			continue
+		}
+
+		// SOS marker — no more metadata segments
+		if marker == 0xDA {
+			return 1
+		}
+
+		// Read segment length
+		if offset+4 > len(data) {
+			return 1
+		}
+		segLen := int(binary.BigEndian.Uint16(data[offset+2 : offset+4]))
+		if segLen < 2 {
+			return 1
+		}
+
+		// APP1 marker (0xE1) — EXIF data
+		if marker == 0xE1 {
+			return parseEXIFOrientation(data[offset+4 : offset+2+segLen])
+		}
+
+		// Skip to next marker
+		offset += 2 + segLen
+	}
+
+	return 1
+}
+
+// parseEXIFOrientation extracts the orientation value from an APP1 EXIF segment body.
+func parseEXIFOrientation(exif []byte) int {
+	// Verify "Exif\0\0" header
+	if len(exif) < 14 || string(exif[0:6]) != "Exif\x00\x00" {
+		return 1
+	}
+
+	tiff := exif[6:]
+
+	// Determine byte order
+	var bo binary.ByteOrder
+	switch string(tiff[0:2]) {
+	case "II":
+		bo = binary.LittleEndian
+	case "MM":
+		bo = binary.BigEndian
+	default:
+		return 1
+	}
+
+	// Verify TIFF magic number (42)
+	if bo.Uint16(tiff[2:4]) != 0x002A {
+		return 1
+	}
+
+	// Get offset to IFD0
+	ifdOffset := int(bo.Uint32(tiff[4:8]))
+	if ifdOffset+2 > len(tiff) {
+		return 1
+	}
+
+	// Read number of IFD entries
+	numEntries := int(bo.Uint16(tiff[ifdOffset : ifdOffset+2]))
+	entryStart := ifdOffset + 2
+
+	// Walk IFD0 entries looking for orientation tag (0x0112)
+	for i := 0; i < numEntries; i++ {
+		entryOffset := entryStart + i*12
+		if entryOffset+12 > len(tiff) {
+			return 1
+		}
+
+		tag := bo.Uint16(tiff[entryOffset : entryOffset+2])
+		if tag == 0x0112 {
+			// Orientation tag found — value is a SHORT (uint16)
+			val := int(bo.Uint16(tiff[entryOffset+8 : entryOffset+10]))
+			if val >= 1 && val <= 8 {
+				return val
+			}
+			return 1
+		}
+	}
+
+	return 1
+}
+
+// applyOrientation transforms an image according to the EXIF orientation value.
+// Returns the original image unchanged for orientation 1 (normal) or invalid values.
+//
+// EXIF orientation values:
+//
+//	1 = Normal (no transform)
+//	2 = Flip horizontal
+//	3 = Rotate 180°
+//	4 = Flip vertical
+//	5 = Transpose (flip horizontal + rotate 270° CW)
+//	6 = Rotate 90° CW
+//	7 = Transverse (flip horizontal + rotate 90° CW)
+//	8 = Rotate 270° CW
+func applyOrientation(img image.Image, orientation int) image.Image {
+	if orientation <= 1 || orientation > 8 {
+		return img
+	}
+
+	bounds := img.Bounds()
+	w := bounds.Dx()
+	h := bounds.Dy()
+
+	// For orientations 5-8, width and height are swapped
+	var dst *image.NRGBA
+	if orientation >= 5 {
+		dst = image.NewNRGBA(image.Rect(0, 0, h, w))
+	} else {
+		dst = image.NewNRGBA(image.Rect(0, 0, w, h))
+	}
+
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			c := img.At(bounds.Min.X+x, bounds.Min.Y+y)
+			var dx, dy int
+			switch orientation {
+			case 2: // Flip horizontal
+				dx, dy = w-1-x, y
+			case 3: // Rotate 180
+				dx, dy = w-1-x, h-1-y
+			case 4: // Flip vertical
+				dx, dy = x, h-1-y
+			case 5: // Transpose
+				dx, dy = y, x
+			case 6: // Rotate 90 CW
+				dx, dy = h-1-y, x
+			case 7: // Transverse
+				dx, dy = h-1-y, w-1-x
+			case 8: // Rotate 270 CW
+				dx, dy = y, w-1-x
+			}
+			dst.Set(dx, dy, color.NRGBAModel.Convert(c))
+		}
+	}
+
+	return dst
+}

--- a/pkg/images/orientation_test.go
+++ b/pkg/images/orientation_test.go
@@ -1,0 +1,401 @@
+package images
+
+import (
+	"bytes"
+	"encoding/binary"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"testing"
+)
+
+// buildEXIFJPEG creates a JPEG with an EXIF APP1 segment containing the given orientation tag.
+// The image is created with dimensions w×h (raw pixel dimensions before EXIF transform).
+func buildEXIFJPEG(t *testing.T, w, h, orientation int, bigEndian bool) []byte {
+	t.Helper()
+
+	// Create a test image with an asymmetric color pattern for verification
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{
+				R: uint8((x * 255) / max(w-1, 1)),
+				G: uint8((y * 255) / max(h-1, 1)),
+				B: 128,
+				A: 255,
+			})
+		}
+	}
+
+	// Encode to JPEG
+	var jpegBuf bytes.Buffer
+	if err := jpeg.Encode(&jpegBuf, img, &jpeg.Options{Quality: 95}); err != nil {
+		t.Fatalf("failed to encode JPEG: %v", err)
+	}
+	jpegData := jpegBuf.Bytes()
+
+	// Build EXIF APP1 segment with orientation tag
+	exifSegment := buildEXIFSegment(orientation, bigEndian)
+
+	// Insert APP1 segment right after SOI marker (first 2 bytes)
+	var result bytes.Buffer
+	result.Write(jpegData[:2]) // SOI: FF D8
+	result.Write(exifSegment)
+	result.Write(jpegData[2:]) // Rest of JPEG
+
+	return result.Bytes()
+}
+
+// buildEXIFSegment creates a minimal EXIF APP1 segment with just the orientation tag.
+func buildEXIFSegment(orientation int, bigEndian bool) []byte {
+	var buf bytes.Buffer
+
+	var bo binary.ByteOrder
+	var boMarker []byte
+	if bigEndian {
+		bo = binary.BigEndian
+		boMarker = []byte("MM")
+	} else {
+		bo = binary.LittleEndian
+		boMarker = []byte("II")
+	}
+
+	// Build TIFF data
+	var tiff bytes.Buffer
+
+	// Byte order marker
+	tiff.Write(boMarker)
+
+	// TIFF magic number (42)
+	magic := make([]byte, 2)
+	bo.PutUint16(magic, 0x002A)
+	tiff.Write(magic)
+
+	// Offset to IFD0 (immediately after header = 8)
+	ifdOffset := make([]byte, 4)
+	bo.PutUint32(ifdOffset, 8)
+	tiff.Write(ifdOffset)
+
+	// IFD0: 1 entry
+	numEntries := make([]byte, 2)
+	bo.PutUint16(numEntries, 1)
+	tiff.Write(numEntries)
+
+	// IFD entry: orientation tag (0x0112), type SHORT (3), count 1, value
+	tag := make([]byte, 2)
+	bo.PutUint16(tag, 0x0112)
+	tiff.Write(tag)
+
+	typ := make([]byte, 2)
+	bo.PutUint16(typ, 3) // SHORT
+	tiff.Write(typ)
+
+	count := make([]byte, 4)
+	bo.PutUint32(count, 1)
+	tiff.Write(count)
+
+	// Value (4 bytes, value in first 2)
+	val := make([]byte, 4)
+	bo.PutUint16(val, uint16(orientation))
+	tiff.Write(val)
+
+	// Next IFD offset (0 = no more IFDs)
+	nextIFD := make([]byte, 4)
+	tiff.Write(nextIFD)
+
+	// Build APP1 segment
+	exifHeader := []byte("Exif\x00\x00")
+	segBody := append(exifHeader, tiff.Bytes()...)
+	segLen := len(segBody) + 2 // +2 for the length field itself
+
+	// APP1 marker + length + body
+	buf.Write([]byte{0xFF, 0xE1})
+	lenBytes := make([]byte, 2)
+	binary.BigEndian.PutUint16(lenBytes, uint16(segLen))
+	buf.Write(lenBytes)
+	buf.Write(segBody)
+
+	return buf.Bytes()
+}
+
+func TestReadEXIFOrientation(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		expected int
+	}{
+		{
+			name:     "JPEG with orientation 6 (little-endian)",
+			data:     buildEXIFJPEG(t, 100, 80, 6, false),
+			expected: 6,
+		},
+		{
+			name:     "JPEG with orientation 6 (big-endian)",
+			data:     buildEXIFJPEG(t, 100, 80, 6, true),
+			expected: 6,
+		},
+		{
+			name:     "JPEG with orientation 1",
+			data:     buildEXIFJPEG(t, 100, 80, 1, false),
+			expected: 1,
+		},
+		{
+			name:     "JPEG with orientation 3",
+			data:     buildEXIFJPEG(t, 100, 80, 3, false),
+			expected: 3,
+		},
+		{
+			name:     "JPEG with orientation 8",
+			data:     buildEXIFJPEG(t, 100, 80, 8, true),
+			expected: 8,
+		},
+		{
+			name:     "JPEG without EXIF (plain JPEG)",
+			data:     createTestJPEG(100, 80),
+			expected: 1,
+		},
+		{
+			name:     "PNG data",
+			data:     createTestPNG(100, 80),
+			expected: 1,
+		},
+		{
+			name:     "Empty data",
+			data:     []byte{},
+			expected: 1,
+		},
+		{
+			name:     "Short data",
+			data:     []byte{0xFF, 0xD8},
+			expected: 1,
+		},
+		{
+			name:     "Not an image",
+			data:     []byte("hello world this is not an image"),
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := readEXIFOrientation(tt.data)
+			if got != tt.expected {
+				t.Errorf("readEXIFOrientation() = %d, want %d", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestApplyOrientation(t *testing.T) {
+	// Create a 4x2 test image with known pixel colors:
+	//   (0,0)=Red    (1,0)=Green  (2,0)=Blue   (3,0)=White
+	//   (0,1)=Yellow (1,1)=Cyan   (2,1)=Magenta (3,1)=Black
+	img := image.NewNRGBA(image.Rect(0, 0, 4, 2))
+	pixels := []struct {
+		x, y int
+		c    color.NRGBA
+	}{
+		{0, 0, color.NRGBA{255, 0, 0, 255}},     // Red
+		{1, 0, color.NRGBA{0, 255, 0, 255}},     // Green
+		{2, 0, color.NRGBA{0, 0, 255, 255}},     // Blue
+		{3, 0, color.NRGBA{255, 255, 255, 255}}, // White
+		{0, 1, color.NRGBA{255, 255, 0, 255}},   // Yellow
+		{1, 1, color.NRGBA{0, 255, 255, 255}},   // Cyan
+		{2, 1, color.NRGBA{255, 0, 255, 255}},   // Magenta
+		{3, 1, color.NRGBA{0, 0, 0, 255}},       // Black
+	}
+	for _, p := range pixels {
+		img.SetNRGBA(p.x, p.y, p.c)
+	}
+
+	red := color.NRGBA{255, 0, 0, 255}
+	green := color.NRGBA{0, 255, 0, 255}
+	blue := color.NRGBA{0, 0, 255, 255}
+	white := color.NRGBA{255, 255, 255, 255}
+	yellow := color.NRGBA{255, 255, 0, 255}
+	cyan := color.NRGBA{0, 255, 255, 255}
+	magenta := color.NRGBA{255, 0, 255, 255}
+	black := color.NRGBA{0, 0, 0, 255}
+
+	tests := []struct {
+		name        string
+		orientation int
+		wantW       int
+		wantH       int
+		// Check a few key pixel positions
+		checks []struct {
+			x, y int
+			c    color.NRGBA
+		}
+	}{
+		{
+			name:        "Orientation 1 (normal)",
+			orientation: 1,
+			wantW:       4,
+			wantH:       2,
+			checks: []struct {
+				x, y int
+				c    color.NRGBA
+			}{
+				{0, 0, red}, {3, 0, white}, {0, 1, yellow}, {3, 1, black},
+			},
+		},
+		{
+			name:        "Orientation 2 (flip horizontal)",
+			orientation: 2,
+			wantW:       4,
+			wantH:       2,
+			checks: []struct {
+				x, y int
+				c    color.NRGBA
+			}{
+				{0, 0, white}, {3, 0, red}, {0, 1, black}, {3, 1, yellow},
+			},
+		},
+		{
+			name:        "Orientation 3 (rotate 180)",
+			orientation: 3,
+			wantW:       4,
+			wantH:       2,
+			checks: []struct {
+				x, y int
+				c    color.NRGBA
+			}{
+				{0, 0, black}, {3, 0, yellow}, {0, 1, white}, {3, 1, red},
+			},
+		},
+		{
+			name:        "Orientation 4 (flip vertical)",
+			orientation: 4,
+			wantW:       4,
+			wantH:       2,
+			checks: []struct {
+				x, y int
+				c    color.NRGBA
+			}{
+				{0, 0, yellow}, {3, 0, black}, {0, 1, red}, {3, 1, white},
+			},
+		},
+		{
+			name:        "Orientation 5 (transpose)",
+			orientation: 5,
+			wantW:       2,
+			wantH:       4,
+			checks: []struct {
+				x, y int
+				c    color.NRGBA
+			}{
+				{0, 0, red}, {1, 0, yellow}, {0, 3, white}, {1, 3, black},
+			},
+		},
+		{
+			name:        "Orientation 6 (rotate 90 CW)",
+			orientation: 6,
+			wantW:       2,
+			wantH:       4,
+			checks: []struct {
+				x, y int
+				c    color.NRGBA
+			}{
+				{0, 0, yellow}, {1, 0, red}, {0, 3, black}, {1, 3, white},
+			},
+		},
+		{
+			name:        "Orientation 7 (transverse)",
+			orientation: 7,
+			wantW:       2,
+			wantH:       4,
+			checks: []struct {
+				x, y int
+				c    color.NRGBA
+			}{
+				{0, 0, black}, {1, 0, white}, {0, 3, yellow}, {1, 3, red},
+			},
+		},
+		{
+			name:        "Orientation 8 (rotate 270 CW)",
+			orientation: 8,
+			wantW:       2,
+			wantH:       4,
+			checks: []struct {
+				x, y int
+				c    color.NRGBA
+			}{
+				{0, 0, white}, {1, 0, black}, {0, 3, red}, {1, 3, yellow},
+			},
+		},
+	}
+
+	_ = green
+	_ = blue
+	_ = cyan
+	_ = magenta
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := applyOrientation(img, tt.orientation)
+			bounds := result.Bounds()
+
+			if bounds.Dx() != tt.wantW || bounds.Dy() != tt.wantH {
+				t.Errorf("dimensions = %dx%d, want %dx%d", bounds.Dx(), bounds.Dy(), tt.wantW, tt.wantH)
+			}
+
+			for _, check := range tt.checks {
+				got := color.NRGBAModel.Convert(result.At(check.x, check.y)).(color.NRGBA)
+				if got != check.c {
+					t.Errorf("pixel(%d,%d) = %v, want %v", check.x, check.y, got, check.c)
+				}
+			}
+		})
+	}
+}
+
+// TestProcessImage_EXIFOrientation6 verifies the full pipeline correctly rotates
+// a JPEG with EXIF orientation 6 (iPhone portrait).
+func TestProcessImage_EXIFOrientation6(t *testing.T) {
+	// Create a 200x300 JPEG (landscape pixels) with orientation 6
+	// After EXIF correction, it should become 300x200 (portrait → rotated to landscape dims swapped)
+	// Actually: 200w x 300h pixels stored, orientation 6 = rotate 90 CW → output should be 300w x 200h
+	data := buildEXIFJPEG(t, 200, 300, 6, false)
+
+	result, err := ProcessImage(data)
+	if err != nil {
+		t.Fatalf("ProcessImage() error: %v", err)
+	}
+
+	// After rotating 90° CW, a 200×300 image becomes 300×200
+	if result.Metadata.Width != 300 || result.Metadata.Height != 200 {
+		t.Errorf("dimensions = %dx%d, want 300x200", result.Metadata.Width, result.Metadata.Height)
+	}
+}
+
+// TestProcessImage_NoEXIF verifies that images without EXIF data are processed unchanged.
+func TestProcessImage_NoEXIF(t *testing.T) {
+	data := createTestJPEG(200, 300)
+
+	result, err := ProcessImage(data)
+	if err != nil {
+		t.Fatalf("ProcessImage() error: %v", err)
+	}
+
+	if result.Metadata.Width != 200 || result.Metadata.Height != 300 {
+		t.Errorf("dimensions = %dx%d, want 200x300", result.Metadata.Width, result.Metadata.Height)
+	}
+}
+
+// TestProcessInventoryItemImage_EXIFOrientation6 verifies inventory item processing
+// correctly handles EXIF orientation.
+func TestProcessInventoryItemImage_EXIFOrientation6(t *testing.T) {
+	// 300x400 pixels with orientation 6 → after rotation: 400x300
+	data := buildEXIFJPEG(t, 300, 400, 6, false)
+
+	result, err := ProcessInventoryItemImage(data)
+	if err != nil {
+		t.Fatalf("ProcessInventoryItemImage() error: %v", err)
+	}
+
+	// After rotation: 400×300, then resize to fit 400px max → already fits
+	if result.Metadata.Width != 400 || result.Metadata.Height != 300 {
+		t.Errorf("dimensions = %dx%d, want 400x300", result.Metadata.Width, result.Metadata.Height)
+	}
+}

--- a/pkg/images/orientation_test.go
+++ b/pkg/images/orientation_test.go
@@ -119,6 +119,33 @@ func buildEXIFSegment(orientation int, bigEndian bool) []byte {
 	return buf.Bytes()
 }
 
+// buildXMPThenEXIFJPEG creates a JPEG with a non-EXIF APP1 segment (XMP) followed
+// by a real EXIF APP1 segment with the given orientation. This tests that the parser
+// correctly skips non-EXIF APP1 segments.
+func buildXMPThenEXIFJPEG(t *testing.T, w, h, orientation int) []byte {
+	t.Helper()
+
+	base := buildEXIFJPEG(t, w, h, orientation, false)
+
+	// Build a fake XMP APP1 segment (starts with "http://ns.adobe.com/xap/", not "Exif\0\0")
+	xmpBody := []byte("http://ns.adobe.com/xap/1.0/\x00<x:xmpmeta/>")
+	xmpSegLen := len(xmpBody) + 2
+	var xmpSeg bytes.Buffer
+	xmpSeg.Write([]byte{0xFF, 0xE1})
+	lenBytes := make([]byte, 2)
+	binary.BigEndian.PutUint16(lenBytes, uint16(xmpSegLen))
+	xmpSeg.Write(lenBytes)
+	xmpSeg.Write(xmpBody)
+
+	// Insert XMP segment after SOI, before the existing EXIF APP1
+	var result bytes.Buffer
+	result.Write(base[:2]) // SOI
+	result.Write(xmpSeg.Bytes())
+	result.Write(base[2:]) // EXIF APP1 + rest of JPEG
+
+	return result.Bytes()
+}
+
 func TestReadEXIFOrientation(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -175,6 +202,11 @@ func TestReadEXIFOrientation(t *testing.T) {
 			data:     []byte("hello world this is not an image"),
 			expected: 1,
 		},
+		{
+			name:     "XMP APP1 before EXIF APP1",
+			data:     buildXMPThenEXIFJPEG(t, 100, 80, 6),
+			expected: 6,
+		},
 	}
 
 	for _, tt := range tests {
@@ -210,12 +242,8 @@ func TestApplyOrientation(t *testing.T) {
 	}
 
 	red := color.NRGBA{255, 0, 0, 255}
-	green := color.NRGBA{0, 255, 0, 255}
-	blue := color.NRGBA{0, 0, 255, 255}
 	white := color.NRGBA{255, 255, 255, 255}
 	yellow := color.NRGBA{255, 255, 0, 255}
-	cyan := color.NRGBA{0, 255, 255, 255}
-	magenta := color.NRGBA{255, 0, 255, 255}
 	black := color.NRGBA{0, 0, 0, 255}
 
 	tests := []struct {
@@ -327,11 +355,6 @@ func TestApplyOrientation(t *testing.T) {
 		},
 	}
 
-	_ = green
-	_ = blue
-	_ = cyan
-	_ = magenta
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := applyOrientation(img, tt.orientation)
@@ -358,9 +381,8 @@ func TestApplyOrientation(t *testing.T) {
 // TestProcessImage_EXIFOrientation6 verifies the full pipeline correctly rotates
 // a JPEG with EXIF orientation 6 (iPhone portrait).
 func TestProcessImage_EXIFOrientation6(t *testing.T) {
-	// Create a 200x300 JPEG (landscape pixels) with orientation 6
-	// After EXIF correction, it should become 300x200 (portrait → rotated to landscape dims swapped)
-	// Actually: 200w x 300h pixels stored, orientation 6 = rotate 90 CW → output should be 300w x 200h
+	// Stored pixels: 200w × 300h, tagged with EXIF orientation 6 (rotate 90° CW).
+	// After applying the EXIF orientation, the output image should be 300w × 200h.
 	data := buildEXIFJPEG(t, 200, 300, 6, false)
 
 	result, err := ProcessImage(data)

--- a/pkg/images/orientation_test.go
+++ b/pkg/images/orientation_test.go
@@ -105,7 +105,8 @@ func buildEXIFSegment(orientation int, bigEndian bool) []byte {
 
 	// Build APP1 segment
 	exifHeader := []byte("Exif\x00\x00")
-	segBody := append(exifHeader, tiff.Bytes()...)
+	exifHeader = append(exifHeader, tiff.Bytes()...)
+	segBody := exifHeader
 	segLen := len(segBody) + 2 // +2 for the length field itself
 
 	// APP1 marker + length + body
@@ -341,7 +342,11 @@ func TestApplyOrientation(t *testing.T) {
 			}
 
 			for _, check := range tt.checks {
-				got := color.NRGBAModel.Convert(result.At(check.x, check.y)).(color.NRGBA)
+				converted := color.NRGBAModel.Convert(result.At(check.x, check.y))
+				got, ok := converted.(color.NRGBA)
+				if !ok {
+					t.Fatalf("pixel(%d,%d) failed color conversion", check.x, check.y)
+				}
 				if got != check.c {
 					t.Errorf("pixel(%d,%d) = %v, want %v", check.x, check.y, got, check.c)
 				}

--- a/pkg/images/processor.go
+++ b/pkg/images/processor.go
@@ -75,6 +75,9 @@ func DecodeImage(data []byte) (image.Image, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrCorrupted, err)
 	}
+	// Apply EXIF orientation correction (no-op for non-JPEG or orientation=1)
+	orientation := readEXIFOrientation(data)
+	img = applyOrientation(img, orientation)
 	return img, nil
 }
 


### PR DESCRIPTION
## Summary
- iPhone photos taken in portrait appear rotated to landscape because Go's `image.Decode()` ignores EXIF orientation metadata
- Added EXIF orientation parsing (`readEXIFOrientation`) and pixel-level transform (`applyOrientation`) in `pkg/images/orientation.go`
- Integrated into `DecodeImage()` so all 4 image processing pipelines (pack, profile, inventory, banner) are fixed in one place
- Rotation applied before resize for correct dimension handling
- Comprehensive unit tests covering all 8 EXIF orientations, both endianness, and edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)