### PR TITLE
feat: add duplicate pack endpoint

### DIFF
--- a/api-doc/docs.go
+++ b/api-doc/docs.go
@@ -1879,6 +1879,70 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/mypack/{id}/duplicate": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Clone an existing pack (metadata + all pack contents) into a new pack\nowned by the same user. The new pack's name is prefixed with \"COPY - \",\nis_favorite is reset to false and sharing_code is not copied. The pack\nimage is intentionally not copied.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packs"
+                ],
+                "summary": "Duplicate a pack by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Pack ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Pack duplicated successfully",
+                        "schema": {
+                            "$ref": "#/definitions/packs.Pack"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID format",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "This pack does not belong to you",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Pack not found",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/mypack/{id}/favorite": {
             "post": {
                 "security": [

--- a/api-doc/swagger.json
+++ b/api-doc/swagger.json
@@ -1876,6 +1876,70 @@
                 }
             }
         },
+        "/v1/mypack/{id}/duplicate": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Clone an existing pack (metadata + all pack contents) into a new pack\nowned by the same user. The new pack's name is prefixed with \"COPY - \",\nis_favorite is reset to false and sharing_code is not copied. The pack\nimage is intentionally not copied.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packs"
+                ],
+                "summary": "Duplicate a pack by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Pack ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Pack duplicated successfully",
+                        "schema": {
+                            "$ref": "#/definitions/packs.Pack"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID format",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "This pack does not belong to you",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Pack not found",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/mypack/{id}/favorite": {
             "post": {
                 "security": [

--- a/api-doc/swagger.yaml
+++ b/api-doc/swagger.yaml
@@ -1761,6 +1761,51 @@ paths:
       summary: Update a pack by ID
       tags:
       - Packs
+  /v1/mypack/{id}/duplicate:
+    post:
+      description: |-
+        Clone an existing pack (metadata + all pack contents) into a new pack
+        owned by the same user. The new pack's name is prefixed with "COPY - ",
+        is_favorite is reset to false and sharing_code is not copied. The pack
+        image is intentionally not copied.
+      parameters:
+      - description: Pack ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Pack duplicated successfully
+          schema:
+            $ref: '#/definitions/packs.Pack'
+        "400":
+          description: Invalid ID format
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "403":
+          description: This pack does not belong to you
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "404":
+          description: Pack not found
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+      security:
+      - Bearer: []
+      summary: Duplicate a pack by ID
+      tags:
+      - Packs
   /v1/mypack/{id}/favorite:
     delete:
       description: Remove favorite status from a pack (idempotent)

--- a/main.go
+++ b/main.go
@@ -154,6 +154,7 @@ func setupProtectedRoutes(router *gin.Engine) {
 	protected.DELETE("/mypack/:id/share", packs.UnshareMyPack)
 	protected.POST("/mypack/:id/favorite", packs.FavoriteMyPack)
 	protected.DELETE("/mypack/:id/favorite", packs.UnfavoriteMyPack)
+	protected.POST("/mypack/:id/duplicate", packs.DuplicateMyPack)
 	protected.GET("/mypack/:id/packcontents", packs.GetMyPackContentsByPackID)
 	protected.POST("/mypack/:id/packcontent", packs.PostMyPackContent)
 	protected.PUT("/mypack/:id/packcontent/:item_id", packs.PutMyPackContentByID)

--- a/pkg/packs/handlers.go
+++ b/pkg/packs/handlers.go
@@ -1157,6 +1157,69 @@ func UnfavoriteMyPack(c *gin.Context) {
 	packAction(c, "unfavorite", unfavoritePackByID, "Pack unfavorited successfully")
 }
 
+// Duplicate a pack by ID
+// @Summary Duplicate a pack by ID
+// @Description Clone an existing pack (metadata + all pack contents) into a new pack
+// @Description owned by the same user. The new pack's name is prefixed with "COPY - ",
+// @Description is_favorite is reset to false and sharing_code is not copied. The pack
+// @Description image is intentionally not copied.
+// @Security Bearer
+// @Tags Packs
+// @Produce  json
+// @Param id path int true "Pack ID"
+// @Success 201 {object} Pack "Pack duplicated successfully"
+// @Failure 400 {object} apitypes.ErrorResponse "Invalid ID format"
+// @Failure 401 {object} apitypes.ErrorResponse "Unauthorized"
+// @Failure 403 {object} apitypes.ErrorResponse "This pack does not belong to you"
+// @Failure 404 {object} apitypes.ErrorResponse "Pack not found"
+// @Failure 500 {object} apitypes.ErrorResponse "Internal Server Error"
+// @Router /v1/mypack/{id}/duplicate [post]
+func DuplicateMyPack(c *gin.Context) {
+	id, err := helper.StringToUint(c.Param("id"))
+	if err != nil {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"error": "Invalid ID format"})
+		return
+	}
+
+	userID, err := security.ExtractTokenID(c)
+	if err != nil {
+		helper.LogAndSanitize(err, "duplicate my pack: extract token ID failed")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": helper.ErrMsgUnauthorized})
+		return
+	}
+
+	_, err = FindPackByID(c.Request.Context(), id)
+	if err != nil {
+		if errors.Is(err, ErrPackNotFound) {
+			c.IndentedJSON(http.StatusNotFound, gin.H{"error": "Pack not found"})
+			return
+		}
+		helper.LogAndSanitize(err, "duplicate my pack: find pack failed")
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	newPackID, err := duplicatePackByID(c.Request.Context(), id, userID)
+	if err != nil {
+		if errors.Is(err, ErrPackNotOwned) {
+			c.IndentedJSON(http.StatusForbidden, gin.H{"error": "This pack does not belong to you"})
+			return
+		}
+		helper.LogAndSanitize(err, "duplicate my pack: duplicate pack failed")
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	newPack, err := FindPackByID(c.Request.Context(), newPackID)
+	if err != nil {
+		helper.LogAndSanitize(err, "duplicate my pack: re-read new pack failed")
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	c.IndentedJSON(http.StatusCreated, newPack)
+}
+
 // packAction is a shared helper for pack operations that follow the same pattern:
 // parse ID, extract token, check pack exists, call action, handle ownership error.
 func packAction(c *gin.Context, actionName string,

--- a/pkg/packs/packs_test.go
+++ b/pkg/packs/packs_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/Angak0k/pimpmypack/pkg/config"
 	"github.com/Angak0k/pimpmypack/pkg/database"
@@ -1809,6 +1810,208 @@ func TestUnfavoriteMyPack(t *testing.T) {
 	})
 	t.Run("Pack not found", func(t *testing.T) {
 		testUnfavoriteNotFound(t, router, token)
+	})
+}
+
+type duplicateContentRow struct {
+	itemID     uint
+	quantity   int
+	worn       bool
+	consumable bool
+}
+
+func loadPackContentRows(t *testing.T, packID uint) []duplicateContentRow {
+	t.Helper()
+	rows, err := database.DB().Query(
+		`SELECT item_id, quantity, worn, consumable
+		 FROM pack_content WHERE pack_id = $1 ORDER BY item_id`, packID)
+	if err != nil {
+		t.Fatalf("Failed to query pack_content for pack %d: %v", packID, err)
+	}
+	defer rows.Close()
+	var out []duplicateContentRow
+	for rows.Next() {
+		var r duplicateContentRow
+		if err := rows.Scan(&r.itemID, &r.quantity, &r.worn, &r.consumable); err != nil {
+			t.Fatalf("Failed to scan pack_content row: %v", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("pack_content rows error: %v", err)
+	}
+	return out
+}
+
+func testDuplicateSuccess(t *testing.T, router *gin.Engine, token string) {
+	sourceID := FindPackIDByPackName(packs, "First Pack")
+	sourceContents := loadPackContentRows(t, sourceID)
+	if len(sourceContents) == 0 {
+		t.Fatalf("Expected source pack to have items, got 0")
+	}
+
+	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("/mypack/%d/duplicate", sourceID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Expected status %d but got %d. Body: %s", http.StatusCreated, w.Code, w.Body.String())
+	}
+
+	var newPack Pack
+	if err := json.Unmarshal(w.Body.Bytes(), &newPack); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	if newPack.ID == 0 || newPack.ID == sourceID {
+		t.Errorf("Expected a new pack ID distinct from source %d, got %d", sourceID, newPack.ID)
+	}
+	if newPack.PackName != "COPY - First Pack" {
+		t.Errorf("Expected pack name 'COPY - First Pack', got %q", newPack.PackName)
+	}
+	if newPack.UserID != users[0].ID {
+		t.Errorf("Expected new pack to be owned by user %d, got %d", users[0].ID, newPack.UserID)
+	}
+	if newPack.IsFavorite {
+		t.Error("Expected new pack to not be favorited")
+	}
+	if newPack.SharingCode != nil {
+		t.Errorf("Expected new pack sharing_code to be nil, got %v", *newPack.SharingCode)
+	}
+
+	dupContents := loadPackContentRows(t, newPack.ID)
+	if diff := cmp.Diff(sourceContents, dupContents, cmp.AllowUnexported(duplicateContentRow{})); diff != "" {
+		t.Errorf("Pack contents mismatch (-want +got):\n%s", diff)
+	}
+
+	// Verify metadata copied verbatim in DB (description, season, trail, adventure)
+	var description string
+	var season, trail, adventure sql.NullString
+	err := database.DB().QueryRow(
+		"SELECT pack_description, season, trail, adventure FROM pack WHERE id = $1", newPack.ID,
+	).Scan(&description, &season, &trail, &adventure)
+	if err != nil {
+		t.Fatalf("Failed to read duplicated pack metadata: %v", err)
+	}
+	if description != "Description for the first pack" {
+		t.Errorf("Expected description copied verbatim, got %q", description)
+	}
+	if !season.Valid || season.String != "Winter" {
+		t.Errorf("Expected season 'Winter', got %+v", season)
+	}
+	if !adventure.Valid || adventure.String != "Thru-hike" {
+		t.Errorf("Expected adventure 'Thru-hike', got %+v", adventure)
+	}
+
+	// Cleanup so reruns don't pile up duplicates and downstream tests aren't affected.
+	if _, err := database.DB().Exec("DELETE FROM pack WHERE id = $1", newPack.ID); err != nil {
+		t.Fatalf("Failed to clean up duplicated pack: %v", err)
+	}
+}
+
+func testDuplicateEmptyPack(t *testing.T, router *gin.Engine, token string) {
+	now := time.Now().Truncate(time.Second)
+	var emptyPackID uint
+	err := database.DB().QueryRow(
+		`INSERT INTO pack (user_id, pack_name, pack_description, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $4) RETURNING id`,
+		users[0].ID, "Empty Pack For Duplicate", "no items here", now,
+	).Scan(&emptyPackID)
+	if err != nil {
+		t.Fatalf("Failed to seed empty pack: %v", err)
+	}
+	defer func() {
+		_, _ = database.DB().Exec("DELETE FROM pack WHERE id = $1 OR pack_name = $2",
+			emptyPackID, "COPY - Empty Pack For Duplicate")
+	}()
+
+	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("/mypack/%d/duplicate", emptyPackID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Expected status %d but got %d. Body: %s", http.StatusCreated, w.Code, w.Body.String())
+	}
+
+	var newPack Pack
+	if err := json.Unmarshal(w.Body.Bytes(), &newPack); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+	if newPack.PackName != "COPY - Empty Pack For Duplicate" {
+		t.Errorf("Expected COPY - prefix, got %q", newPack.PackName)
+	}
+	if got := loadPackContentRows(t, newPack.ID); len(got) != 0 {
+		t.Errorf("Expected zero pack_content rows in duplicate, got %d", len(got))
+	}
+}
+
+func testDuplicateForbidden(t *testing.T, router *gin.Engine, token string) {
+	// Third Pack belongs to users[1]; users[0]'s token must be rejected.
+	packID := FindPackIDByPackName(packs, "Third Pack")
+	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("/mypack/%d/duplicate", packID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden && w.Code != http.StatusNotFound {
+		t.Errorf("Expected status %d or %d but got %d", http.StatusForbidden, http.StatusNotFound, w.Code)
+	}
+}
+
+func testDuplicateNotFound(t *testing.T, router *gin.Engine, token string) {
+	req, _ := http.NewRequest(http.MethodPost, "/mypack/99999/duplicate", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status %d but got %d", http.StatusNotFound, w.Code)
+	}
+}
+
+func testDuplicateUnauthorized(t *testing.T, router *gin.Engine) {
+	packID := FindPackIDByPackName(packs, "First Pack")
+	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("/mypack/%d/duplicate", packID), nil)
+	// No Authorization header
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("Expected status %d but got %d", http.StatusUnauthorized, w.Code)
+	}
+}
+
+func TestDuplicateMyPack(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	router.POST("/mypack/:id/duplicate", DuplicateMyPack)
+
+	token, err := security.GenerateToken(users[0].ID)
+	if err != nil {
+		t.Fatalf("Failed to generate token: %v", err)
+	}
+
+	t.Run("Successfully duplicate a pack with items", func(t *testing.T) {
+		testDuplicateSuccess(t, router, token)
+	})
+	t.Run("Successfully duplicate an empty pack", func(t *testing.T) {
+		testDuplicateEmptyPack(t, router, token)
+	})
+	t.Run("Forbidden - pack does not belong to user", func(t *testing.T) {
+		testDuplicateForbidden(t, router, token)
+	})
+	t.Run("Pack not found", func(t *testing.T) {
+		testDuplicateNotFound(t, router, token)
+	})
+	t.Run("Unauthorized - no token", func(t *testing.T) {
+		testDuplicateUnauthorized(t, router)
 	})
 }
 

--- a/pkg/packs/repository.go
+++ b/pkg/packs/repository.go
@@ -433,6 +433,66 @@ func unfavoritePackByID(ctx context.Context, packID uint, userID uint) error {
 	return nil
 }
 
+// Pack duplication
+
+// duplicatePackByID clones a pack (metadata + every pack_content row) into a new pack
+// for the same user, in a single transaction. The new pack's name is prefixed with
+// "COPY - ", its sharing_code is NULL and is_favorite is false. The pack image is
+// intentionally not copied.
+func duplicatePackByID(ctx context.Context, sourceID uint, userID uint) (uint, error) {
+	owns, err := checkPackOwnership(ctx, sourceID, userID)
+	if err != nil {
+		return 0, err
+	}
+	if !owns {
+		return 0, ErrPackNotOwned
+	}
+
+	tx, err := database.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	now := time.Now().Truncate(time.Second)
+
+	var newPackID uint
+	err = tx.QueryRowContext(ctx,
+		`INSERT INTO pack
+		(user_id, pack_name, pack_description, sharing_code, is_favorite,
+		 season, trail, trail_id, adventure, created_at, updated_at)
+		SELECT $1, 'COPY - ' || pack_name, pack_description, NULL, false,
+		       season, trail, trail_id, adventure, $2, $2
+		FROM pack
+		WHERE id = $3
+		RETURNING id;`,
+		userID, now, sourceID).Scan(&newPackID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to insert duplicated pack: %w", err)
+	}
+
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO pack_content
+		(pack_id, item_id, quantity, worn, consumable, created_at, updated_at)
+		SELECT $1, item_id, quantity, worn, consumable, $2, $2
+		FROM pack_content
+		WHERE pack_id = $3;`,
+		newPackID, now, sourceID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to copy pack contents: %w", err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return 0, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return newPackID, nil
+}
+
 // returnPackInfoBySharingCode retrieves pack metadata using sharing code.
 // Returns nil if pack not found or sharing_code is NULL.
 func returnPackInfoBySharingCode(ctx context.Context, sharingCode string) (*SharedPackInfo, error) {

--- a/tests/api-scenarios/002-pack-crud.yaml
+++ b/tests/api-scenarios/002-pack-crud.yaml
@@ -365,6 +365,78 @@ scenarios:
       - type: status_code
         expected: 200
 
+  - name: "Duplicate the pack"
+    request:
+      method: POST
+      endpoint: "/v1/mypack/{{pack_id}}/duplicate"
+      headers:
+        Authorization: "Bearer {{access_token}}"
+    assertions:
+      - type: status_code
+        expected: 201
+      - type: json_path
+        path: "$.id"
+        exists: true
+      - type: json_path
+        path: "$.pack_name"
+        equals: "COPY - Updated Weekend Pack"
+      - type: json_path
+        path: "$.pack_description"
+        equals: "An updated description for the pack"
+      - type: json_path
+        path: "$.season"
+        equals: "Winter"
+      - type: json_path
+        path: "$.trail"
+        equals: "Pacific Crest Trail"
+      - type: json_path
+        path: "$.adventure"
+        equals: "Thru-hike"
+      - type: json_path
+        path: "$.is_favorite"
+        equals: "false"
+      - type: json_path
+        path: "$.pack_items_count"
+        equals: "2"
+    store:
+      duplicated_pack_id: "{{response.id}}"
+
+  - name: "Verify the duplicate has the source pack's items"
+    request:
+      method: GET
+      endpoint: "/v1/mypack/{{duplicated_pack_id}}/packcontents"
+      headers:
+        Authorization: "Bearer {{access_token}}"
+    assertions:
+      - type: status_code
+        expected: 200
+      - type: json_path
+        path: "$[0].inventory_id"
+        equals: "{{inventory_item_id}}"
+      - type: json_path
+        path: "$[0].quantity"
+        equals: "2"
+
+  - name: "Duplicate not found (id 99999)"
+    request:
+      method: POST
+      endpoint: "/v1/mypack/99999/duplicate"
+      headers:
+        Authorization: "Bearer {{access_token}}"
+    assertions:
+      - type: status_code
+        expected: 404
+
+  - name: "Cleanup: Delete duplicated pack"
+    request:
+      method: DELETE
+      endpoint: "/v1/mypack/{{duplicated_pack_id}}"
+      headers:
+        Authorization: "Bearer {{access_token}}"
+    assertions:
+      - type: status_code
+        expected: 200
+
   - name: "Cleanup: Delete pack content"
     request:
       method: DELETE

--- a/tests/api-scenarios/006-ownership-validation.yaml
+++ b/tests/api-scenarios/006-ownership-validation.yaml
@@ -193,6 +193,16 @@ scenarios:
       - type: status_code
         expected: 403
 
+  - name: "User B tries to duplicate User A's pack (should fail with 403)"
+    request:
+      method: POST
+      endpoint: "/v1/mypack/{{user_a_pack_id}}/duplicate"
+      headers:
+        Authorization: "Bearer {{user_b_token}}"
+    assertions:
+      - type: status_code
+        expected: 403
+
   # User A adds pack content (inventory item to pack)
   - name: "User A adds inventory item to their pack"
     request:


### PR DESCRIPTION
## Summary

- Adds `POST /v1/mypack/:id/duplicate` — clones a pack's metadata and every `pack_content` row into a brand new pack owned by the same user, in a single DB transaction.
- The new pack's name is prefixed `COPY - `, `is_favorite` is reset to `false`, `sharing_code` is not copied, and the pack image is intentionally not duplicated.
- 404 if the source pack doesn't exist; 403 if it exists but belongs to another user; 201 + the new `packs.Pack` body on success.

## Changes

- New repository function `duplicatePackByID` (transactional `INSERT … SELECT` for `pack` then `pack_content`).
- New handler `DuplicateMyPack` with full swagger annotations.
- Route registered in `main.go` next to the other `/mypack/:id/*` actions.
- Unit tests in `pkg/packs/packs_test.go` cover happy path with items, empty pack, cross-user 403, 404 not-found, unauthorized.
- api-test scenarios added: happy-path + 404 in `002-pack-crud.yaml`, cross-user 403 in `006-ownership-validation.yaml`.
- Regenerated `api-doc/{docs.go,swagger.json,swagger.yaml}` via `make api-doc`.

## Pre-PR checklist

- `make lint` — 0 issues
- `make build` — clean
- `make test` — all packages green
- `make api-doc` — regenerated and committed
- `make api-test-full` — 152/152 pass (+5 new tests)

Closes #240
