### PR TITLE
fix(SEC-7): harden refresh-token storage and session lifecycle

### DIFF
--- a/api-doc/docs.go
+++ b/api-doc/docs.go
@@ -43,7 +43,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/security.LogoutResponse"
+                            "$ref": "#/definitions/apitypes.OkResponse"
                         }
                     },
                     "400": {
@@ -3870,14 +3870,6 @@ const docTemplate = `{
                 }
             }
         },
-        "security.LogoutResponse": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string"
-                }
-            }
-        },
         "security.RefreshResponse": {
             "type": "object",
             "properties": {
@@ -3886,12 +3878,6 @@ const docTemplate = `{
                 },
                 "expires_in": {
                     "type": "integer"
-                },
-                "refresh_expires_in": {
-                    "type": "integer"
-                },
-                "refresh_token": {
-                    "type": "string"
                 }
             }
         },

--- a/api-doc/docs.go
+++ b/api-doc/docs.go
@@ -15,6 +15,52 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/auth/logout": {
+            "post": {
+                "description": "Revoke the presented refresh token, ending that session. Always 200: token existence cannot be probed.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Logout (revoke a refresh token)",
+                "parameters": [
+                    {
+                        "description": "Refresh Token",
+                        "name": "refresh_token",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/security.RefreshTokenInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/security.LogoutResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/refresh": {
             "post": {
                 "description": "Exchange a valid refresh token for a new access token",
@@ -515,6 +561,43 @@ const docTemplate = `{
                         "description": "Internal server error",
                         "schema": {
                             "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/auth/logout-all": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Revoke all refresh tokens of the authenticated user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Logout from all devices",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/security.LogoutAllResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
                         }
                     }
                 }
@@ -3776,6 +3859,25 @@ const docTemplate = `{
                 }
             }
         },
+        "security.LogoutAllResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "revoked_sessions": {
+                    "type": "integer"
+                }
+            }
+        },
+        "security.LogoutResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
         "security.RefreshResponse": {
             "type": "object",
             "properties": {
@@ -3784,6 +3886,12 @@ const docTemplate = `{
                 },
                 "expires_in": {
                     "type": "integer"
+                },
+                "refresh_expires_in": {
+                    "type": "integer"
+                },
+                "refresh_token": {
+                    "type": "string"
                 }
             }
         },

--- a/api-doc/swagger.json
+++ b/api-doc/swagger.json
@@ -12,6 +12,52 @@
     "host": "pmp-dev.alki.earth",
     "basePath": "/api",
     "paths": {
+        "/auth/logout": {
+            "post": {
+                "description": "Revoke the presented refresh token, ending that session. Always 200: token existence cannot be probed.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Logout (revoke a refresh token)",
+                "parameters": [
+                    {
+                        "description": "Refresh Token",
+                        "name": "refresh_token",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/security.RefreshTokenInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/security.LogoutResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/refresh": {
             "post": {
                 "description": "Exchange a valid refresh token for a new access token",
@@ -512,6 +558,43 @@
                         "description": "Internal server error",
                         "schema": {
                             "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/auth/logout-all": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Revoke all refresh tokens of the authenticated user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Logout from all devices",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/security.LogoutAllResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apitypes.ErrorResponse"
                         }
                     }
                 }
@@ -3773,6 +3856,25 @@
                 }
             }
         },
+        "security.LogoutAllResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "revoked_sessions": {
+                    "type": "integer"
+                }
+            }
+        },
+        "security.LogoutResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
         "security.RefreshResponse": {
             "type": "object",
             "properties": {
@@ -3781,6 +3883,12 @@
                 },
                 "expires_in": {
                     "type": "integer"
+                },
+                "refresh_expires_in": {
+                    "type": "integer"
+                },
+                "refresh_token": {
+                    "type": "string"
                 }
             }
         },

--- a/api-doc/swagger.json
+++ b/api-doc/swagger.json
@@ -40,7 +40,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/security.LogoutResponse"
+                            "$ref": "#/definitions/apitypes.OkResponse"
                         }
                     },
                     "400": {
@@ -3867,14 +3867,6 @@
                 }
             }
         },
-        "security.LogoutResponse": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string"
-                }
-            }
-        },
         "security.RefreshResponse": {
             "type": "object",
             "properties": {
@@ -3883,12 +3875,6 @@
                 },
                 "expires_in": {
                     "type": "integer"
-                },
-                "refresh_expires_in": {
-                    "type": "integer"
-                },
-                "refresh_token": {
-                    "type": "string"
                 }
             }
         },

--- a/api-doc/swagger.yaml
+++ b/api-doc/swagger.yaml
@@ -550,21 +550,12 @@ definitions:
       revoked_sessions:
         type: integer
     type: object
-  security.LogoutResponse:
-    properties:
-      message:
-        type: string
-    type: object
   security.RefreshResponse:
     properties:
       access_token:
         type: string
       expires_in:
         type: integer
-      refresh_expires_in:
-        type: integer
-      refresh_token:
-        type: string
     type: object
   security.RefreshTokenInput:
     properties:
@@ -624,7 +615,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/security.LogoutResponse'
+            $ref: '#/definitions/apitypes.OkResponse'
         "400":
           description: Invalid input
           schema:

--- a/api-doc/swagger.yaml
+++ b/api-doc/swagger.yaml
@@ -543,12 +543,28 @@ definitions:
       trail:
         type: string
     type: object
+  security.LogoutAllResponse:
+    properties:
+      message:
+        type: string
+      revoked_sessions:
+        type: integer
+    type: object
+  security.LogoutResponse:
+    properties:
+      message:
+        type: string
+    type: object
   security.RefreshResponse:
     properties:
       access_token:
         type: string
       expires_in:
         type: integer
+      refresh_expires_in:
+        type: integer
+      refresh_token:
+        type: string
     type: object
   security.RefreshTokenInput:
     properties:
@@ -589,6 +605,37 @@ info:
   title: PimpMyPack API
   version: "1.0"
 paths:
+  /auth/logout:
+    post:
+      consumes:
+      - application/json
+      description: 'Revoke the presented refresh token, ending that session. Always
+        200: token existence cannot be probed.'
+      parameters:
+      - description: Refresh Token
+        in: body
+        name: refresh_token
+        required: true
+        schema:
+          $ref: '#/definitions/security.RefreshTokenInput'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/security.LogoutResponse'
+        "400":
+          description: Invalid input
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+      summary: Logout (revoke a refresh token)
+      tags:
+      - Authentication
   /auth/refresh:
     post:
       consumes:
@@ -929,6 +976,29 @@ paths:
       summary: Get profile image
       tags:
       - Account Images
+  /v1/auth/logout-all:
+    post:
+      description: Revoke all refresh tokens of the authenticated user
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/security.LogoutAllResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/apitypes.ErrorResponse'
+      security:
+      - Bearer: []
+      summary: Logout from all devices
+      tags:
+      - Authentication
   /v1/importfromlighterpack:
     post:
       consumes:

--- a/claude.md
+++ b/claude.md
@@ -140,8 +140,8 @@ func PostMyResource(c *gin.Context) {
 - `security.JwtAuthAdminProcessor()` - JWT validation + admin role check
 
 **Token extraction**:
-- Header: `Authorization: Bearer <token>`
-- Query param: `?token=<token>` (legacy, avoid in new code)
+- Header: `Authorization: Bearer <token>` — the **only** supported transport
+- Query param `?token=` is **not** accepted (removed: URLs leak into logs/history/Referer)
 
 ### Testing
 

--- a/main.go
+++ b/main.go
@@ -138,6 +138,7 @@ func setupPublicRoutes(router *gin.Engine) {
 			config.RefreshRateLimitWindowMinutes,
 		),
 		security.RefreshTokenHandler)
+	public.POST("/auth/logout", security.LogoutHandler)
 	public.GET("/confirmemail", accounts.ConfirmEmail)
 	public.POST("/forgotpassword", accounts.ForgotPassword)
 	public.POST("/resend-confirmemail",
@@ -162,6 +163,7 @@ func setupPublicRoutes(router *gin.Engine) {
 func setupProtectedRoutes(router *gin.Engine) {
 	protected := router.Group("/api/v1")
 	protected.Use(security.JwtAuthProcessor())
+	protected.POST("/auth/logout-all", security.LogoutAllHandler)
 	protected.GET("/myaccount", accounts.GetMyAccount)
 	protected.PUT("/myaccount", accounts.PutMyAccount)
 	protected.PUT("/mypassword", accounts.PutMyPassword)

--- a/pkg/accounts/accounts.go
+++ b/pkg/accounts/accounts.go
@@ -333,6 +333,13 @@ func updatePassword(ctx context.Context, userID uint, updatedPassword string) er
 		return fmt.Errorf("failed to execute update query: %w", err)
 	}
 
+	// A password change must kill every live session, whichever path
+	// triggered it (self-service or forgot-password). Non-fatal: the
+	// password is already updated.
+	if _, err := security.RevokeAllUserTokens(ctx, userID); err != nil {
+		helper.LogAndSanitize(err, "update password: revoke refresh tokens failed")
+	}
+
 	return nil
 }
 
@@ -467,6 +474,16 @@ func updateAccountByID(ctx context.Context, id uint, a *Account) error {
 		return errors.New("payload is empty")
 	}
 
+	// Capture current authority fields: a status or role change must also
+	// revoke the account's live sessions (below)
+	var oldStatus, oldRole string
+	err := database.DB().QueryRowContext(ctx,
+		`SELECT status, role FROM account WHERE id = $1;`, id,
+	).Scan(&oldStatus, &oldRole)
+	if err != nil {
+		return err
+	}
+
 	a.ID = id
 	a.UpdatedAt = time.Now().Truncate(time.Second)
 	statement, err := database.DB().PrepareContext(ctx,
@@ -486,6 +503,16 @@ func updateAccountByID(ctx context.Context, id uint, a *Account) error {
 	if err != nil {
 		return err
 	}
+
+	// An account whose status or role changed must not keep minting access
+	// tokens from old sessions (e.g. a banned or demoted user). Non-fatal:
+	// the account is already updated.
+	if a.Status != oldStatus || a.Role != oldRole {
+		if _, err := security.RevokeAllUserTokens(ctx, id); err != nil {
+			helper.LogAndSanitize(err, "update account: revoke refresh tokens failed")
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/accounts/accounts_test.go
+++ b/pkg/accounts/accounts_test.go
@@ -2,6 +2,7 @@ package accounts
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -1038,6 +1039,12 @@ func TestPutMyPassword(t *testing.T) {
 
 	// Test: Correct current password
 	t.Run("Correct current password", func(t *testing.T) {
+		// A live session that must not survive the password change
+		refreshToken, err := security.CreateRefreshToken(context.Background(), testUser.ID, false)
+		if err != nil {
+			t.Fatalf("failed to create refresh token: %v", err)
+		}
+
 		input := PasswordUpdateInput{
 			CurrentPassword: testUser.Password,
 			NewPassword:     "newpassword",
@@ -1052,6 +1059,14 @@ func TestPutMyPassword(t *testing.T) {
 
 		if w.Code != http.StatusOK {
 			t.Errorf("Expected status code %d but got %d", http.StatusOK, w.Code)
+		}
+
+		retrieved, err := security.GetRefreshToken(context.Background(), refreshToken.Token)
+		if err != nil {
+			t.Fatalf("failed to get refresh token: %v", err)
+		}
+		if !retrieved.Revoked {
+			t.Errorf("Expected refresh token to be revoked after password change")
 		}
 	})
 }

--- a/pkg/accounts/accounts_test.go
+++ b/pkg/accounts/accounts_test.go
@@ -336,6 +336,61 @@ func TestPutAccountByID(t *testing.T) {
 	})
 }
 
+// putAccountForTest sends a PUT /accounts/:id with the given account payload
+func putAccountForTest(t *testing.T, router *gin.Engine, account Account) int {
+	t.Helper()
+	jsonData, err := json.Marshal(account)
+	if err != nil {
+		t.Fatalf("Failed to marshal account data: %v", err)
+	}
+	path := fmt.Sprintf("/accounts/%d", account.ID)
+	req, _ := http.NewRequest(http.MethodPut, path, bytes.NewBuffer(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w.Code
+}
+
+func TestPutAccountByID_StatusChangeRevokesSessions(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	router.PUT("/accounts/:id", PutAccountByID)
+
+	activeAccount := Account{
+		ID:        users[2].ID,
+		Username:  users[2].Username,
+		Email:     "joseph.doe@example.com",
+		Firstname: "Joseph",
+		Lastname:  "Doe",
+		Role:      "standard",
+		Status:    "active",
+	}
+
+	refreshToken, err := security.CreateRefreshToken(context.Background(), activeAccount.ID, false)
+	if err != nil {
+		t.Fatalf("failed to create refresh token: %v", err)
+	}
+
+	suspended := activeAccount
+	suspended.Status = "inactive"
+	if code := putAccountForTest(t, router, suspended); code != http.StatusOK {
+		t.Fatalf("Expected status code %d but got %d", http.StatusOK, code)
+	}
+
+	retrieved, err := security.GetRefreshToken(context.Background(), refreshToken.Token)
+	if err != nil {
+		t.Fatalf("failed to get refresh token: %v", err)
+	}
+	if !retrieved.Revoked {
+		t.Errorf("Expected refresh token to be revoked after status change")
+	}
+
+	// Restore the original status so later tests see an active account
+	if code := putAccountForTest(t, router, activeAccount); code != http.StatusOK {
+		t.Fatalf("failed to restore account status: %d", code)
+	}
+}
+
 func TestDeleteAccountByID(t *testing.T) {
 	// Set Gin to test mode
 	gin.SetMode(gin.TestMode)

--- a/pkg/accounts/handlers.go
+++ b/pkg/accounts/handlers.go
@@ -331,18 +331,11 @@ func PutMyPassword(c *gin.Context) {
 		return
 	}
 
-	// Update the password
+	// Update the password (also revokes every live session)
 	if err := updatePassword(c.Request.Context(), userID, input.NewPassword); err != nil {
 		helper.LogAndSanitize(err, "put my password: update password failed")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
 		return
-	}
-
-	// Kill every live session: a password change must invalidate refresh
-	// tokens a potential attacker may hold. Non-fatal — the password is
-	// already updated.
-	if _, err := security.RevokeAllUserTokens(c.Request.Context(), userID); err != nil {
-		helper.LogAndSanitize(err, "put my password: revoke refresh tokens failed")
 	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "Password updated"})

--- a/pkg/accounts/handlers.go
+++ b/pkg/accounts/handlers.go
@@ -338,6 +338,13 @@ func PutMyPassword(c *gin.Context) {
 		return
 	}
 
+	// Kill every live session: a password change must invalidate refresh
+	// tokens a potential attacker may hold. Non-fatal — the password is
+	// already updated.
+	if _, err := security.RevokeAllUserTokens(c.Request.Context(), userID); err != nil {
+		helper.LogAndSanitize(err, "put my password: revoke refresh tokens failed")
+	}
+
 	c.JSON(http.StatusOK, gin.H{"message": "Password updated"})
 }
 

--- a/pkg/database/migration/migration_scripts/000026_refresh_token_hash.down.sql
+++ b/pkg/database/migration/migration_scripts/000026_refresh_token_hash.down.sql
@@ -1,0 +1,3 @@
+-- Hashing is one-way; plaintext tokens cannot be restored. Drop all rows,
+-- users will simply re-authenticate (same approach as migration 000025).
+TRUNCATE TABLE refresh_token;

--- a/pkg/database/migration/migration_scripts/000026_refresh_token_hash.up.sql
+++ b/pkg/database/migration/migration_scripts/000026_refresh_token_hash.up.sql
@@ -1,0 +1,4 @@
+-- Refresh tokens are now stored as hex-encoded SHA-256 hashes so a database
+-- leak cannot be replayed as live sessions. Hash existing plaintext tokens in
+-- place: lookups hash the presented token, so current sessions keep working.
+UPDATE refresh_token SET token = encode(sha256(convert_to(token, 'UTF8')), 'hex');

--- a/pkg/database/migration/migration_scripts/000026_refresh_token_hash.up.sql
+++ b/pkg/database/migration/migration_scripts/000026_refresh_token_hash.up.sql
@@ -1,4 +1,8 @@
 -- Refresh tokens are now stored as hex-encoded SHA-256 hashes so a database
 -- leak cannot be replayed as live sessions. Hash existing plaintext tokens in
 -- place: lookups hash the presented token, so current sessions keep working.
-UPDATE refresh_token SET token = encode(sha256(convert_to(token, 'UTF8')), 'hex');
+-- The WHERE guard makes the migration idempotent: plaintext tokens (base64url)
+-- never look like a 64-char hex digest, already-hashed ones always do.
+UPDATE refresh_token
+SET token = encode(sha256(convert_to(token, 'UTF8')), 'hex')
+WHERE token !~ '^[0-9a-f]{64}$';

--- a/pkg/security/audit_log.go
+++ b/pkg/security/audit_log.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"time"
 
@@ -17,7 +18,8 @@ const (
 	EventLoginFailed       AuditEventType = "login_failed"
 	EventRefreshSuccess    AuditEventType = "refresh_success"
 	EventRefreshFailed     AuditEventType = "refresh_failed"
-	EventLogout            AuditEventType = "logout"
+	EventLogout            AuditEventType = "logout_success"
+	EventLogoutAll         AuditEventType = "logout_all_success"
 	EventRateLimitExceeded AuditEventType = "rate_limit_exceeded"
 )
 
@@ -98,6 +100,17 @@ func AuditLogout(c *gin.Context, userID uint) {
 		IP:        c.ClientIP(),
 		UserAgent: c.Request.UserAgent(),
 		Message:   "User logged out",
+	})
+}
+
+// AuditLogoutAll logs a logout-from-all-devices event
+func AuditLogoutAll(c *gin.Context, userID uint, revokedSessions int64) {
+	logAuditEvent(AuditEvent{
+		EventType: EventLogoutAll,
+		UserID:    &userID,
+		IP:        c.ClientIP(),
+		UserAgent: c.Request.UserAgent(),
+		Message:   fmt.Sprintf("User logged out from all devices (%d sessions revoked)", revokedSessions),
 	})
 }
 

--- a/pkg/security/handlers.go
+++ b/pkg/security/handlers.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/Angak0k/pimpmypack/pkg/apitypes"
 	"github.com/Angak0k/pimpmypack/pkg/config"
 	"github.com/Angak0k/pimpmypack/pkg/helper"
 	"github.com/gin-gonic/gin"
@@ -64,24 +65,12 @@ func RefreshTokenHandler(c *gin.Context) {
 	// 5. Update last_used_at (ignore errors - non-blocking)
 	_ = UpdateLastUsed(c.Request.Context(), refreshToken.ID)
 
-	// 6. Issue a rotated refresh token preserving the session horizon.
-	// Non-fatal: refresh still succeeds with the presented token if this
-	// fails, since strict rotation is not enforced yet.
-	response := RefreshResponse{
+	// 6. Audit successful refresh and respond
+	AuditRefreshSuccess(c, refreshToken.AccountID)
+	c.JSON(http.StatusOK, RefreshResponse{
 		AccessToken: accessToken,
 		ExpiresIn:   int64(config.AccessTokenMinutes * 60),
-	}
-	rotated, err := createRefreshTokenExpiringAt(c.Request.Context(), refreshToken.AccountID, refreshToken.ExpiresAt)
-	if err != nil {
-		helper.LogAndSanitize(err, "refresh token: rotate refresh token failed")
-	} else {
-		response.RefreshToken = rotated.Token
-		response.RefreshExpiresIn = int64(time.Until(rotated.ExpiresAt).Seconds())
-	}
-
-	// 7. Audit successful refresh and respond
-	AuditRefreshSuccess(c, refreshToken.AccountID)
-	c.JSON(http.StatusOK, response)
+	})
 }
 
 // LogoutHandler handles POST /auth/logout
@@ -91,7 +80,7 @@ func RefreshTokenHandler(c *gin.Context) {
 // @Accept json
 // @Produce json
 // @Param refresh_token body RefreshTokenInput true "Refresh Token"
-// @Success 200 {object} LogoutResponse
+// @Success 200 {object} apitypes.OkResponse
 // @Failure 400 {object} apitypes.ErrorResponse "Invalid input"
 // @Failure 500 {object} apitypes.ErrorResponse "Internal server error"
 // @Router /auth/logout [post]
@@ -115,7 +104,7 @@ func LogoutHandler(c *gin.Context) {
 	}
 
 	// 200 even when no live token matched: no token enumeration
-	c.JSON(http.StatusOK, LogoutResponse{Message: "Logged out successfully"})
+	c.JSON(http.StatusOK, apitypes.OkResponse{Response: "Logged out successfully"})
 }
 
 // LogoutAllHandler handles POST /v1/auth/logout-all

--- a/pkg/security/handlers.go
+++ b/pkg/security/handlers.go
@@ -64,10 +64,89 @@ func RefreshTokenHandler(c *gin.Context) {
 	// 5. Update last_used_at (ignore errors - non-blocking)
 	_ = UpdateLastUsed(c.Request.Context(), refreshToken.ID)
 
-	// 6. Audit successful refresh and respond
-	AuditRefreshSuccess(c, refreshToken.AccountID)
-	c.JSON(http.StatusOK, RefreshResponse{
+	// 6. Issue a rotated refresh token preserving the session horizon.
+	// Non-fatal: refresh still succeeds with the presented token if this
+	// fails, since strict rotation is not enforced yet.
+	response := RefreshResponse{
 		AccessToken: accessToken,
 		ExpiresIn:   int64(config.AccessTokenMinutes * 60),
+	}
+	rotated, err := createRefreshTokenExpiringAt(c.Request.Context(), refreshToken.AccountID, refreshToken.ExpiresAt)
+	if err != nil {
+		helper.LogAndSanitize(err, "refresh token: rotate refresh token failed")
+	} else {
+		response.RefreshToken = rotated.Token
+		response.RefreshExpiresIn = int64(time.Until(rotated.ExpiresAt).Seconds())
+	}
+
+	// 7. Audit successful refresh and respond
+	AuditRefreshSuccess(c, refreshToken.AccountID)
+	c.JSON(http.StatusOK, response)
+}
+
+// LogoutHandler handles POST /auth/logout
+// @Summary Logout (revoke a refresh token)
+// @Description Revoke the presented refresh token, ending that session. Always 200: token existence cannot be probed.
+// @Tags Authentication
+// @Accept json
+// @Produce json
+// @Param refresh_token body RefreshTokenInput true "Refresh Token"
+// @Success 200 {object} LogoutResponse
+// @Failure 400 {object} apitypes.ErrorResponse "Invalid input"
+// @Failure 500 {object} apitypes.ErrorResponse "Internal server error"
+// @Router /auth/logout [post]
+func LogoutHandler(c *gin.Context) {
+	var input RefreshTokenInput
+
+	if err := c.ShouldBindJSON(&input); err != nil {
+		helper.LogAndSanitize(err, "logout: bind JSON failed")
+		c.JSON(http.StatusBadRequest, gin.H{"error": helper.ErrMsgBadRequest})
+		return
+	}
+
+	accountID, found, err := RevokeRefreshToken(c.Request.Context(), input.Token)
+	if err != nil {
+		helper.LogAndSanitize(err, "logout: revoke refresh token failed")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+	if found {
+		AuditLogout(c, accountID)
+	}
+
+	// 200 even when no live token matched: no token enumeration
+	c.JSON(http.StatusOK, LogoutResponse{Message: "Logged out successfully"})
+}
+
+// LogoutAllHandler handles POST /v1/auth/logout-all
+// @Summary Logout from all devices
+// @Description Revoke all refresh tokens of the authenticated user
+// @Security Bearer
+// @Tags Authentication
+// @Produce json
+// @Success 200 {object} LogoutAllResponse
+// @Failure 401 {object} apitypes.ErrorResponse "Unauthorized"
+// @Failure 500 {object} apitypes.ErrorResponse "Internal server error"
+// @Router /v1/auth/logout-all [post]
+func LogoutAllHandler(c *gin.Context) {
+	userID, err := ExtractTokenID(c)
+	if err != nil {
+		helper.LogAndSanitize(err, "logout all: extract token ID failed")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": helper.ErrMsgUnauthorized})
+		return
+	}
+
+	revoked, err := RevokeAllUserTokens(c.Request.Context(), userID)
+	if err != nil {
+		helper.LogAndSanitize(err, "logout all: revoke user tokens failed")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": helper.ErrMsgInternalServer})
+		return
+	}
+
+	AuditLogoutAll(c, userID, revoked)
+
+	c.JSON(http.StatusOK, LogoutAllResponse{
+		Message:         "Logged out from all devices",
+		RevokedSessions: revoked,
 	})
 }

--- a/pkg/security/handlers_test.go
+++ b/pkg/security/handlers_test.go
@@ -46,16 +46,8 @@ func TestRefreshTokenHandler_Success(t *testing.T) {
 	refreshToken, err := CreateRefreshToken(ctx, accountID, false)
 	require.NoError(t, err)
 
-	// Make request
-	input := RefreshTokenInput{Token: refreshToken.Token}
-	body, _ := json.Marshal(input)
-	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
+	w := postJSON(router, "/auth/refresh", RefreshTokenInput{Token: refreshToken.Token}, "")
 
-	router.ServeHTTP(w, req)
-
-	// Assertions
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var response RefreshResponse
@@ -63,37 +55,12 @@ func TestRefreshTokenHandler_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, response.AccessToken)
 	assert.Positive(t, response.ExpiresIn)
-
-	// Rotation prep: a fresh refresh token is returned so clients can adopt
-	// rotation; strict revocation of the old one comes in a later phase
-	assert.NotEmpty(t, response.RefreshToken)
-	assert.NotEqual(t, refreshToken.Token, response.RefreshToken)
-	assert.Positive(t, response.RefreshExpiresIn)
-
-	// The new token preserves the original session horizon
-	rotated, err := GetRefreshToken(context.Background(), response.RefreshToken)
-	require.NoError(t, err)
-	assert.WithinDuration(t, refreshToken.ExpiresAt, rotated.ExpiresAt, time.Second)
-
-	// Phase 1: the old token stays valid until the front adopts rotation
-	w = postJSON(router, "/auth/refresh", RefreshTokenInput{Token: refreshToken.Token}, "")
-	assert.Equal(t, http.StatusOK, w.Code)
-
-	// The new token is itself usable
-	w = postJSON(router, "/auth/refresh", RefreshTokenInput{Token: response.RefreshToken}, "")
-	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestRefreshTokenHandler_InvalidToken(t *testing.T) {
 	router := setupTestRouter()
 
-	input := RefreshTokenInput{Token: "invalid-token"}
-	body, _ := json.Marshal(input)
-	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-
-	router.ServeHTTP(w, req)
+	w := postJSON(router, "/auth/refresh", RefreshTokenInput{Token: "invalid-token"}, "")
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 	assert.Contains(t, w.Body.String(), "Invalid refresh token")
@@ -106,7 +73,7 @@ func TestRefreshTokenHandler_ExpiredToken(t *testing.T) {
 	// Create an expired token manually with unique token string
 	now := time.Now()
 	expiredToken := "expired-token-" + now.Format("20060102150405") + "-" + strconv.FormatInt(now.UnixNano(), 10)
-	_, err := database.DB().Exec(
+	_, err := database.DB().ExecContext(context.Background(),
 		`INSERT INTO refresh_token (token, account_id, expires_at, created_at)
          VALUES ($1, $2, $3, $4)`,
 		hashRefreshToken(expiredToken),
@@ -116,14 +83,7 @@ func TestRefreshTokenHandler_ExpiredToken(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Make request
-	input := RefreshTokenInput{Token: expiredToken}
-	body, _ := json.Marshal(input)
-	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-
-	router.ServeHTTP(w, req)
+	w := postJSON(router, "/auth/refresh", RefreshTokenInput{Token: expiredToken}, "")
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 	assert.Contains(t, w.Body.String(), "expired")
@@ -132,11 +92,7 @@ func TestRefreshTokenHandler_ExpiredToken(t *testing.T) {
 func TestRefreshTokenHandler_MissingInput(t *testing.T) {
 	router := setupTestRouter()
 
-	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", bytes.NewBufferString("{}"))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-
-	router.ServeHTTP(w, req)
+	w := postJSON(router, "/auth/refresh", struct{}{}, "")
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
@@ -171,10 +127,7 @@ func TestLogoutHandler_InvalidTokenStillSucceeds(t *testing.T) {
 func TestLogoutHandler_MissingInput(t *testing.T) {
 	router := setupTestRouter()
 
-	req := httptest.NewRequest(http.MethodPost, "/auth/logout", bytes.NewBufferString("{}"))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
+	w := postJSON(router, "/auth/logout", struct{}{}, "")
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }

--- a/pkg/security/handlers_test.go
+++ b/pkg/security/handlers_test.go
@@ -25,8 +25,12 @@ func setupTestRouter() *gin.Engine {
 	return r
 }
 
-func postJSON(router *gin.Engine, path string, payload any, accessToken string) *httptest.ResponseRecorder {
-	body, _ := json.Marshal(payload)
+func postJSON(
+	t *testing.T, router *gin.Engine, path string, payload any, accessToken string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
 	req := httptest.NewRequest(http.MethodPost, path, bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
 	if accessToken != "" {
@@ -46,7 +50,7 @@ func TestRefreshTokenHandler_Success(t *testing.T) {
 	refreshToken, err := CreateRefreshToken(ctx, accountID, false)
 	require.NoError(t, err)
 
-	w := postJSON(router, "/auth/refresh", RefreshTokenInput{Token: refreshToken.Token}, "")
+	w := postJSON(t, router, "/auth/refresh", RefreshTokenInput{Token: refreshToken.Token}, "")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
@@ -60,7 +64,7 @@ func TestRefreshTokenHandler_Success(t *testing.T) {
 func TestRefreshTokenHandler_InvalidToken(t *testing.T) {
 	router := setupTestRouter()
 
-	w := postJSON(router, "/auth/refresh", RefreshTokenInput{Token: "invalid-token"}, "")
+	w := postJSON(t, router, "/auth/refresh", RefreshTokenInput{Token: "invalid-token"}, "")
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 	assert.Contains(t, w.Body.String(), "Invalid refresh token")
@@ -83,7 +87,7 @@ func TestRefreshTokenHandler_ExpiredToken(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	w := postJSON(router, "/auth/refresh", RefreshTokenInput{Token: expiredToken}, "")
+	w := postJSON(t, router, "/auth/refresh", RefreshTokenInput{Token: expiredToken}, "")
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 	assert.Contains(t, w.Body.String(), "expired")
@@ -92,7 +96,7 @@ func TestRefreshTokenHandler_ExpiredToken(t *testing.T) {
 func TestRefreshTokenHandler_MissingInput(t *testing.T) {
 	router := setupTestRouter()
 
-	w := postJSON(router, "/auth/refresh", struct{}{}, "")
+	w := postJSON(t, router, "/auth/refresh", struct{}{}, "")
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
@@ -105,12 +109,12 @@ func TestLogoutHandler_Success(t *testing.T) {
 	refreshToken, err := CreateRefreshToken(ctx, accountID, false)
 	require.NoError(t, err)
 
-	w := postJSON(router, "/auth/logout", RefreshTokenInput{Token: refreshToken.Token}, "")
+	w := postJSON(t, router, "/auth/logout", RefreshTokenInput{Token: refreshToken.Token}, "")
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "Logged out successfully")
 
 	// The revoked token must no longer refresh
-	w = postJSON(router, "/auth/refresh", RefreshTokenInput{Token: refreshToken.Token}, "")
+	w = postJSON(t, router, "/auth/refresh", RefreshTokenInput{Token: refreshToken.Token}, "")
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 	assert.Contains(t, w.Body.String(), "revoked")
 }
@@ -119,7 +123,7 @@ func TestLogoutHandler_InvalidTokenStillSucceeds(t *testing.T) {
 	router := setupTestRouter()
 
 	// 200 even for unknown tokens: no token enumeration
-	w := postJSON(router, "/auth/logout", RefreshTokenInput{Token: "unknown-token"}, "")
+	w := postJSON(t, router, "/auth/logout", RefreshTokenInput{Token: "unknown-token"}, "")
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "Logged out successfully")
 }
@@ -127,7 +131,7 @@ func TestLogoutHandler_InvalidTokenStillSucceeds(t *testing.T) {
 func TestLogoutHandler_MissingInput(t *testing.T) {
 	router := setupTestRouter()
 
-	w := postJSON(router, "/auth/logout", struct{}{}, "")
+	w := postJSON(t, router, "/auth/logout", struct{}{}, "")
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
@@ -145,7 +149,7 @@ func TestLogoutAllHandler_Success(t *testing.T) {
 	accessToken, err := GenerateToken(accountID)
 	require.NoError(t, err)
 
-	w := postJSON(router, "/v1/auth/logout-all", struct{}{}, accessToken)
+	w := postJSON(t, router, "/v1/auth/logout-all", struct{}{}, accessToken)
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var response LogoutAllResponse
@@ -155,7 +159,7 @@ func TestLogoutAllHandler_Success(t *testing.T) {
 
 	// Both sessions are dead
 	for _, tok := range []string{token1.Token, token2.Token} {
-		w = postJSON(router, "/auth/refresh", RefreshTokenInput{Token: tok}, "")
+		w = postJSON(t, router, "/auth/refresh", RefreshTokenInput{Token: tok}, "")
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
 	}
 }
@@ -163,6 +167,6 @@ func TestLogoutAllHandler_Success(t *testing.T) {
 func TestLogoutAllHandler_RequiresAuth(t *testing.T) {
 	router := setupTestRouter()
 
-	w := postJSON(router, "/v1/auth/logout-all", struct{}{}, "")
+	w := postJSON(t, router, "/v1/auth/logout-all", struct{}{}, "")
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }

--- a/pkg/security/handlers_test.go
+++ b/pkg/security/handlers_test.go
@@ -20,7 +20,21 @@ func setupTestRouter() *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
 	r.POST("/auth/refresh", RefreshTokenHandler)
+	r.POST("/auth/logout", LogoutHandler)
+	r.POST("/v1/auth/logout-all", JwtAuthProcessor(), LogoutAllHandler)
 	return r
+}
+
+func postJSON(router *gin.Engine, path string, payload any, accessToken string) *httptest.ResponseRecorder {
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	if accessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
 }
 
 func TestRefreshTokenHandler_Success(t *testing.T) {
@@ -49,6 +63,25 @@ func TestRefreshTokenHandler_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, response.AccessToken)
 	assert.Positive(t, response.ExpiresIn)
+
+	// Rotation prep: a fresh refresh token is returned so clients can adopt
+	// rotation; strict revocation of the old one comes in a later phase
+	assert.NotEmpty(t, response.RefreshToken)
+	assert.NotEqual(t, refreshToken.Token, response.RefreshToken)
+	assert.Positive(t, response.RefreshExpiresIn)
+
+	// The new token preserves the original session horizon
+	rotated, err := GetRefreshToken(context.Background(), response.RefreshToken)
+	require.NoError(t, err)
+	assert.WithinDuration(t, refreshToken.ExpiresAt, rotated.ExpiresAt, time.Second)
+
+	// Phase 1: the old token stays valid until the front adopts rotation
+	w = postJSON(router, "/auth/refresh", RefreshTokenInput{Token: refreshToken.Token}, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// The new token is itself usable
+	w = postJSON(router, "/auth/refresh", RefreshTokenInput{Token: response.RefreshToken}, "")
+	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestRefreshTokenHandler_InvalidToken(t *testing.T) {
@@ -76,7 +109,7 @@ func TestRefreshTokenHandler_ExpiredToken(t *testing.T) {
 	_, err := database.DB().Exec(
 		`INSERT INTO refresh_token (token, account_id, expires_at, created_at)
          VALUES ($1, $2, $3, $4)`,
-		expiredToken,
+		hashRefreshToken(expiredToken),
 		accountID,
 		time.Now().Add(-time.Hour),
 		time.Now().Add(-25*time.Hour),
@@ -106,4 +139,77 @@ func TestRefreshTokenHandler_MissingInput(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestLogoutHandler_Success(t *testing.T) {
+	ctx := context.Background()
+	accountID := createTestAccount(t)
+	router := setupTestRouter()
+
+	refreshToken, err := CreateRefreshToken(ctx, accountID, false)
+	require.NoError(t, err)
+
+	w := postJSON(router, "/auth/logout", RefreshTokenInput{Token: refreshToken.Token}, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Logged out successfully")
+
+	// The revoked token must no longer refresh
+	w = postJSON(router, "/auth/refresh", RefreshTokenInput{Token: refreshToken.Token}, "")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Body.String(), "revoked")
+}
+
+func TestLogoutHandler_InvalidTokenStillSucceeds(t *testing.T) {
+	router := setupTestRouter()
+
+	// 200 even for unknown tokens: no token enumeration
+	w := postJSON(router, "/auth/logout", RefreshTokenInput{Token: "unknown-token"}, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Logged out successfully")
+}
+
+func TestLogoutHandler_MissingInput(t *testing.T) {
+	router := setupTestRouter()
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", bytes.NewBufferString("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestLogoutAllHandler_Success(t *testing.T) {
+	ctx := context.Background()
+	accountID := createTestAccount(t)
+	router := setupTestRouter()
+
+	token1, err := CreateRefreshToken(ctx, accountID, false)
+	require.NoError(t, err)
+	token2, err := CreateRefreshToken(ctx, accountID, true)
+	require.NoError(t, err)
+
+	accessToken, err := GenerateToken(accountID)
+	require.NoError(t, err)
+
+	w := postJSON(router, "/v1/auth/logout-all", struct{}{}, accessToken)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response LogoutAllResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, "Logged out from all devices", response.Message)
+	assert.Equal(t, int64(2), response.RevokedSessions)
+
+	// Both sessions are dead
+	for _, tok := range []string{token1.Token, token2.Token} {
+		w = postJSON(router, "/auth/refresh", RefreshTokenInput{Token: tok}, "")
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	}
+}
+
+func TestLogoutAllHandler_RequiresAuth(t *testing.T) {
+	router := setupTestRouter()
+
+	w := postJSON(router, "/v1/auth/logout-all", struct{}{}, "")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }

--- a/pkg/security/refresh_tokens.go
+++ b/pkg/security/refresh_tokens.go
@@ -3,8 +3,10 @@ package security
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"time"
@@ -13,16 +15,15 @@ import (
 	"github.com/Angak0k/pimpmypack/pkg/database"
 )
 
+// hashRefreshToken returns the hex-encoded SHA-256 of a refresh token —
+// the only form ever persisted, so a database leak cannot be replayed
+func hashRefreshToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
 // CreateRefreshToken creates a new refresh token for a user
 func CreateRefreshToken(ctx context.Context, accountID uint, rememberMe bool) (*RefreshToken, error) {
-	// Generate random token
-	tokenBytes := make([]byte, 32)
-	if _, err := rand.Read(tokenBytes); err != nil {
-		return nil, fmt.Errorf("failed to generate random token: %w", err)
-	}
-	tokenString := base64.URLEncoding.EncodeToString(tokenBytes)
-
-	// Calculate expiration
 	var expiresAt time.Time
 	if rememberMe {
 		expiresAt = time.Now().Add(time.Hour * 24 * time.Duration(config.RefreshTokenRememberMeDays))
@@ -30,13 +31,24 @@ func CreateRefreshToken(ctx context.Context, accountID uint, rememberMe bool) (*
 		expiresAt = time.Now().Add(time.Hour * 24 * time.Duration(config.RefreshTokenDays))
 	}
 
-	// Insert into database
+	return createRefreshTokenExpiringAt(ctx, accountID, expiresAt)
+}
+
+// createRefreshTokenExpiringAt generates a token with an explicit expiry
+// (rotation uses it to preserve the original session horizon)
+func createRefreshTokenExpiringAt(ctx context.Context, accountID uint, expiresAt time.Time) (*RefreshToken, error) {
+	tokenBytes := make([]byte, 32)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		return nil, fmt.Errorf("failed to generate random token: %w", err)
+	}
+	tokenString := base64.URLEncoding.EncodeToString(tokenBytes)
+
 	var token RefreshToken
 	err := database.DB().QueryRowContext(ctx,
 		`INSERT INTO refresh_token (token, account_id, expires_at, created_at)
          VALUES ($1, $2, $3, $4)
          RETURNING id, token, account_id, expires_at, created_at, last_used_at, revoked`,
-		tokenString, accountID, expiresAt, time.Now(),
+		hashRefreshToken(tokenString), accountID, expiresAt, time.Now(),
 	).Scan(
 		&token.ID,
 		&token.Token,
@@ -51,6 +63,10 @@ func CreateRefreshToken(ctx context.Context, accountID uint, rememberMe bool) (*
 		return nil, fmt.Errorf("failed to create refresh token: %w", err)
 	}
 
+	// The database holds only the hash; the caller needs the plaintext to
+	// hand to the client — this is the only place it exists server-side
+	token.Token = tokenString
+
 	return &token, nil
 }
 
@@ -62,7 +78,7 @@ func GetRefreshToken(ctx context.Context, tokenString string) (*RefreshToken, er
 		`SELECT id, token, account_id, expires_at, created_at, last_used_at, revoked
          FROM refresh_token
          WHERE token = $1`,
-		tokenString,
+		hashRefreshToken(tokenString),
 	).Scan(
 		&token.ID,
 		&token.Token,
@@ -95,25 +111,46 @@ func UpdateLastUsed(ctx context.Context, tokenID uint) error {
 	return nil
 }
 
-// DeleteRefreshToken deletes a refresh token (revocation)
-func DeleteRefreshToken(ctx context.Context, tokenString string) error {
+// RevokeRefreshToken marks a refresh token as revoked. It returns the owning
+// account ID and whether a live token matched, so callers can audit the event
+// yet respond generically either way (no token enumeration).
+func RevokeRefreshToken(ctx context.Context, tokenString string) (uint, bool, error) {
+	var accountID uint
+	err := database.DB().QueryRowContext(ctx,
+		`UPDATE refresh_token SET revoked = TRUE
+         WHERE token = $1 AND revoked = FALSE
+         RETURNING account_id`,
+		hashRefreshToken(tokenString),
+	).Scan(&accountID)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to revoke refresh token: %w", err)
+	}
+
+	return accountID, true, nil
+}
+
+// RevokeAllUserTokens revokes every live refresh token of an account and
+// returns how many sessions were revoked
+func RevokeAllUserTokens(ctx context.Context, accountID uint) (int64, error) {
 	result, err := database.DB().ExecContext(ctx,
-		`DELETE FROM refresh_token WHERE token = $1`,
-		tokenString,
+		`UPDATE refresh_token SET revoked = TRUE
+         WHERE account_id = $1 AND revoked = FALSE`,
+		accountID,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to delete refresh token: %w", err)
+		return 0, fmt.Errorf("failed to revoke user refresh tokens: %w", err)
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("failed to check rows affected: %w", err)
-	}
-	if rowsAffected == 0 {
-		return errors.New("refresh token not found")
+		return 0, fmt.Errorf("failed to check rows affected: %w", err)
 	}
 
-	return nil
+	return rowsAffected, nil
 }
 
 // CleanupExpiredTokens deletes expired refresh tokens

--- a/pkg/security/refresh_tokens.go
+++ b/pkg/security/refresh_tokens.go
@@ -112,9 +112,9 @@ func RevokeRefreshToken(ctx context.Context, tokenString string) (uint, bool, er
 	var accountID uint
 	err := database.DB().QueryRowContext(ctx,
 		`UPDATE refresh_token SET revoked = TRUE
-         WHERE token = $1 AND revoked = FALSE
+         WHERE token = $1 AND revoked = FALSE AND expires_at > $2
          RETURNING account_id`,
-		hashRefreshToken(tokenString),
+		hashRefreshToken(tokenString), time.Now(),
 	).Scan(&accountID)
 
 	if errors.Is(err, sql.ErrNoRows) {
@@ -132,8 +132,8 @@ func RevokeRefreshToken(ctx context.Context, tokenString string) (uint, bool, er
 func RevokeAllUserTokens(ctx context.Context, accountID uint) (int64, error) {
 	result, err := database.DB().ExecContext(ctx,
 		`UPDATE refresh_token SET revoked = TRUE
-         WHERE account_id = $1 AND revoked = FALSE`,
-		accountID,
+         WHERE account_id = $1 AND revoked = FALSE AND expires_at > $2`,
+		accountID, time.Now(),
 	)
 	if err != nil {
 		return 0, fmt.Errorf("failed to revoke user refresh tokens: %w", err)

--- a/pkg/security/refresh_tokens.go
+++ b/pkg/security/refresh_tokens.go
@@ -31,12 +31,6 @@ func CreateRefreshToken(ctx context.Context, accountID uint, rememberMe bool) (*
 		expiresAt = time.Now().Add(time.Hour * 24 * time.Duration(config.RefreshTokenDays))
 	}
 
-	return createRefreshTokenExpiringAt(ctx, accountID, expiresAt)
-}
-
-// createRefreshTokenExpiringAt generates a token with an explicit expiry
-// (rotation uses it to preserve the original session horizon)
-func createRefreshTokenExpiringAt(ctx context.Context, accountID uint, expiresAt time.Time) (*RefreshToken, error) {
 	tokenBytes := make([]byte, 32)
 	if _, err := rand.Read(tokenBytes); err != nil {
 		return nil, fmt.Errorf("failed to generate random token: %w", err)
@@ -153,10 +147,11 @@ func RevokeAllUserTokens(ctx context.Context, accountID uint) (int64, error) {
 	return rowsAffected, nil
 }
 
-// CleanupExpiredTokens deletes expired refresh tokens
+// CleanupExpiredTokens deletes refresh tokens that can never be valid again:
+// expired ones and revoked ones (logout, logout-all, password change)
 func CleanupExpiredTokens(ctx context.Context) (int64, error) {
 	result, err := database.DB().ExecContext(ctx,
-		`DELETE FROM refresh_token WHERE expires_at < $1`,
+		`DELETE FROM refresh_token WHERE expires_at < $1 OR revoked = TRUE`,
 		time.Now(),
 	)
 	if err != nil {

--- a/pkg/security/refresh_tokens_test.go
+++ b/pkg/security/refresh_tokens_test.go
@@ -242,15 +242,22 @@ func TestCleanupExpiredTokens(t *testing.T) {
 
 	// Create an expired token by manually inserting with a unique token string
 	expiredTokenStr := fmt.Sprintf("expired-token-%d", time.Now().UnixNano())
-	_, err := database.DB().Exec(
+	_, err := database.DB().ExecContext(ctx,
 		`INSERT INTO refresh_token (token, account_id, expires_at, created_at)
          VALUES ($1, $2, $3, $4)`,
-		expiredTokenStr,
+		hashRefreshToken(expiredTokenStr),
 		accountID,
 		time.Now().Add(-time.Hour), // expired 1 hour ago
 		time.Now().Add(-25*time.Hour),
 	)
 	require.NoError(t, err)
+
+	// Create a revoked (but unexpired) token: cleanup must reclaim it too
+	revokedToken, err := CreateRefreshToken(ctx, accountID, false)
+	require.NoError(t, err)
+	_, found, err := RevokeRefreshToken(ctx, revokedToken.Token)
+	require.NoError(t, err)
+	require.True(t, found)
 
 	// Create a valid token
 	validToken, err := CreateRefreshToken(ctx, accountID, false)
@@ -260,10 +267,12 @@ func TestCleanupExpiredTokens(t *testing.T) {
 	deleted, err := CleanupExpiredTokens(ctx)
 
 	require.NoError(t, err)
-	assert.GreaterOrEqual(t, deleted, int64(1))
+	assert.GreaterOrEqual(t, deleted, int64(2))
 
-	// Verify expired token is gone
+	// Verify expired and revoked tokens are gone
 	_, err = GetRefreshToken(ctx, expiredTokenStr)
+	require.Error(t, err)
+	_, err = GetRefreshToken(ctx, revokedToken.Token)
 	require.Error(t, err)
 
 	// Verify valid token still exists

--- a/pkg/security/refresh_tokens_test.go
+++ b/pkg/security/refresh_tokens_test.go
@@ -116,8 +116,28 @@ func TestGetRefreshToken_Success(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, created.ID, retrieved.ID)
-	assert.Equal(t, created.Token, retrieved.Token)
 	assert.Equal(t, created.AccountID, retrieved.AccountID)
+	// At rest only the hash is stored: the retrieved row must not contain
+	// the plaintext handed to the client
+	assert.NotEqual(t, created.Token, retrieved.Token)
+	assert.Equal(t, hashRefreshToken(created.Token), retrieved.Token)
+}
+
+func TestRefreshTokenStoredHashed(t *testing.T) {
+	ctx := context.Background()
+	accountID := createTestAccount(t)
+
+	created, err := CreateRefreshToken(ctx, accountID, false)
+	require.NoError(t, err)
+
+	var stored string
+	err = database.DB().QueryRowContext(ctx,
+		`SELECT token FROM refresh_token WHERE id = $1`, created.ID,
+	).Scan(&stored)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, created.Token, stored)
+	assert.Equal(t, hashRefreshToken(created.Token), stored)
 }
 
 func TestGetRefreshToken_NotFound(t *testing.T) {
@@ -148,29 +168,72 @@ func TestUpdateLastUsed(t *testing.T) {
 	assert.NotNil(t, updated.LastUsedAt)
 }
 
-func TestDeleteRefreshToken_Success(t *testing.T) {
+func TestRevokeRefreshToken_Success(t *testing.T) {
 	ctx := context.Background()
 	accountID := createTestAccount(t)
 
 	token, err := CreateRefreshToken(ctx, accountID, false)
 	require.NoError(t, err)
 
-	err = DeleteRefreshToken(ctx, token.Token)
+	revokedAccountID, found, err := RevokeRefreshToken(ctx, token.Token)
 	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, accountID, revokedAccountID)
 
-	// Verify it's deleted
 	retrieved, err := GetRefreshToken(ctx, token.Token)
-	require.Error(t, err)
-	assert.Nil(t, retrieved)
+	require.NoError(t, err)
+	assert.True(t, retrieved.Revoked)
 }
 
-func TestDeleteRefreshToken_NotFound(t *testing.T) {
+func TestRevokeRefreshToken_NotFound(t *testing.T) {
 	ctx := context.Background()
 
-	err := DeleteRefreshToken(ctx, "nonexistent-token")
+	_, found, err := RevokeRefreshToken(ctx, "nonexistent-token")
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
+	require.NoError(t, err)
+	assert.False(t, found)
+}
+
+func TestRevokeRefreshToken_AlreadyRevoked(t *testing.T) {
+	ctx := context.Background()
+	accountID := createTestAccount(t)
+
+	token, err := CreateRefreshToken(ctx, accountID, false)
+	require.NoError(t, err)
+
+	_, found, err := RevokeRefreshToken(ctx, token.Token)
+	require.NoError(t, err)
+	assert.True(t, found)
+
+	// Revoking an already-revoked token is a no-op
+	_, found, err = RevokeRefreshToken(ctx, token.Token)
+	require.NoError(t, err)
+	assert.False(t, found)
+}
+
+func TestRevokeAllUserTokens(t *testing.T) {
+	ctx := context.Background()
+	accountID := createTestAccount(t)
+
+	token1, err := CreateRefreshToken(ctx, accountID, false)
+	require.NoError(t, err)
+	token2, err := CreateRefreshToken(ctx, accountID, true)
+	require.NoError(t, err)
+
+	revoked, err := RevokeAllUserTokens(ctx, accountID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), revoked)
+
+	for _, tok := range []string{token1.Token, token2.Token} {
+		retrieved, err := GetRefreshToken(ctx, tok)
+		require.NoError(t, err)
+		assert.True(t, retrieved.Revoked)
+	}
+
+	// Second pass revokes nothing
+	revoked, err = RevokeAllUserTokens(ctx, accountID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), revoked)
 }
 
 func TestCleanupExpiredTokens(t *testing.T) {

--- a/pkg/security/security_test.go
+++ b/pkg/security/security_test.go
@@ -166,13 +166,13 @@ func TestExtractToken(t *testing.T) {
 		expectedError bool
 	}{
 		{
-			name: "token in query parameter",
+			name: "token in query parameter is ignored (URL leak vector)",
 			setupRequest: func(r *http.Request) {
 				q := r.URL.Query()
 				q.Add("token", "test_token")
 				r.URL.RawQuery = q.Encode()
 			},
-			expectedToken: "test_token",
+			expectedToken: "",
 			expectedError: false,
 		},
 		{

--- a/pkg/security/tokens.go
+++ b/pkg/security/tokens.go
@@ -43,12 +43,10 @@ func TokenValid(c *gin.Context) error {
 	return err
 }
 
-// ExtractToken extracts token from header or query (existing function, moved here)
+// ExtractToken extracts the JWT from the Authorization header. Tokens are
+// deliberately not accepted via query string: URLs leak into access logs,
+// proxies, browser history and Referer headers.
 func ExtractToken(c *gin.Context) string {
-	token := c.Query("token")
-	if token != "" {
-		return token
-	}
 	bearerToken := c.Request.Header.Get("Authorization")
 	if len(strings.Split(bearerToken, " ")) == 2 {
 		return strings.Split(bearerToken, " ")[1]

--- a/pkg/security/types.go
+++ b/pkg/security/types.go
@@ -27,8 +27,24 @@ type TokenPairResponse struct {
 	RefreshExpiresIn int64  `json:"refresh_expires_in"`
 }
 
-// RefreshResponse represents the response from refresh endpoint
+// RefreshResponse represents the response from refresh endpoint.
+// RefreshToken carries a freshly rotated token clients should store; the
+// presented token currently stays valid (strict rotation lands once clients
+// have adopted the new field).
 type RefreshResponse struct {
-	AccessToken string `json:"access_token"`
-	ExpiresIn   int64  `json:"expires_in"`
+	AccessToken      string `json:"access_token"`
+	ExpiresIn        int64  `json:"expires_in"`
+	RefreshToken     string `json:"refresh_token,omitempty"`
+	RefreshExpiresIn int64  `json:"refresh_expires_in,omitempty"`
+}
+
+// LogoutResponse is the response of POST /auth/logout
+type LogoutResponse struct {
+	Message string `json:"message"`
+}
+
+// LogoutAllResponse is the response of POST /v1/auth/logout-all
+type LogoutAllResponse struct {
+	Message         string `json:"message"`
+	RevokedSessions int64  `json:"revoked_sessions"`
 }

--- a/pkg/security/types.go
+++ b/pkg/security/types.go
@@ -2,15 +2,18 @@ package security
 
 import "time"
 
-// RefreshToken represents a refresh token in the database
+// RefreshToken represents a refresh token row in the database. It is a
+// storage model, never serialized to clients — no json tags on purpose:
+// Token holds the plaintext right after creation but the SHA-256 hash when
+// read back from the database.
 type RefreshToken struct {
-	ID         uint       `json:"id"`
-	Token      string     `json:"token"`
-	AccountID  uint       `json:"account_id"`
-	ExpiresAt  time.Time  `json:"expires_at"`
-	CreatedAt  time.Time  `json:"created_at"`
-	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
-	Revoked    bool       `json:"revoked"`
+	ID         uint
+	Token      string
+	AccountID  uint
+	ExpiresAt  time.Time
+	CreatedAt  time.Time
+	LastUsedAt *time.Time
+	Revoked    bool
 }
 
 // RefreshTokenInput represents the input for refresh token endpoint
@@ -27,20 +30,10 @@ type TokenPairResponse struct {
 	RefreshExpiresIn int64  `json:"refresh_expires_in"`
 }
 
-// RefreshResponse represents the response from refresh endpoint.
-// RefreshToken carries a freshly rotated token clients should store; the
-// presented token currently stays valid (strict rotation lands once clients
-// have adopted the new field).
+// RefreshResponse represents the response from refresh endpoint
 type RefreshResponse struct {
-	AccessToken      string `json:"access_token"`
-	ExpiresIn        int64  `json:"expires_in"`
-	RefreshToken     string `json:"refresh_token,omitempty"`
-	RefreshExpiresIn int64  `json:"refresh_expires_in,omitempty"`
-}
-
-// LogoutResponse is the response of POST /auth/logout
-type LogoutResponse struct {
-	Message string `json:"message"`
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int64  `json:"expires_in"`
 }
 
 // LogoutAllResponse is the response of POST /v1/auth/logout-all

--- a/tests/api-scenarios/001-user-registration-auth.yaml
+++ b/tests/api-scenarios/001-user-registration-auth.yaml
@@ -153,6 +153,16 @@ scenarios:
     store:
       password: "NewTestPass456!"
 
+  - name: "SECURITY: Refresh token from before the password change is revoked"
+    request:
+      method: POST
+      endpoint: "/auth/refresh"
+      body:
+        refresh_token: "{{refresh_token}}"
+    assertions:
+      - type: status_code
+        expected: 401
+
   - name: "Login with new password to verify change"
     request:
       method: POST
@@ -166,8 +176,12 @@ scenarios:
       - type: json_path
         path: "$.access_token"
         exists: true
+      - type: json_path
+        path: "$.refresh_token"
+        exists: true
     store:
       new_access_token: "{{response.access_token}}"
+      refresh_token: "{{response.refresh_token}}"
 
   - name: "Refresh access token using refresh token"
     request:
@@ -184,8 +198,12 @@ scenarios:
       - type: json_path
         path: "$.expires_in"
         exists: true
+      - type: json_path
+        path: "$.refresh_token"
+        exists: true
     store:
       refreshed_access_token: "{{response.access_token}}"
+      rotated_refresh_token: "{{response.refresh_token}}"
 
   - name: "Verify refreshed access token works"
     request:
@@ -199,6 +217,57 @@ scenarios:
       - type: json_path
         path: "$.username"
         equals: "{{username}}"
+
+  - name: "SECURITY: Token in query string is not accepted"
+    request:
+      method: GET
+      endpoint: "/v1/myaccount?token={{refreshed_access_token}}"
+    assertions:
+      - type: status_code
+        expected: 401
+
+  - name: "Logout revokes the presented refresh token"
+    request:
+      method: POST
+      endpoint: "/auth/logout"
+      body:
+        refresh_token: "{{refresh_token}}"
+    assertions:
+      - type: status_code
+        expected: 200
+      - type: json_path
+        path: "$.message"
+        contains: "Logged out"
+
+  - name: "Refresh with a logged-out token is rejected"
+    request:
+      method: POST
+      endpoint: "/auth/refresh"
+      body:
+        refresh_token: "{{refresh_token}}"
+    assertions:
+      - type: status_code
+        expected: 401
+
+  - name: "Logout with an unknown token still returns 200 (no enumeration)"
+    request:
+      method: POST
+      endpoint: "/auth/logout"
+      body:
+        refresh_token: "unknown-token-{{timestamp}}"
+    assertions:
+      - type: status_code
+        expected: 200
+
+  - name: "Rotated refresh token from the earlier refresh still works"
+    request:
+      method: POST
+      endpoint: "/auth/refresh"
+      body:
+        refresh_token: "{{rotated_refresh_token}}"
+    assertions:
+      - type: status_code
+        expected: 200
 
   - name: "Test login with remember_me flag"
     request:
@@ -217,3 +286,32 @@ scenarios:
       - type: json_path
         path: "$.refresh_token"
         exists: true
+    store:
+      rm_access_token: "{{response.access_token}}"
+      rm_refresh_token: "{{response.refresh_token}}"
+
+  - name: "Logout from all devices revokes every session"
+    request:
+      method: POST
+      endpoint: "/v1/auth/logout-all"
+      headers:
+        Authorization: "Bearer {{rm_access_token}}"
+    assertions:
+      - type: status_code
+        expected: 200
+      - type: json_path
+        path: "$.message"
+        contains: "all devices"
+      - type: json_path
+        path: "$.revoked_sessions"
+        exists: true
+
+  - name: "Refresh after logout-all is rejected"
+    request:
+      method: POST
+      endpoint: "/auth/refresh"
+      body:
+        refresh_token: "{{rm_refresh_token}}"
+    assertions:
+      - type: status_code
+        expected: 401

--- a/tests/api-scenarios/001-user-registration-auth.yaml
+++ b/tests/api-scenarios/001-user-registration-auth.yaml
@@ -198,12 +198,8 @@ scenarios:
       - type: json_path
         path: "$.expires_in"
         exists: true
-      - type: json_path
-        path: "$.refresh_token"
-        exists: true
     store:
       refreshed_access_token: "{{response.access_token}}"
-      rotated_refresh_token: "{{response.refresh_token}}"
 
   - name: "Verify refreshed access token works"
     request:
@@ -255,16 +251,6 @@ scenarios:
       endpoint: "/auth/logout"
       body:
         refresh_token: "unknown-token-{{timestamp}}"
-    assertions:
-      - type: status_code
-        expected: 200
-
-  - name: "Rotated refresh token from the earlier refresh still works"
-    request:
-      method: POST
-      endpoint: "/auth/refresh"
-      body:
-        refresh_token: "{{rotated_refresh_token}}"
     assertions:
       - type: status_code
         expected: 200


### PR DESCRIPTION
## Summary

Hardening of the refresh-token layer and session lifecycle:

- **Hash at rest**: refresh tokens are now stored as hex-encoded SHA-256 hashes; lookups and revocations hash the presented token. Migration `000026` hashes existing rows in place (idempotent), so live sessions survive the deploy. The plaintext only ever exists in transit to the client.
- **Logout endpoints** (closes #158):
  - `POST /auth/logout` — revokes the presented refresh token; always returns 200 so token existence cannot be probed; audits `logout_success`.
  - `POST /v1/auth/logout-all` — authenticated; revokes every live session of the user and returns `revoked_sessions`; audits `logout_all_success`.
- **Session invalidation**: any password change (self-service **and** forgot-password path) and any admin change of an account's status or role now revoke all of the account's refresh tokens.
- **Header-only JWT**: the query-string token transport is removed — tokens in URLs leak into logs, proxies, history and Referer. `Authorization: Bearer` is the only supported transport (no known client used the query form).
- **Cleanup**: the periodic job now also reclaims revoked-but-unexpired tokens.

Refresh-token rotation is intentionally **not** part of this PR: it will land in a follow-up once clients store the rotated token, so that issuance and revocation ship atomically with reuse detection.

apitest scenario 001 covers the new flows end-to-end (logout, logout-all, revocation on password change, query-token rejection, anti-enumeration logout).

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)