### PR TITLE
docs: refresh CLAUDE.md, agents.md and PATTERNS.md to current architecture

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -2,11 +2,11 @@
 
 This document outlines the main design and architecture principles to contribute in the PimpMyPack project.
 
-> **For AI Agents**: See [CLAUDE.md](CLAUDE.md) for quick reference (automatically loaded by Claude Code). This file provides comprehensive details.
+> **For AI Agents**: See [claude.md](claude.md) for quick reference (automatically loaded by Claude Code). This file provides comprehensive details.
 >
 > **Related Documentation**:
 >
-> - [CLAUDE.md](CLAUDE.md) - Quick reference for Claude Code (stack, conventions, critical info)
+> - [claude.md](claude.md) - Quick reference for Claude Code (stack, conventions, critical info)
 > - [Code Patterns & Examples](docs/PATTERNS.md) - Detailed code patterns and templates
 > - [Collaboration Guide](docs/COLLABORATION.md) - Spec-driven development and learnings
 > - [Code Templates](docs/agent-templates/) - Ready-to-use code templates

--- a/agents.md
+++ b/agents.md
@@ -2,14 +2,14 @@
 
 This document outlines the main design and architecture principles to contribute in the PimpMyPack project.
 
-> **For AI Agents**: See [claude.md](claude.md) for quick reference (automatically loaded by Claude Code). This file provides comprehensive details.
+> **For AI Agents**: See [CLAUDE.md](CLAUDE.md) for quick reference (automatically loaded by Claude Code). This file provides comprehensive details.
 >
 > **Related Documentation**:
 >
-> - [claude.md](claude.md) - Quick reference for Claude Code (stack, conventions, critical info)
-> - [Code Patterns & Examples](agents/PATTERNS.md) - Detailed code patterns and templates
-> - [Collaboration Guide](agents/COLLABORATION.md) - Spec-driven development and learnings
-> - [Code Templates](agents/templates/) - Ready-to-use code templates
+> - [CLAUDE.md](CLAUDE.md) - Quick reference for Claude Code (stack, conventions, critical info)
+> - [Code Patterns & Examples](docs/PATTERNS.md) - Detailed code patterns and templates
+> - [Collaboration Guide](docs/COLLABORATION.md) - Spec-driven development and learnings
+> - [Code Templates](docs/agent-templates/) - Ready-to-use code templates
 
 ## 🎯 Purpose of the project
 
@@ -29,13 +29,13 @@ If you are an agent willing to contribute to this project, follow this workflow:
 6. **Implement**: Code following guidelines, write tests, document
 7. **Update status**: Systematically update task checkboxes in specs with implementation dates, files modified, and key decisions
 
-See [COLLABORATION.md](agents/COLLABORATION.md) for detailed best practices.
+See [COLLABORATION.md](docs/COLLABORATION.md) for detailed best practices.
 
 ## 🏗️ Architecture Overview
 
 ### Project Structure
 
-- **Functional package organization**: By business domain (`accounts`, `inventories`, `packs`, `security`, `config`, `database`, `helper`)
+- **Functional package organization**: By business domain (`accounts`, `inventories`, `packs`, `profiles`, `trails`, `images`) plus shared/utility packages (`apitypes`, `security`, `config`, `database`, `helper`)
 - **Separation of concerns**: Clear package responsibilities
 - **Repository Pattern**: Gin handlers separated from business logic
 
@@ -54,7 +54,7 @@ See [COLLABORATION.md](agents/COLLABORATION.md) for detailed best practices.
 - **Structure**: Bind → Validate → Execute → Respond
 - **Documentation**: Complete Swagger annotations required
 
-See [PATTERNS.md#handlers](agents/PATTERNS.md#handlers) for detailed examples.
+See [PATTERNS.md#handlers](docs/PATTERNS.md#handlers) for detailed examples.
 
 ### Business Functions
 
@@ -62,7 +62,7 @@ See [PATTERNS.md#handlers](agents/PATTERNS.md#handlers) for detailed examples.
 - **Context**: Always accept `context.Context` as first parameter
 - **Errors**: Use `fmt.Errorf` with wrapping (`%w`), define sentinel errors
 
-See [PATTERNS.md#business-functions](agents/PATTERNS.md#business-functions) for patterns.
+See [PATTERNS.md#business-functions](docs/PATTERNS.md#business-functions) for patterns.
 
 ### Database Management
 
@@ -76,7 +76,7 @@ See [PATTERNS.md#business-functions](agents/PATTERNS.md#business-functions) for 
 - **JWT**: Generation, extraction (header/query), validation via middleware
 - **Middlewares**: `JwtAuthProcessor()` (standard), `JwtAuthAdminProcessor()` (admin)
 - **Passwords**: bcrypt for hashing and validation
-- **Routes**: `/api` (public), `/api/v1` (protected), `/api/admin` (admin)
+- **Routes**: `/api` (public), `/api/v1` & `/api/v2` (protected), `/api/admin` (admin)
 
 ## 🧪 Testing
 
@@ -94,7 +94,7 @@ See [PATTERNS.md#business-functions](agents/PATTERNS.md#business-functions) for 
 - **Coverage**: Run with `-coverprofile=coverage.out`
 - **Complexity**: Extract helpers when cognitive complexity > 20
 
-See [PATTERNS.md#testing](agents/PATTERNS.md#testing) for examples.
+See [PATTERNS.md#testing](docs/PATTERNS.md#testing) for examples.
 
 ## ⚙️ Configuration
 
@@ -104,14 +104,13 @@ See [PATTERNS.md#testing](agents/PATTERNS.md#testing) for examples.
   - `LOCAL`/`DEV`: Swagger enabled
   - Production: Swagger disabled, Gin release mode
 
-## 📄 Dataset (Data Models)
+## 📄 Data Models
 
-All types in `pkg/dataset`:
+**Types live in their domain package** (`types.go`), NOT in a centralized `dataset` package (that package has been removed):
 
-- Base types: `Account`, `Inventory`, `Pack`, `PackContent`
-- Collections: `Accounts`, `Inventories`, `Packs`
-- Input/Response types: `RegisterInput`, `OkResponse`, `ErrorResponse`
-- Composite types: `PackContentWithItem` (joins)
+- Domain types in their package: `accounts.Account`, `inventories.Inventory`, `packs.Pack`/`PackContent` (+ collections `Accounts`, `Inventories`, `Packs`), input types like `accounts.RegisterInput`
+- **Shared HTTP responses** in `pkg/apitypes`: `OkResponse`, `ErrorResponse`
+- Composite types: `packs.PackContentWithItem` (joins)
 - **Timestamps**: `created_at`, `updated_at` (truncated to second)
 
 ## 🚀 Build and Deployment
@@ -183,7 +182,7 @@ All types in `pkg/dataset`:
 
 ## 📝 New Feature Checklist
 
-- [ ] Create types in `pkg/dataset`
+- [ ] Create types in the domain package (`pkg/<domain>/types.go`)
 - [ ] Create SQL migration (up and down)
 - [ ] Implement business functions with context
 - [ ] Define sentinel errors if necessary

--- a/claude.md
+++ b/claude.md
@@ -7,11 +7,11 @@
 **Purpose**: Backend API for managing user packs and gear inventories (hiking, camping, etc.)
 
 **Stack**:
-- **Go 1.21+** (Gin Web Framework)
+- **Go 1.26** (Gin Web Framework)
 - **PostgreSQL** with **direct SQL** (`database/sql`, **NO GORM**)
 - **JWT authentication** (golang-jwt/jwt v5)
 - **bcrypt** for password hashing
-- **Testing**: stdlib testing, httptest, testify/assert
+- **Testing**: stdlib `testing` (table-driven) + `httptest`; `testify/assert` in some packages
 
 **⚠️ CRITICAL**: Always use `QueryContext`, `ExecContext`, `QueryRowContext` - **NEVER use GORM or any ORM**.
 
@@ -22,12 +22,16 @@ pimpmypack/
 ├── main.go                 # Application entry point, routing
 ├── pkg/
 │   ├── accounts/           # User accounts, login, registration
+│   ├── apitypes/           # Shared API request/response types (OkResponse, ErrorResponse...)
+│   ├── images/             # Image subsystem: upload/serve pack/profile/banner/inventory, EXIF, DB storage
 │   ├── inventories/        # User gear inventories
 │   ├── packs/              # Pack management (user packs with items)
+│   ├── profiles/           # Public user profiles
+│   ├── trails/             # Trails feature
 │   ├── security/           # JWT, auth middleware, password hashing
 │   ├── config/             # Environment configuration loading
 │   ├── database/           # DB connection singleton + migrations
-│   │   └── migration/      # SQL migration files
+│   │   └── migration/migration_scripts/  # SQL migration files
 │   └── helper/             # Utilities (email, validation, etc.)
 ├── specs/                  # Technical specifications (*.md)
 ├── agents/                 # Agent definitions for Claude Code
@@ -80,43 +84,55 @@ _, err := database.DB().ExecContext(ctx,
 - Migration files: `snake_case` with sequence number (`000001_account.up.sql`)
 - Go files: `snake_case` (`accounts.go`, `security_test.go`)
 
+### Package Layering (current standard)
+
+Refactored packages split responsibilities across files (NOT inline in one file):
+- `handlers.go`    — Gin HTTP handlers (binding, validation, response)
+- `service.go`     — business logic
+- `repository.go`  — direct SQL data access
+- `types.go`       — package types
+- `testdata.go`    — test fixtures
+
+Fully split: `inventories`, `packs`, `trails`. Partially migrated: `accounts` (handlers extracted to `handlers.go`, but service + SQL still combined in `accounts.go`). **Use the full split for new packages.**
+
 ### HTTP Handlers Structure
 
-All Gin handlers follow this pattern:
+All Gin handlers follow this pattern (business logic lives in `service.go`, not the handler):
 
 ```go
 func PostMyResource(c *gin.Context) {
     var input ResourceInput
 
-    // 1. Bind JSON
+    // 1. Bind JSON — never leak raw err.Error() to clients
     if err := c.ShouldBindJSON(&input); err != nil {
-        c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+        helper.LogAndSanitize(err, "post my resource: bind json failed")
+        c.JSON(http.StatusBadRequest, gin.H{"error": helper.ErrMsgBadRequest})
         return
     }
 
-    // 2. Validate (if needed)
-    if !isValid(input) {
-        c.JSON(http.StatusBadRequest, gin.H{"error": "validation error"})
-        return
-    }
-
-    // 3. Execute business logic
+    // 2. Execute business logic (lives in service.go)
     result, err := createResource(c.Request.Context(), input)
     if err != nil {
-        c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+        helper.LogAndSanitize(err, "post my resource: create failed")
+        c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
         return
     }
 
-    // 4. Respond
-    c.JSON(http.StatusOK, gin.H{"data": result})
+    // 3. Respond
+    c.JSON(http.StatusOK, result)
 }
 ```
+
+**Response conventions**:
+- Prefer `helper.ErrMsg*` constants over leaking raw `err.Error()` in error responses
+- Use `apitypes.OkResponse` / `apitypes.ErrorResponse` for typed responses & Swagger annotations
 
 ### Security & Authentication
 
 **Routes**:
 - `/api` - Public endpoints (no auth)
 - `/api/v1` - Protected endpoints (JWT required via `JwtAuthProcessor()`)
+- `/api/v2` - Protected endpoints, newer API revision (JWT required)
 - `/api/admin` - Admin-only endpoints (JWT + admin role via `JwtAuthAdminProcessor()`)
 
 **Middleware**:
@@ -130,24 +146,33 @@ func PostMyResource(c *gin.Context) {
 ### Testing
 
 **Organization**:
-- Test files: `*_test.go` in same package as tested code
-- Use `httptest` for HTTP handlers
-- Use `testify/assert` for assertions
+- Test files: `*_test.go` in the same package as the tested code
+- `TestMain` seeds a test database; tests share a package-level `users` fixture
+- Primary style: stdlib `testing` with **table-driven** tests and `t.Errorf`/`t.Fatalf` (domain packages: `packs`, `inventories`, `accounts`, `trails`)
+- `testify/assert` is used in a few packages (e.g. `security`, `helper`) — match the style of the package you're editing
+- HTTP handlers: `gin.SetMode(gin.TestMode)` + `gin.Default()` + `httptest`; authenticate with `security.GenerateToken(users[0].ID)`
 
-**Example**:
+**Example** (stdlib, handler test):
 ```go
-func TestGetMyInventory_Success(t *testing.T) {
-    router := setupTestRouter(t)
-    user := createTestUser(t)
-    token := generateTestToken(user.ID)
+func TestImportPack_Success(t *testing.T) {
+    token, err := security.GenerateToken(users[0].ID)
+    if err != nil {
+        t.Fatalf("failed to generate token: %v", err)
+    }
 
-    req := httptest.NewRequest("GET", "/api/v1/my/inventory", nil)
+    gin.SetMode(gin.TestMode)
+    router := gin.Default()
+    router.POST("/importpack", ImportPack)
+
+    req, _ := http.NewRequest(http.MethodPost, "/importpack", body)
     req.Header.Set("Authorization", "Bearer "+token)
     w := httptest.NewRecorder()
 
     router.ServeHTTP(w, req)
 
-    assert.Equal(t, 200, w.Code)
+    if w.Code != http.StatusOK {
+        t.Errorf("expected 200, got %d", w.Code)
+    }
 }
 ```
 
@@ -239,27 +264,34 @@ The project includes specialized agents for common tasks. Invoke them explicitly
 # Build the test CLI
 make build-apitest
 
-# Run all test scenarios (35 tests across 4 scenarios)
+# Run all scenarios (8 YAML scenarios in tests/api-scenarios/, ~150 checks)
 make api-test
 
-# Run specific scenario
-./bin/apitest run 001    # Authentication & registration
+# Run specific scenario(s) by number prefix
+./bin/apitest run 001    # User registration & authentication
 ./bin/apitest run 002    # Pack CRUD operations
 ./bin/apitest run 003    # Inventory management
-./bin/apitest run 004    # CSV import (LighterPack)
+./bin/apitest run 004    # Import from LighterPack (CSV)
+./bin/apitest run 005    # Security: input validation & sanitization
+./bin/apitest run 006    # Ownership validation (403 vs 404)
+./bin/apitest run 007    # Account profile: social URLs & profile image
+./bin/apitest run 008    # Trails database & admin management
 
 # Run with verbose output for debugging
 ./bin/apitest run -v 001
 ```
 
+Scenarios are YAML files in `tests/api-scenarios/` (one `NNN-*.yaml` per scenario). Add a scenario by dropping a numbered YAML there.
+
 **What it tests**:
 
-- User registration and email confirmation
-- Login and token refresh flows
-- Pack creation, update, deletion
-- Inventory CRUD operations
-- File upload (CSV import)
-- Authorization and access control
+- User registration, email confirmation, login & token refresh
+- Pack and inventory CRUD
+- LighterPack CSV import
+- Input validation/sanitization and ownership (403 vs 404) checks
+- Account profile (social URLs, profile image) and trails management
+
+> **Coverage gap**: no scenario yet for the LighterPack **URL** import (`/v1/importfromlighterpackurl`) or the anonymous parse/bulk endpoints (`/parselighterpackurl`, `/v1/importpack`) — worth adding.
 
 **Note**: Server must be running on `localhost:8080` with `STAGE=LOCAL` in `.env`
 
@@ -267,7 +299,7 @@ make api-test
 
 **Critical Errors**:
 - ❌ **NO GORM**: Project uses `database/sql` directly, never use any ORM
-- ❌ **NO auto-migrations**: Always write migration files in `pkg/database/migration/`
+- ❌ **NO auto-migrations**: Always write migration files in `pkg/database/migration/migration_scripts/`
 - ❌ **NO `go.mod` changes**: Unless explicitly requested (dependencies are stable)
 - ❌ **NO breaking changes**: Always maintain backward compatibility
 
@@ -292,5 +324,5 @@ make api-test
 
 ---
 
-**Last Updated**: 2026-03-09
+**Last Updated**: 2026-05-31
 **Project Version**: See [go.mod](go.mod) for Go version and dependencies

--- a/claude.md
+++ b/claude.md
@@ -88,8 +88,8 @@ _, err := database.DB().ExecContext(ctx,
 
 Refactored packages split responsibilities across files (NOT inline in one file):
 - `handlers.go`    — Gin HTTP handlers (binding, validation, response)
-- `service.go`     — business logic
-- `repository.go`  — direct SQL data access
+- `service.go`     — public wrappers for cross-package use only (thin; no business logic)
+- `repository.go`  — direct SQL data access and private business functions
 - `types.go`       — package types
 - `testdata.go`    — test fixtures
 
@@ -97,7 +97,7 @@ Fully split: `inventories`, `packs`, `trails`. Partially migrated: `accounts` (h
 
 ### HTTP Handlers Structure
 
-All Gin handlers follow this pattern (business logic lives in `service.go`, not the handler):
+All Gin handlers follow this pattern (business logic is in private package functions, not the handler):
 
 ```go
 func PostMyResource(c *gin.Context) {
@@ -110,7 +110,7 @@ func PostMyResource(c *gin.Context) {
         return
     }
 
-    // 2. Execute business logic (lives in service.go)
+    // 2. Execute business logic (private function in repository.go)
     result, err := createResource(c.Request.Context(), input)
     if err != nil {
         helper.LogAndSanitize(err, "post my resource: create failed")

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -102,8 +102,8 @@ func GetAccounts(c *gin.Context) { /* ... */ }
 // Service functions (public, framework-agnostic)
 func GetAllAccounts(ctx context.Context) ([]Account, error) { /* ... */ }
 
-// Repository functions (private, database access)
-func getAllAccounts(ctx context.Context, db *sql.DB) ([]Account, error) { /* ... */ }
+// Repository functions (private, database access) — call database.DB() internally
+func getAllAccounts(ctx context.Context) ([]Account, error) { /* ... */ }
 
 // Helper functions (package-specific)
 func FindUserIDByUsername(users []Account, username string) uint { /* ... */ }
@@ -128,7 +128,7 @@ func GetAllInventoriesByUserID(ctx context.Context, userID uint) (Inventories, e
 
 // pkg/inventories/repository.go or pkg/packs/repository.go (private data access)
 package inventories
-func getAllInventoriesByUserID(ctx context.Context, db *sql.DB, userID uint) (Inventories, error) { /* ... */ }
+func getAllInventoriesByUserID(ctx context.Context, userID uint) (Inventories, error) { /* ... */ }
 ```
 
 **Examples**: Both `pkg/inventories/` and `pkg/packs/` follow this pattern.
@@ -176,32 +176,39 @@ func FindPackIDByPackName(packs dataset.Packs, packname string) uint { /* ... */
 
 ### Service Layer Pattern
 
-Use a clean separation between handlers (HTTP), service (business logic), and repository (data access):
+Separate handlers (HTTP), service (cross-package public API), and repository (data access). Note the real layout:
+- **`repository.go`**: private (lowercase) functions that call the `database.DB()` singleton directly — they do NOT take a `db *sql.DB` parameter.
+- **`service.go`**: public (Uppercase) thin re-exports of repository functions, exposed so **other packages** can reuse the logic (e.g. `packs` calling `trails.FindTrailByName`).
+- **`handlers.go`**: same-package handlers call the private repository functions directly.
 
 ```go
-// Handler layer (Gin-specific, public)
-func GetMyInventories(c *gin.Context) {
+// Repository layer (repository.go, private) — uses the database.DB() singleton, no db param
+func returnInventoriesByUserID(ctx context.Context, userID uint) (*Inventories, error) {
+    query := `SELECT id, user_id, item_name, category, weight FROM inventory WHERE user_id = $1`
+    rows, err := database.DB().QueryContext(ctx, query, userID)
+    if err != nil {
+        return nil, fmt.Errorf("failed to query inventory: %w", err)
+    }
+    defer rows.Close()
+    // ... scan rows
+}
+
+// Service layer (service.go, public) — re-export for OTHER packages to reuse
+func FindInventoryByID(ctx context.Context, id uint) (*Inventory, error) {
+    return findInventoryByID(ctx, id)
+}
+
+// Handler layer (handlers.go, Gin-specific) — calls the private repository function directly
+func GetMyInventory(c *gin.Context) {
     userID := c.GetUint("user_id")
 
-    inventories, err := GetAllInventoriesByUserID(c.Request.Context(), userID)
+    inventories, err := returnInventoriesByUserID(c.Request.Context(), userID)
     if err != nil {
-        c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+        c.JSON(http.StatusInternalServerError, apitypes.ErrorResponse{Error: err.Error()})
         return
     }
 
     c.JSON(http.StatusOK, inventories)
-}
-
-// Service layer (framework-agnostic, public)
-func GetAllInventoriesByUserID(ctx context.Context, userID uint) (Inventories, error) {
-    db := database.DB()
-    return getAllInventoriesByUserID(ctx, db, userID)
-}
-
-// Repository layer (data access, private)
-func getAllInventoriesByUserID(ctx context.Context, db *sql.DB, userID uint) (Inventories, error) {
-    query := `SELECT id, user_id, item_name, category, weight FROM inventory WHERE user_id = $1`
-    // ... database query logic
 }
 ```
 
@@ -361,31 +368,25 @@ func CreateInventoryItem(ctx context.Context, userID uint, item *Inventory) erro
 func UpdatePackContent(ctx context.Context, content *PackContent) error
 func DeletePackByID(ctx context.Context, packID uint) error
 
-// Repository layer: Private functions (lowercase)
-// Read operations: prefix with "get" or "return"
-func getAllInventories(ctx context.Context, db *sql.DB, userID uint) (Inventories, error)
-func getPackByID(ctx context.Context, db *sql.DB, packID uint) (*Pack, error)
+// Repository layer: Private functions (lowercase) — call database.DB() internally, no db param
+// Read operations: prefix with "return" (collections) or "find" (single item / lookup)
+func returnInventoriesByUserID(ctx context.Context, userID uint) (*Inventories, error)
+func findPackByID(ctx context.Context, packID uint) (*Pack, error)
 
 // Write operations: descriptive verbs
-func createInventoryItem(ctx context.Context, db *sql.DB, item *Inventory) error
-func updatePackContent(ctx context.Context, db *sql.DB, content *PackContent) error
-func deletePackByID(ctx context.Context, db *sql.DB, packID uint) error
+func insertInventory(ctx context.Context, item *Inventory) error
+func updatePackContent(ctx context.Context, content *PackContent) error
+func deletePackByID(ctx context.Context, packID uint) error
 ```
 
 ### Context Propagation Pattern
 
 ```go
-// Service layer: Always accept context.Context as first parameter
-func GetInventoryItems(ctx context.Context, userID uint) (Inventories, error) {
-    db := database.DB()
-    return getInventoryItems(ctx, db, userID)
-}
-
-// Repository layer: Accept context and db connection
-func getInventoryItems(ctx context.Context, db *sql.DB, userID uint) (Inventories, error) {
+// Repository layer: always accept context.Context as first parameter; use the database.DB() singleton
+func returnInventoryItems(ctx context.Context, userID uint) (Inventories, error) {
     query := `SELECT id, item_name, category, weight FROM inventory WHERE user_id = $1`
 
-    rows, err := db.QueryContext(ctx, query, userID)
+    rows, err := database.DB().QueryContext(ctx, query, userID)
     if err != nil {
         return nil, fmt.Errorf("failed to query inventory: %w", err)
     }
@@ -415,18 +416,13 @@ var (
     ErrUnauthorized     = errors.New("unauthorized access")
 )
 
-// Use in service functions
-// pkg/accounts/accounts.go
-func GetAccountByID(ctx context.Context, accountID uint) (*Account, error) {
-    db := database.DB()
-    return getAccountByID(ctx, db, accountID)
-}
-
-func getAccountByID(ctx context.Context, db *sql.DB, accountID uint) (*Account, error) {
+// Use in repository functions
+// pkg/accounts/accounts.go (repository) — uses database.DB() directly, no db param
+func findAccountByID(ctx context.Context, accountID uint) (*Account, error) {
     query := `SELECT id, username, email, firstname, lastname FROM account WHERE id = $1`
 
     var account Account
-    err := db.QueryRowContext(ctx, query, accountID).Scan(
+    err := database.DB().QueryRowContext(ctx, query, accountID).Scan(
         &account.ID,
         &account.Username,
         &account.Email,
@@ -501,7 +497,7 @@ func TestHandlerName(t *testing.T) {
             t.Errorf("Expected %d but got %d", http.StatusOK, w.Code)
         }
 
-        var response dataset.Response
+        var response SuccessResponse
         if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
             t.Errorf("Failed to parse response: %v", err)
         }
@@ -650,7 +646,7 @@ func HandlerWithErrors(c *gin.Context) {
 ### Query Pattern with Context
 
 ```go
-func returnItems(ctx context.Context, userID uint) (*dataset.Items, error) {
+func returnItems(ctx context.Context, userID uint) (*Items, error) {
     query := `
         SELECT id, name, description, created_at, updated_at
         FROM items
@@ -658,15 +654,15 @@ func returnItems(ctx context.Context, userID uint) (*dataset.Items, error) {
         ORDER BY created_at DESC
     `
 
-    rows, err := database.DB.QueryContext(ctx, query, userID)
+    rows, err := database.DB().QueryContext(ctx, query, userID)
     if err != nil {
         return nil, fmt.Errorf("failed to query items: %w", err)
     }
     defer rows.Close()
 
-    var items dataset.Items
+    var items Items
     for rows.Next() {
-        var item dataset.Item
+        var item Item
         if err := rows.Scan(&item.ID, &item.Name, &item.Description, &item.CreatedAt, &item.UpdatedAt); err != nil {
             return nil, fmt.Errorf("failed to scan item: %w", err)
         }
@@ -684,15 +680,15 @@ func returnItems(ctx context.Context, userID uint) (*dataset.Items, error) {
 ### Single Row Query Pattern
 
 ```go
-func returnItemByID(ctx context.Context, itemID uint) (*dataset.Item, error) {
+func returnItemByID(ctx context.Context, itemID uint) (*Item, error) {
     query := `
         SELECT id, name, description, created_at, updated_at
         FROM items
         WHERE id = $1
     `
 
-    var item dataset.Item
-    err := database.DB.QueryRowContext(ctx, query, itemID).Scan(
+    var item Item
+    err := database.DB().QueryRowContext(ctx, query, itemID).Scan(
         &item.ID,
         &item.Name,
         &item.Description,
@@ -714,14 +710,14 @@ func returnItemByID(ctx context.Context, itemID uint) (*dataset.Item, error) {
 ### Exec Pattern (INSERT/UPDATE/DELETE)
 
 ```go
-func createItem(ctx context.Context, item dataset.ItemInput, userID uint) error {
+func createItem(ctx context.Context, item ItemInput, userID uint) error {
     query := `
         INSERT INTO items (user_id, name, description, created_at, updated_at)
         VALUES ($1, $2, $3, $4, $5)
     `
 
     now := time.Now().Truncate(time.Second)
-    _, err := database.DB.ExecContext(ctx, query, userID, item.Name, item.Description, now, now)
+    _, err := database.DB().ExecContext(ctx, query, userID, item.Name, item.Description, now, now)
     if err != nil {
         return fmt.Errorf("failed to create item: %w", err)
     }
@@ -729,14 +725,14 @@ func createItem(ctx context.Context, item dataset.ItemInput, userID uint) error 
     return nil
 }
 
-func updateItem(ctx context.Context, itemID uint, updates dataset.ItemInput) error {
+func updateItem(ctx context.Context, itemID uint, updates ItemInput) error {
     query := `
         UPDATE items
         SET name = $1, description = $2, updated_at = $3
         WHERE id = $4
     `
 
-    result, err := database.DB.ExecContext(ctx, query, updates.Name, updates.Description, time.Now().Truncate(time.Second), itemID)
+    result, err := database.DB().ExecContext(ctx, query, updates.Name, updates.Description, time.Now().Truncate(time.Second), itemID)
     if err != nil {
         return fmt.Errorf("failed to update item: %w", err)
     }
@@ -757,9 +753,9 @@ func updateItem(ctx context.Context, itemID uint, updates dataset.ItemInput) err
 ### Transaction Pattern
 
 ```go
-func complexOperation(ctx context.Context, data dataset.ComplexInput) error {
+func complexOperation(ctx context.Context, data ComplexInput) error {
     // Begin transaction
-    tx, err := database.DB.BeginTx(ctx, nil)
+    tx, err := database.DB().BeginTx(ctx, nil)
     if err != nil {
         return fmt.Errorf("failed to begin transaction: %w", err)
     }
@@ -804,13 +800,13 @@ type Pack struct {
 }
 
 // Query with nullable fields
-func returnPack(ctx context.Context, packID uint) (*dataset.Pack, error) {
+func returnPack(ctx context.Context, packID uint) (*Pack, error) {
     query := `SELECT id, name, sharing_code, created_at FROM packs WHERE id = $1`
 
-    var pack dataset.Pack
+    var pack Pack
     var sharingCode sql.NullString
 
-    err := database.DB.QueryRowContext(ctx, query, packID).Scan(
+    err := database.DB().QueryRowContext(ctx, query, packID).Scan(
         &pack.ID,
         &pack.Name,
         &sharingCode,


### PR DESCRIPTION
## Why

The agent-facing context files had drifted from the actual codebase (audited against the current code). This realigns them.

## Changes

**CLAUDE.md**
- Go `1.21+` → `1.26`
- Add missing packages to the structure: `apitypes`, `images`, `profiles`, `trails`
- Document the `handlers.go` / `service.go` / `repository.go` / `types.go` layering (standard for new packages)
- Add the `/api/v2` route group
- Note response conventions (`helper.ErrMsg*` constants, `apitypes` types)
- Fix migration path → `migration/migration_scripts/`

**agents.md**
- Fix broken doc links (`agents/*` → `docs/*`, `agents/templates/` → `docs/agent-templates/`) and `claude.md` casing
- Replace the obsolete "Dataset" section (`pkg/dataset` was removed) with the domain-package + `apitypes` model
- Add missing packages and `/api/v2`

**docs/PATTERNS.md**
- `database.DB` → `database.DB()` (singleton accessor)
- Drop stale `dataset.*` references from code examples (kept only in the ❌ anti-example)
- Remove the `db *sql.DB` repository parameter — repos call `database.DB()` internally
- Correct the service-layer description: `service.go` exposes public cross-package re-exports; handlers call private repository functions directly

Documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)