### PR TITLE
fix: update API_SECRET in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           DB_PASSWORD: pmp1234
           DB_NAME: pmp_db
           DB_PORT: 5432 
-          API_SECRET: myawsomeapisecret
+          API_SECRET: averylongsecretthatis32byteslong
           TOKEN_HOUR_LIFESPAN: 1
           MAIL_IDENTITY: "test@exemple.com"
           MAIL_USERNAME: "test_user"


### PR DESCRIPTION
## Summary

- Update `API_SECRET` in `.github/workflows/release.yml` to a non-placeholder 32-byte value, consistent with the startup validation hardening landed in #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)