### PR TITLE
feat(ci): add e2e test job and /health endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Build server
-        run: go build -o bin/pimpmypack .
+        run: mkdir -p bin && go build -o bin/pimpmypack .
 
       - name: Build apitest CLI
         run: make build-apitest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,80 @@ jobs:
           MAIL_SERVER: "smtp.exemple.com"
         run: go test -covermode=atomic -coverprofile=coverage.out -race -p=1 ./...
 
+  e2e:
+    name: e2e tests
+    runs-on: ubuntu-latest
+    needs: build
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: pmp_user
+          POSTGRES_PASSWORD: pmp1234
+          POSTGRES_DB: pmp_db
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Build server
+        run: go build -o bin/pimpmypack .
+
+      - name: Build apitest CLI
+        run: make build-apitest
+
+      - name: Start server
+        env:
+          DB_HOST: localhost
+          DB_USER: pmp_user
+          DB_PASSWORD: pmp1234
+          DB_NAME: pmp_db
+          DB_PORT: 5432
+          API_SECRET: averylongsecretthatis32byteslong
+          ACCESS_TOKEN_MINUTES: 15
+          REFRESH_TOKEN_DAYS: 1
+          STAGE: LOCAL
+          SEED_ON_STARTUP: "false"
+          MAIL_IDENTITY: "noreply@example.com"
+          MAIL_USERNAME: "test_user"
+          MAIL_PASSWORD: "test_password"
+          MAIL_SERVER: "smtp.example.com"
+          MAIL_PORT: "587"
+        run: |
+          ./bin/pimpmypack > /tmp/pimpmypack-server.log 2>&1 &
+          echo "Waiting for server to be ready..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/health > /dev/null; then
+              echo "Server ready (attempt $i)"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "Server did not become ready in time"
+              cat /tmp/pimpmypack-server.log
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Run E2E tests
+        run: ./bin/apitest run --all
+
+      - name: Upload server logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-logs
+          path: /tmp/pimpmypack-server.log
+
   linter:
     name: lint
     runs-on: ubuntu-latest

--- a/api-doc/docs.go
+++ b/api-doc/docs.go
@@ -197,6 +197,58 @@ const docTemplate = `{
                 }
             }
         },
+        "/parselighterpackurl": {
+            "post": {
+                "description": "Fetch and parse a LighterPack sharing URL and return its items without saving",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packs"
+                ],
+                "summary": "Parse a LighterPack sharing URL",
+                "parameters": [
+                    {
+                        "description": "LighterPack URL",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/packs.ImportFromURLRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/packs.ParseExternalPackResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid URL",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Failed to parse page",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "502": {
+                        "description": "Failed to fetch page",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/register": {
             "post": {
                 "description": "Register a new user with username, password, email, firstname, and lastname",
@@ -624,6 +676,63 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Shared pack not found",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/importpack": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Create a pack and its contents from a client-provided item list",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packs"
+                ],
+                "summary": "Import a pack from structured items",
+                "parameters": [
+                    {
+                        "description": "Pack name, description and items",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/packs.ImportPackRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/packs.ImportExternalPackResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Empty payload",
                         "schema": {
                             "$ref": "#/definitions/apitypes.ErrorResponse"
                         }
@@ -3202,6 +3311,44 @@ const docTemplate = `{
                 }
             }
         },
+        "packs.ExternalPackItem": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "consumable": {
+                    "type": "boolean"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "item_name": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "integer"
+                },
+                "qty": {
+                    "type": "integer"
+                },
+                "unit": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "weight": {
+                    "type": "integer"
+                },
+                "worn": {
+                    "type": "boolean"
+                }
+            }
+        },
         "packs.ImportExternalPackResponse": {
             "type": "object",
             "properties": {
@@ -3220,6 +3367,23 @@ const docTemplate = `{
             ],
             "properties": {
                 "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "packs.ImportPackRequest": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/packs.ExternalPackItem"
+                    }
+                },
+                "pack_description": {
+                    "type": "string"
+                },
+                "pack_name": {
                     "type": "string"
                 }
             }
@@ -3466,6 +3630,23 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "trail": {
+                    "type": "string"
+                }
+            }
+        },
+        "packs.ParseExternalPackResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/packs.ExternalPackItem"
+                    }
+                },
+                "pack_description": {
+                    "type": "string"
+                },
+                "pack_name": {
                     "type": "string"
                 }
             }

--- a/api-doc/swagger.json
+++ b/api-doc/swagger.json
@@ -194,6 +194,58 @@
                 }
             }
         },
+        "/parselighterpackurl": {
+            "post": {
+                "description": "Fetch and parse a LighterPack sharing URL and return its items without saving",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packs"
+                ],
+                "summary": "Parse a LighterPack sharing URL",
+                "parameters": [
+                    {
+                        "description": "LighterPack URL",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/packs.ImportFromURLRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/packs.ParseExternalPackResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid URL",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Failed to parse page",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "502": {
+                        "description": "Failed to fetch page",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/register": {
             "post": {
                 "description": "Register a new user with username, password, email, firstname, and lastname",
@@ -621,6 +673,63 @@
                     },
                     "404": {
                         "description": "Shared pack not found",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/importpack": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Create a pack and its contents from a client-provided item list",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packs"
+                ],
+                "summary": "Import a pack from structured items",
+                "parameters": [
+                    {
+                        "description": "Pack name, description and items",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/packs.ImportPackRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/packs.ImportExternalPackResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Empty payload",
                         "schema": {
                             "$ref": "#/definitions/apitypes.ErrorResponse"
                         }
@@ -3199,6 +3308,44 @@
                 }
             }
         },
+        "packs.ExternalPackItem": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "consumable": {
+                    "type": "boolean"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "item_name": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "integer"
+                },
+                "qty": {
+                    "type": "integer"
+                },
+                "unit": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "weight": {
+                    "type": "integer"
+                },
+                "worn": {
+                    "type": "boolean"
+                }
+            }
+        },
         "packs.ImportExternalPackResponse": {
             "type": "object",
             "properties": {
@@ -3217,6 +3364,23 @@
             ],
             "properties": {
                 "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "packs.ImportPackRequest": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/packs.ExternalPackItem"
+                    }
+                },
+                "pack_description": {
+                    "type": "string"
+                },
+                "pack_name": {
                     "type": "string"
                 }
             }
@@ -3463,6 +3627,23 @@
                     "type": "string"
                 },
                 "trail": {
+                    "type": "string"
+                }
+            }
+        },
+        "packs.ParseExternalPackResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/packs.ExternalPackItem"
+                    }
+                },
+                "pack_description": {
+                    "type": "string"
+                },
+                "pack_name": {
                     "type": "string"
                 }
             }

--- a/api-doc/swagger.yaml
+++ b/api-doc/swagger.yaml
@@ -238,6 +238,31 @@ definitions:
     - source_item_id
     - target_item_id
     type: object
+  packs.ExternalPackItem:
+    properties:
+      category:
+        type: string
+      consumable:
+        type: boolean
+      currency:
+        type: string
+      desc:
+        type: string
+      item_name:
+        type: string
+      price:
+        type: integer
+      qty:
+        type: integer
+      unit:
+        type: string
+      url:
+        type: string
+      weight:
+        type: integer
+      worn:
+        type: boolean
+    type: object
   packs.ImportExternalPackResponse:
     properties:
       message:
@@ -251,6 +276,17 @@ definitions:
         type: string
     required:
     - url
+    type: object
+  packs.ImportPackRequest:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/packs.ExternalPackItem'
+        type: array
+      pack_description:
+        type: string
+      pack_name:
+        type: string
     type: object
   packs.Pack:
     properties:
@@ -413,6 +449,17 @@ definitions:
         type: string
     required:
     - pack_name
+    type: object
+  packs.ParseExternalPackResponse:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/packs.ExternalPackItem'
+        type: array
+      pack_description:
+        type: string
+      pack_name:
+        type: string
     type: object
   packs.SharedPackInfo:
     properties:
@@ -665,6 +712,41 @@ paths:
       summary: User login
       tags:
       - Public
+  /parselighterpackurl:
+    post:
+      consumes:
+      - application/json
+      description: Fetch and parse a LighterPack sharing URL and return its items
+        without saving
+      parameters:
+      - description: LighterPack URL
+        in: body
+        name: input
+        required: true
+        schema:
+          $ref: '#/definitions/packs.ImportFromURLRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/packs.ParseExternalPackResponse'
+        "400":
+          description: Invalid URL
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "422":
+          description: Failed to parse page
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "502":
+          description: Failed to fetch page
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+      summary: Parse a LighterPack sharing URL
+      tags:
+      - Packs
   /register:
     post:
       consumes:
@@ -952,6 +1034,42 @@ paths:
       security:
       - Bearer: []
       summary: Import a pack from a PimpMyPack sharing URL
+      tags:
+      - Packs
+  /v1/importpack:
+    post:
+      consumes:
+      - application/json
+      description: Create a pack and its contents from a client-provided item list
+      parameters:
+      - description: Pack name, description and items
+        in: body
+        name: input
+        required: true
+        schema:
+          $ref: '#/definitions/packs.ImportPackRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/packs.ImportExternalPackResponse'
+        "400":
+          description: Invalid request
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "422":
+          description: Empty payload
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+      security:
+      - Bearer: []
+      summary: Import a pack from structured items
       tags:
       - Packs
   /v1/myaccount:

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	_ "github.com/Angak0k/pimpmypack/api-doc"
@@ -105,6 +106,9 @@ func main() {
 }
 
 func setupRoutes(router *gin.Engine) {
+	router.GET("/health", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
 	setupPublicRoutes(router)
 	setupProtectedRoutes(router)
 	setupV2Routes(router)


### PR DESCRIPTION
## Summary

- Add `GET /health` endpoint returning `{"status": "ok"}` — used as a readiness probe for the server
- Add `e2e` CI job to `.github/workflows/ci.yml` that runs all 8 API scenarios on every PR
  - Gates on the `build` (unit test) job passing first
  - Starts a Postgres service container, builds the server binary, waits for `/health` to respond, then runs `./bin/apitest run --all`
  - Uploads server logs as an artifact on failure
- Swagger doc updates (`api-doc/`) are auto-generated by the mandatory `make api-doc` pre-PR step — they reflect existing `@Router` annotations on `/parselighterpackurl` and `/v1/importpack` that were already in the codebase but missing from the generated docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)