### PR TITLE
feat(packs): anonymous LighterPack import endpoints

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,6 +132,7 @@ func setupPublicRoutes(router *gin.Engine) {
 		accounts.ResendConfirmEmail)
 	public.GET("/sharedlist/:sharing_code", packs.SharedList)
 	public.GET("/user/:username", profiles.GetPublicProfile)
+	public.POST("/parselighterpackurl", packs.ParseLighterPackURL)
 	public.GET("/v1/packs/:id/image", images.GetPackImage)
 	public.GET("/v1/packs/:id/items/:itemId/image", images.GetPackItemImage)
 	public.GET("/v1/accounts/:id/image", images.GetProfileImage)

--- a/main.go
+++ b/main.go
@@ -169,6 +169,7 @@ func setupProtectedRoutes(router *gin.Engine) {
 	protected.POST("/importfromlighterpack", packs.ImportFromLighterPack)
 	protected.POST("/importfromlighterpackurl", packs.ImportFromLighterPackURL)
 	protected.POST("/importfrompimpmypackurl", packs.ImportFromPimpMyPackURL)
+	protected.POST("/importpack", packs.ImportPack)
 	protected.POST("/mypack/:id/image", images.UploadPackImage)
 	protected.DELETE("/mypack/:id/image", images.DeletePackImage)
 	protected.POST("/myaccount/image", images.UploadMyProfileImage)

--- a/pkg/packs/anonymous_import_test.go
+++ b/pkg/packs/anonymous_import_test.go
@@ -55,7 +55,7 @@ func TestImportPack_Success(t *testing.T) {
 	router := gin.Default()
 	router.POST("/importpack", ImportPack)
 
-	payload := ParseExternalPackResponse{
+	payload := ImportPackRequest{
 		PackName:        "Imported Pack",
 		PackDescription: "from anonymous flow",
 		Items: ExternalPack{
@@ -95,7 +95,7 @@ func TestImportPack_EmptyItems(t *testing.T) {
 	router := gin.Default()
 	router.POST("/importpack", ImportPack)
 
-	payload := ParseExternalPackResponse{
+	payload := ImportPackRequest{
 		PackName:        "Empty Pack",
 		PackDescription: "no items",
 		Items:           ExternalPack{},

--- a/pkg/packs/anonymous_import_test.go
+++ b/pkg/packs/anonymous_import_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Angak0k/pimpmypack/pkg/security"
 	"github.com/gin-gonic/gin"
 )
 
@@ -41,5 +42,74 @@ func TestParseLighterPackURL_NoAuthRequired(t *testing.T) {
 
 	if w.Code == http.StatusUnauthorized {
 		t.Errorf("endpoint must not require auth, got 401")
+	}
+}
+
+func TestImportPack_Success(t *testing.T) {
+	token, err := security.GenerateToken(users[0].ID)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	router.POST("/importpack", ImportPack)
+
+	payload := ParseExternalPackResponse{
+		PackName:        "Imported Pack",
+		PackDescription: "from anonymous flow",
+		Items: ExternalPack{
+			{
+				ItemName: "Tent",
+				Category: "Shelter",
+				Qty:      1,
+				Weight:   1200,
+				Unit:     "g",
+				Currency: "EUR",
+			},
+		},
+	}
+	body, _ := json.Marshal(payload)
+
+	req, _ := http.NewRequest(http.MethodPost, "/importpack", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	verifyImportResponse(t, w.Body.Bytes())
+}
+
+func TestImportPack_EmptyItems(t *testing.T) {
+	token, err := security.GenerateToken(users[0].ID)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	router.POST("/importpack", ImportPack)
+
+	payload := ParseExternalPackResponse{
+		PackName:        "Empty Pack",
+		PackDescription: "no items",
+		Items:           ExternalPack{},
+	}
+	body, _ := json.Marshal(payload)
+
+	req, _ := http.NewRequest(http.MethodPost, "/importpack", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d (body: %s)", w.Code, w.Body.String())
 	}
 }

--- a/pkg/packs/anonymous_import_test.go
+++ b/pkg/packs/anonymous_import_test.go
@@ -1,0 +1,45 @@
+package packs
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestParseLighterPackURL_InvalidURL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	router.POST("/parselighterpackurl", ParseLighterPackURL)
+
+	body, _ := json.Marshal(map[string]string{"url": "https://example.com/not-lighterpack"})
+	req, _ := http.NewRequest(http.MethodPost, "/parselighterpackurl", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestParseLighterPackURL_NoAuthRequired(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	router.POST("/parselighterpackurl", ParseLighterPackURL)
+
+	body, _ := json.Marshal(map[string]string{"url": "ftp://bad"})
+	req, _ := http.NewRequest(http.MethodPost, "/parselighterpackurl", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code == http.StatusUnauthorized {
+		t.Errorf("endpoint must not require auth, got 401")
+	}
+}

--- a/pkg/packs/handlers.go
+++ b/pkg/packs/handlers.go
@@ -1416,6 +1416,53 @@ func ImportFromLighterPackURL(c *gin.Context) {
 	})
 }
 
+// Parse a LighterPack URL without persisting (public, no auth).
+// @Summary Parse a LighterPack sharing URL
+// @Description Fetch and parse a LighterPack sharing URL and return its items without saving
+// @Tags Packs
+// @Accept json
+// @Produce json
+// @Param input body ImportFromURLRequest true "LighterPack URL"
+// @Success 200 {object} ParseExternalPackResponse
+// @Failure 400 {object} apitypes.ErrorResponse "Invalid URL"
+// @Failure 422 {object} apitypes.ErrorResponse "Failed to parse page"
+// @Failure 502 {object} apitypes.ErrorResponse "Failed to fetch page"
+// @Router /parselighterpackurl [post]
+func ParseLighterPackURL(c *gin.Context) {
+	var input ImportFromURLRequest
+
+	if err := c.ShouldBindJSON(&input); err != nil {
+		helper.LogAndSanitize(err, "parse lighterpack url: bind json failed")
+		c.JSON(http.StatusBadRequest, gin.H{"error": helper.ErrMsgBadRequest})
+		return
+	}
+
+	if err := validateLighterPackURL(input.URL); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	body, err := fetchLighterPackPage(c.Request.Context(), input.URL)
+	if err != nil {
+		helper.LogAndSanitize(err, "parse lighterpack url: fetch page failed")
+		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to fetch LighterPack page"})
+		return
+	}
+
+	packName, packDescription, items, err := parseLighterPackHTML(body)
+	if err != nil {
+		helper.LogAndSanitize(err, "parse lighterpack url: parse HTML failed")
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "failed to parse LighterPack page: " + err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, ParseExternalPackResponse{
+		PackName:        packName,
+		PackDescription: packDescription,
+		Items:           items,
+	})
+}
+
 // Import from PimpMyPack URL
 // @Summary Import a pack from a PimpMyPack sharing URL
 // @Description Import items from a PimpMyPack sharing URL into a new pack

--- a/pkg/packs/handlers.go
+++ b/pkg/packs/handlers.go
@@ -1416,6 +1416,53 @@ func ImportFromLighterPackURL(c *gin.Context) {
 	})
 }
 
+// Import a pack from a structured payload (authenticated bulk import).
+// @Summary Import a pack from structured items
+// @Description Create a pack and its contents from a client-provided item list
+// @Tags Packs
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param input body ParseExternalPackResponse true "Pack name, description and items"
+// @Success 200 {object} ImportExternalPackResponse
+// @Failure 400 {object} apitypes.ErrorResponse "Invalid request"
+// @Failure 422 {object} apitypes.ErrorResponse "Empty payload"
+// @Failure 500 {object} apitypes.ErrorResponse "Internal Server Error"
+// @Router /v1/importpack [post]
+func ImportPack(c *gin.Context) {
+	var input ParseExternalPackResponse
+
+	userID, err := security.ExtractTokenID(c)
+	if err != nil {
+		helper.LogAndSanitize(err, "import pack: extract token ID failed")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": helper.ErrMsgUnauthorized})
+		return
+	}
+
+	if err := c.ShouldBindJSON(&input); err != nil {
+		helper.LogAndSanitize(err, "import pack: bind json failed")
+		c.JSON(http.StatusBadRequest, gin.H{"error": helper.ErrMsgBadRequest})
+		return
+	}
+
+	if len(input.Items) == 0 {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "payload is empty"})
+		return
+	}
+
+	packID, err := insertExternalPack(c.Request.Context(), &input.Items, userID, input.PackName, input.PackDescription)
+	if err != nil {
+		helper.LogAndSanitize(err, "import pack: insert external pack failed")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	c.JSON(http.StatusOK, ImportExternalPackResponse{
+		Message: "Pack imported successfully",
+		PackID:  packID,
+	})
+}
+
 // Parse a LighterPack URL without persisting (public, no auth).
 // @Summary Parse a LighterPack sharing URL
 // @Description Fetch and parse a LighterPack sharing URL and return its items without saving

--- a/pkg/packs/handlers.go
+++ b/pkg/packs/handlers.go
@@ -1423,14 +1423,14 @@ func ImportFromLighterPackURL(c *gin.Context) {
 // @Accept json
 // @Produce json
 // @Security Bearer
-// @Param input body ParseExternalPackResponse true "Pack name, description and items"
+// @Param input body ImportPackRequest true "Pack name, description and items"
 // @Success 200 {object} ImportExternalPackResponse
 // @Failure 400 {object} apitypes.ErrorResponse "Invalid request"
 // @Failure 422 {object} apitypes.ErrorResponse "Empty payload"
 // @Failure 500 {object} apitypes.ErrorResponse "Internal Server Error"
 // @Router /v1/importpack [post]
 func ImportPack(c *gin.Context) {
-	var input ParseExternalPackResponse
+	var input ImportPackRequest
 
 	userID, err := security.ExtractTokenID(c)
 	if err != nil {

--- a/pkg/packs/types.go
+++ b/pkg/packs/types.go
@@ -178,6 +178,16 @@ type ParseExternalPackResponse struct {
 	Items           ExternalPack `json:"items"`
 }
 
+// ImportPackRequest is the request body of the authenticated bulk import
+// endpoint. It mirrors ParseExternalPackResponse's fields but is a distinct
+// type so generated OpenAPI clients model the import payload as a request,
+// not a response.
+type ImportPackRequest struct {
+	PackName        string       `json:"pack_name"`
+	PackDescription string       `json:"pack_description"`
+	Items           ExternalPack `json:"items"`
+}
+
 // SharedPackResponse represents the response structure for shared pack endpoint
 type SharedPackResponse struct {
 	Pack     SharedPackInfo       `json:"pack"`

--- a/pkg/packs/types.go
+++ b/pkg/packs/types.go
@@ -170,6 +170,14 @@ type ImportExternalPackResponse struct {
 	PackID  uint   `json:"pack_id"`
 }
 
+// ParseExternalPackResponse is returned by the public parse endpoint.
+// It contains parsed pack data WITHOUT persisting anything.
+type ParseExternalPackResponse struct {
+	PackName        string       `json:"pack_name"`
+	PackDescription string       `json:"pack_description"`
+	Items           ExternalPack `json:"items"`
+}
+
 // SharedPackResponse represents the response structure for shared pack endpoint
 type SharedPackResponse struct {
 	Pack     SharedPackInfo       `json:"pack"`


### PR DESCRIPTION
## Context

Backend support for the **anonymous LighterPack import** feature (frontend: Angak0k/pimpmypack-front#87). Lets a visitor parse and preview a LighterPack list without an account, then persist it after signing up.

Both endpoints reuse existing factored code — no new parsing or persistence logic.

## Changes

**New type** (`pkg/packs/types.go`)
- `ParseExternalPackResponse` — `{ pack_name, pack_description, items: []ExternalPackItem }`.

**`POST /api/parselighterpackurl`** — PUBLIC, no auth (`pkg/packs/handlers.go`)
- Validates + fetches + parses a `lighterpack.com/r/<id>` URL (reusing `validateLighterPackURL` / `fetchLighterPackPage` / `parseLighterPackHTML`) and returns the parsed items **without persisting**.
- Errors: 400 invalid URL, 502 fetch failure, 422 parse failure.
- Registered in the public route group.

**`POST /api/v1/importpack`** — AUTHENTICATED bulk import (`pkg/packs/handlers.go`)
- Accepts `{ pack_name, pack_description, items }` and creates a pack + inventory items + contents via the existing `insertExternalPack`.
- Errors: 401 unauth, 400 bad request, 422 empty payload, 500 internal.
- Registered in the protected route group.

## Tests

`pkg/packs/anonymous_import_test.go`:
- `TestParseLighterPackURL_InvalidURL` (400), `TestParseLighterPackURL_NoAuthRequired` (never 401)
- `TestImportPack_Success` (200 + non-zero pack_id, DB-verified), `TestImportPack_EmptyItems` (422)

`go build ./...` clean; new tests pass.

## Notes

- Swagger annotations added on both handlers (frontend `swagger.json` updated in the companion frontend PR).
- The public parse endpoint performs an outbound server-side fetch; existing safety guards (HTTPS-only `lighterpack.com`, 15s timeout, 5 MB cap) are preserved. Consider adding rate limiting before production rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)