### PR TITLE
fix(SEC-5): enforce inventory item ownership on pack content write

### DIFF
--- a/api-doc/docs.go
+++ b/api-doc/docs.go
@@ -1739,7 +1739,65 @@ const docTemplate = `{
         },
         "/v1/mypack/:id/packcontent": {
             "post": {
-                "responses": {}
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Create a new pack content",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packs"
+                ],
+                "summary": "Create a new pack content",
+                "parameters": [
+                    {
+                        "description": "Pack Content",
+                        "name": "packcontent",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/packs.PackContent"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/packs.PackContent"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/v1/mypack/{id}": {

--- a/api-doc/docs.go
+++ b/api-doc/docs.go
@@ -197,6 +197,58 @@ const docTemplate = `{
                 }
             }
         },
+        "/parselighterpackurl": {
+            "post": {
+                "description": "Fetch and parse a LighterPack sharing URL and return its items without saving",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packs"
+                ],
+                "summary": "Parse a LighterPack sharing URL",
+                "parameters": [
+                    {
+                        "description": "LighterPack URL",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/packs.ImportFromURLRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/packs.ParseExternalPackResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid URL",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Failed to parse page",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "502": {
+                        "description": "Failed to fetch page",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/register": {
             "post": {
                 "description": "Register a new user with username, password, email, firstname, and lastname",
@@ -624,6 +676,63 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Shared pack not found",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/importpack": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Create a pack and its contents from a client-provided item list",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packs"
+                ],
+                "summary": "Import a pack from structured items",
+                "parameters": [
+                    {
+                        "description": "Pack name, description and items",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/packs.ImportPackRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/packs.ImportExternalPackResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Empty payload",
                         "schema": {
                             "$ref": "#/definitions/apitypes.ErrorResponse"
                         }
@@ -1630,65 +1739,7 @@ const docTemplate = `{
         },
         "/v1/mypack/:id/packcontent": {
             "post": {
-                "security": [
-                    {
-                        "Bearer": []
-                    }
-                ],
-                "description": "Create a new pack content",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Packs"
-                ],
-                "summary": "Create a new pack content",
-                "parameters": [
-                    {
-                        "description": "Pack Content",
-                        "name": "packcontent",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/packs.PackContent"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/packs.PackContent"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/apitypes.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/apitypes.ErrorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/apitypes.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/apitypes.ErrorResponse"
-                        }
-                    }
-                }
+                "responses": {}
             }
         },
         "/v1/mypack/{id}": {
@@ -3202,6 +3253,44 @@ const docTemplate = `{
                 }
             }
         },
+        "packs.ExternalPackItem": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "consumable": {
+                    "type": "boolean"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "item_name": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "integer"
+                },
+                "qty": {
+                    "type": "integer"
+                },
+                "unit": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "weight": {
+                    "type": "integer"
+                },
+                "worn": {
+                    "type": "boolean"
+                }
+            }
+        },
         "packs.ImportExternalPackResponse": {
             "type": "object",
             "properties": {
@@ -3220,6 +3309,23 @@ const docTemplate = `{
             ],
             "properties": {
                 "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "packs.ImportPackRequest": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/packs.ExternalPackItem"
+                    }
+                },
+                "pack_description": {
+                    "type": "string"
+                },
+                "pack_name": {
                     "type": "string"
                 }
             }
@@ -3466,6 +3572,23 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "trail": {
+                    "type": "string"
+                }
+            }
+        },
+        "packs.ParseExternalPackResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/packs.ExternalPackItem"
+                    }
+                },
+                "pack_description": {
+                    "type": "string"
+                },
+                "pack_name": {
                     "type": "string"
                 }
             }

--- a/api-doc/swagger.json
+++ b/api-doc/swagger.json
@@ -1736,7 +1736,65 @@
         },
         "/v1/mypack/:id/packcontent": {
             "post": {
-                "responses": {}
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Create a new pack content",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packs"
+                ],
+                "summary": "Create a new pack content",
+                "parameters": [
+                    {
+                        "description": "Pack Content",
+                        "name": "packcontent",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/packs.PackContent"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/packs.PackContent"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/v1/mypack/{id}": {

--- a/api-doc/swagger.json
+++ b/api-doc/swagger.json
@@ -194,6 +194,58 @@
                 }
             }
         },
+        "/parselighterpackurl": {
+            "post": {
+                "description": "Fetch and parse a LighterPack sharing URL and return its items without saving",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packs"
+                ],
+                "summary": "Parse a LighterPack sharing URL",
+                "parameters": [
+                    {
+                        "description": "LighterPack URL",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/packs.ImportFromURLRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/packs.ParseExternalPackResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid URL",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Failed to parse page",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "502": {
+                        "description": "Failed to fetch page",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/register": {
             "post": {
                 "description": "Register a new user with username, password, email, firstname, and lastname",
@@ -621,6 +673,63 @@
                     },
                     "404": {
                         "description": "Shared pack not found",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/importpack": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Create a pack and its contents from a client-provided item list",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packs"
+                ],
+                "summary": "Import a pack from structured items",
+                "parameters": [
+                    {
+                        "description": "Pack name, description and items",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/packs.ImportPackRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/packs.ImportExternalPackResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Empty payload",
                         "schema": {
                             "$ref": "#/definitions/apitypes.ErrorResponse"
                         }
@@ -1627,65 +1736,7 @@
         },
         "/v1/mypack/:id/packcontent": {
             "post": {
-                "security": [
-                    {
-                        "Bearer": []
-                    }
-                ],
-                "description": "Create a new pack content",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Packs"
-                ],
-                "summary": "Create a new pack content",
-                "parameters": [
-                    {
-                        "description": "Pack Content",
-                        "name": "packcontent",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/packs.PackContent"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/packs.PackContent"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/apitypes.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/apitypes.ErrorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/apitypes.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/apitypes.ErrorResponse"
-                        }
-                    }
-                }
+                "responses": {}
             }
         },
         "/v1/mypack/{id}": {
@@ -3199,6 +3250,44 @@
                 }
             }
         },
+        "packs.ExternalPackItem": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "consumable": {
+                    "type": "boolean"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "item_name": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "integer"
+                },
+                "qty": {
+                    "type": "integer"
+                },
+                "unit": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "weight": {
+                    "type": "integer"
+                },
+                "worn": {
+                    "type": "boolean"
+                }
+            }
+        },
         "packs.ImportExternalPackResponse": {
             "type": "object",
             "properties": {
@@ -3217,6 +3306,23 @@
             ],
             "properties": {
                 "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "packs.ImportPackRequest": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/packs.ExternalPackItem"
+                    }
+                },
+                "pack_description": {
+                    "type": "string"
+                },
+                "pack_name": {
                     "type": "string"
                 }
             }
@@ -3463,6 +3569,23 @@
                     "type": "string"
                 },
                 "trail": {
+                    "type": "string"
+                }
+            }
+        },
+        "packs.ParseExternalPackResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/packs.ExternalPackItem"
+                    }
+                },
+                "pack_description": {
+                    "type": "string"
+                },
+                "pack_name": {
                     "type": "string"
                 }
             }

--- a/api-doc/swagger.yaml
+++ b/api-doc/swagger.yaml
@@ -238,6 +238,31 @@ definitions:
     - source_item_id
     - target_item_id
     type: object
+  packs.ExternalPackItem:
+    properties:
+      category:
+        type: string
+      consumable:
+        type: boolean
+      currency:
+        type: string
+      desc:
+        type: string
+      item_name:
+        type: string
+      price:
+        type: integer
+      qty:
+        type: integer
+      unit:
+        type: string
+      url:
+        type: string
+      weight:
+        type: integer
+      worn:
+        type: boolean
+    type: object
   packs.ImportExternalPackResponse:
     properties:
       message:
@@ -251,6 +276,17 @@ definitions:
         type: string
     required:
     - url
+    type: object
+  packs.ImportPackRequest:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/packs.ExternalPackItem'
+        type: array
+      pack_description:
+        type: string
+      pack_name:
+        type: string
     type: object
   packs.Pack:
     properties:
@@ -413,6 +449,17 @@ definitions:
         type: string
     required:
     - pack_name
+    type: object
+  packs.ParseExternalPackResponse:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/packs.ExternalPackItem'
+        type: array
+      pack_description:
+        type: string
+      pack_name:
+        type: string
     type: object
   packs.SharedPackInfo:
     properties:
@@ -665,6 +712,41 @@ paths:
       summary: User login
       tags:
       - Public
+  /parselighterpackurl:
+    post:
+      consumes:
+      - application/json
+      description: Fetch and parse a LighterPack sharing URL and return its items
+        without saving
+      parameters:
+      - description: LighterPack URL
+        in: body
+        name: input
+        required: true
+        schema:
+          $ref: '#/definitions/packs.ImportFromURLRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/packs.ParseExternalPackResponse'
+        "400":
+          description: Invalid URL
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "422":
+          description: Failed to parse page
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "502":
+          description: Failed to fetch page
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+      summary: Parse a LighterPack sharing URL
+      tags:
+      - Packs
   /register:
     post:
       consumes:
@@ -952,6 +1034,42 @@ paths:
       security:
       - Bearer: []
       summary: Import a pack from a PimpMyPack sharing URL
+      tags:
+      - Packs
+  /v1/importpack:
+    post:
+      consumes:
+      - application/json
+      description: Create a pack and its contents from a client-provided item list
+      parameters:
+      - description: Pack name, description and items
+        in: body
+        name: input
+        required: true
+        schema:
+          $ref: '#/definitions/packs.ImportPackRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/packs.ImportExternalPackResponse'
+        "400":
+          description: Invalid request
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "422":
+          description: Empty payload
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+      security:
+      - Bearer: []
+      summary: Import a pack from structured items
       tags:
       - Packs
   /v1/myaccount:
@@ -1602,44 +1720,7 @@ paths:
       - Packs
   /v1/mypack/:id/packcontent:
     post:
-      consumes:
-      - application/json
-      description: Create a new pack content
-      parameters:
-      - description: Pack Content
-        in: body
-        name: packcontent
-        required: true
-        schema:
-          $ref: '#/definitions/packs.PackContent'
-      produces:
-      - application/json
-      responses:
-        "201":
-          description: Created
-          schema:
-            $ref: '#/definitions/packs.PackContent'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/apitypes.ErrorResponse'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/apitypes.ErrorResponse'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/apitypes.ErrorResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/apitypes.ErrorResponse'
-      security:
-      - Bearer: []
-      summary: Create a new pack content
-      tags:
-      - Packs
+      responses: {}
   /v1/mypack/{id}:
     delete:
       description: Delete a pack by ID

--- a/api-doc/swagger.yaml
+++ b/api-doc/swagger.yaml
@@ -1720,7 +1720,44 @@ paths:
       - Packs
   /v1/mypack/:id/packcontent:
     post:
-      responses: {}
+      consumes:
+      - application/json
+      description: Create a new pack content
+      parameters:
+      - description: Pack Content
+        in: body
+        name: packcontent
+        required: true
+        schema:
+          $ref: '#/definitions/packs.PackContent'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/packs.PackContent'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+      security:
+      - Bearer: []
+      summary: Create a new pack content
+      tags:
+      - Packs
   /v1/mypack/{id}:
     delete:
       description: Delete a pack by ID

--- a/pkg/packs/handlers.go
+++ b/pkg/packs/handlers.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/Angak0k/pimpmypack/pkg/helper"
+	"github.com/Angak0k/pimpmypack/pkg/inventories"
 	"github.com/Angak0k/pimpmypack/pkg/security"
 	"github.com/Angak0k/pimpmypack/pkg/trails"
 	"github.com/gin-gonic/gin"
@@ -633,6 +634,22 @@ func PostPackContent(c *gin.Context) {
 // @Failure 401 {object} apitypes.ErrorResponse
 // @Failure 403 {object} apitypes.ErrorResponse
 // @Failure 500 {object} apitypes.ErrorResponse
+// itemOwnershipDenied checks that itemID belongs to userID.
+// It writes a 403 or 500 response and returns true when the handler must abort.
+func itemOwnershipDenied(c *gin.Context, itemID, userID uint, logPrefix string) bool {
+	owned, err := inventories.CheckInventoryOwnership(c.Request.Context(), itemID, userID)
+	if err != nil {
+		helper.LogAndSanitize(err, logPrefix+": check item ownership failed")
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return true
+	}
+	if !owned {
+		c.IndentedJSON(http.StatusForbidden, gin.H{"error": "This item does not belong to you"})
+		return true
+	}
+	return false
+}
+
 // @Router /v1/mypack/:id/packcontent [post]
 func PostMyPackContent(c *gin.Context) {
 	var requestData PackContentRequest
@@ -672,6 +689,11 @@ func PostMyPackContent(c *gin.Context) {
 	// Check pack ownership
 	if pack.UserID != userID {
 		c.IndentedJSON(http.StatusForbidden, gin.H{"error": "This pack does not belong to you"})
+		return
+	}
+
+	// Check item ownership (prevent IDOR: attacker attaching another user's item)
+	if itemOwnershipDenied(c, requestData.InventoryID, userID, "post my pack content") {
 		return
 	}
 
@@ -807,6 +829,11 @@ func PutMyPackContentByID(c *gin.Context) {
 	// Check pack ownership
 	if pack.UserID != userID {
 		c.IndentedJSON(http.StatusForbidden, gin.H{"error": "This pack does not belong to you"})
+		return
+	}
+
+	// Check item ownership (prevent IDOR: attacker swapping in another user's item)
+	if itemOwnershipDenied(c, input.InventoryID, userID, "put my pack content by ID") {
 		return
 	}
 

--- a/pkg/packs/handlers.go
+++ b/pkg/packs/handlers.go
@@ -621,19 +621,6 @@ func PostPackContent(c *gin.Context) {
 	c.IndentedJSON(http.StatusCreated, newPackContent)
 }
 
-// Create a new pack content
-// @Summary Create a new pack content
-// @Description Create a new pack content
-// @Security Bearer
-// @Tags Packs
-// @Accept  json
-// @Produce  json
-// @Param packcontent body PackContent true "Pack Content"
-// @Success 201 {object} PackContent
-// @Failure 400 {object} apitypes.ErrorResponse
-// @Failure 401 {object} apitypes.ErrorResponse
-// @Failure 403 {object} apitypes.ErrorResponse
-// @Failure 500 {object} apitypes.ErrorResponse
 // itemOwnershipDenied checks that itemID belongs to userID.
 // It writes a 403 or 500 response and returns true when the handler must abort.
 func itemOwnershipDenied(c *gin.Context, itemID, userID uint, logPrefix string) bool {
@@ -650,6 +637,19 @@ func itemOwnershipDenied(c *gin.Context, itemID, userID uint, logPrefix string) 
 	return false
 }
 
+// Create a new pack content
+// @Summary Create a new pack content
+// @Description Create a new pack content
+// @Security Bearer
+// @Tags Packs
+// @Accept  json
+// @Produce  json
+// @Param packcontent body PackContent true "Pack Content"
+// @Success 201 {object} PackContent
+// @Failure 400 {object} apitypes.ErrorResponse
+// @Failure 401 {object} apitypes.ErrorResponse
+// @Failure 403 {object} apitypes.ErrorResponse
+// @Failure 500 {object} apitypes.ErrorResponse
 // @Router /v1/mypack/:id/packcontent [post]
 func PostMyPackContent(c *gin.Context) {
 	var requestData PackContentRequest
@@ -832,11 +832,6 @@ func PutMyPackContentByID(c *gin.Context) {
 		return
 	}
 
-	// Check item ownership (prevent IDOR: attacker swapping in another user's item)
-	if itemOwnershipDenied(c, input.InventoryID, userID, "put my pack content by ID") {
-		return
-	}
-
 	// Fetch existing pack content to preserve timestamps
 	existingPackContent, err := findPackContentByID(c.Request.Context(), contentID)
 	if err != nil {
@@ -848,6 +843,11 @@ func PutMyPackContentByID(c *gin.Context) {
 	// Ensure the pack content actually belongs to the specified pack
 	if existingPackContent.PackID != packID {
 		c.IndentedJSON(http.StatusNotFound, gin.H{"error": "Pack content not found"})
+		return
+	}
+
+	// Check item ownership (prevent IDOR: attacker swapping in another user's item)
+	if itemOwnershipDenied(c, input.InventoryID, userID, "put my pack content by ID") {
 		return
 	}
 

--- a/tests/api-scenarios/006-ownership-validation.yaml
+++ b/tests/api-scenarios/006-ownership-validation.yaml
@@ -269,6 +269,100 @@ scenarios:
       - type: status_code
         expected: 404
 
+  # IDOR tests: User B tries to use User A's inventory item (M1 fix)
+  - name: "IDOR: User B tries to POST pack content with User A's inventory item (should fail with 403)"
+    request:
+      method: POST
+      endpoint: "/v1/mypack/{{user_b_pack_id}}/packcontent"
+      headers:
+        Authorization: "Bearer {{user_b_token}}"
+      body:
+        inventory_id: "{{user_a_inventory_id}}"
+        quantity: 1
+        worn: false
+        consumable: false
+    assertions:
+      - type: status_code
+        expected: 403
+
+  - name: "User B creates their own inventory item (for PUT IDOR test)"
+    request:
+      method: POST
+      endpoint: "/v1/myinventory"
+      headers:
+        Authorization: "Bearer {{user_b_token}}"
+      body:
+        item_name: "User B's Tent"
+        category: "Shelter"
+        description: "A tent belonging to User B"
+        weight: 2000
+        price: 200
+        currency: "USD"
+    assertions:
+      - type: status_code
+        expected: 201
+      - type: json_path
+        path: "$.id"
+        exists: true
+    store:
+      user_b_inventory_id: "{{response.id}}"
+
+  - name: "User B adds their own item to their pack"
+    request:
+      method: POST
+      endpoint: "/v1/mypack/{{user_b_pack_id}}/packcontent"
+      headers:
+        Authorization: "Bearer {{user_b_token}}"
+      body:
+        inventory_id: "{{user_b_inventory_id}}"
+        quantity: 1
+        worn: false
+        consumable: false
+    assertions:
+      - type: status_code
+        expected: 201
+      - type: json_path
+        path: "$.id"
+        exists: true
+    store:
+      user_b_pack_content_id: "{{response.id}}"
+
+  - name: "IDOR: User B tries to PUT pack content swapping in User A's item (should fail with 403)"
+    request:
+      method: PUT
+      endpoint: "/v1/mypack/{{user_b_pack_id}}/packcontent/{{user_b_pack_content_id}}"
+      headers:
+        Authorization: "Bearer {{user_b_token}}"
+      body:
+        inventory_id: "{{user_a_inventory_id}}"
+        quantity: 2
+        worn: false
+        consumable: false
+    assertions:
+      - type: status_code
+        expected: 403
+
+  # Cleanup - User B deletes their own resources
+  - name: "Cleanup: User B deletes their pack content"
+    request:
+      method: DELETE
+      endpoint: "/v1/mypack/{{user_b_pack_id}}/packcontent/{{user_b_pack_content_id}}"
+      headers:
+        Authorization: "Bearer {{user_b_token}}"
+    assertions:
+      - type: status_code
+        expected: 200
+
+  - name: "Cleanup: User B deletes their inventory item"
+    request:
+      method: DELETE
+      endpoint: "/v1/myinventory/{{user_b_inventory_id}}"
+      headers:
+        Authorization: "Bearer {{user_b_token}}"
+    assertions:
+      - type: status_code
+        expected: 200
+
   # Cleanup - User B deletes their own resources
   - name: "Cleanup: User B deletes their pack"
     request:


### PR DESCRIPTION
## Summary

- `PostMyPackContent` and `PutMyPackContentByID` now verify that the supplied `inventory_id` belongs to the authenticated user before inserting or updating pack content
- Returns 403 if the item belongs to another user, preventing cross-user item disclosure via pack content read-back (IDOR)
- Extracted `itemOwnershipDenied` helper to keep both handlers within the 50-statement lint limit
- Added 4 IDOR coverage steps to api-scenario 006 (POST and PUT paths, plus corresponding cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)